### PR TITLE
License name unification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 cmake_minimum_required(VERSION 2.8)
 project(ArgoDSM)

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,19 @@
-ArgoDSM Open Source License
+Eta Scale Open Source License
 
-By accessing or using ArgoDSM in any form you expressly undertake to be bound
+By accessing or using the software that is licensed under the terms of this
+document ("Eta Scale Software") in any form you expressly undertake to be bound
 by these license terms. If you use the code on behalf of a business, you agree
 to these license terms both in person and on behalf of that business and you
 represent that you have the authority to do so.
 
 1) Alternative License
 
-	ArgoDSM is distributed under a dual-license scheme, an open source and
-	a commercial license. This document is the open source license.
+	Eta Scale Software is distributed under a dual-license scheme,
+	an open source and a commercial license.
+	This document is the open source license.
 
 	If you are interested in the commercial license, please contact
-	Eta Scale AB by email: contact@argodsm.com
+	Eta Scale AB by email: contact@etascale.com
 
 2) No warranties
 
@@ -35,16 +37,16 @@ represent that you have the authority to do so.
 	are met:
 
 	Redistributions of source code must retain all conditions of the
-	ArgoDSM Open Source License. Redistributions in binary form must
-	reproduce the terms of the ArgoDSM Open Source License in the
+	Eta Scale Open Source License. Redistributions in binary form must
+	reproduce the terms of the Eta Scale Open Source License in the
 	documentation and/or other materials provided with the distribution.
 	Neither redistributions in source code or in binary form may impose
 	any further restrictions on the exercise of the rights granted or
-	affirmed under the ArgoDSM Open Source License.
+	affirmed under the Eta Scale Open Source License.
 
 	Redistributions in any form must be accompanied by information on how to
-	obtain complete source code for the ArgoDSM software and any
-	accompanying software that uses the ArgoDSM software. The source code
+	obtain complete source code for the Eta Scale Software and any
+	accompanying software that uses the Eta Scale Software. The source code
 	must either be included in the distribution or be available for no
 	more than the cost of distribution. For an executable file, complete
 	source code means the source code for all modules it contains. It does
@@ -52,14 +54,14 @@ represent that you have the authority to do so.
 	the major components of the operating system on which the executable
 	file runs.
 
-	Neither the name ArgoDSM nor the names of any of its contributors may be
-	used to endorse or promote products derived from this software
-	without specific prior written permission.
+	Neither the name Eta Scale, nor the names of any of its projects or
+	contributors may be used to endorse or promote products derived from
+	Eta Scale Software without specific prior written permission.
 
 4) Copyleft for Software Users
 
-	Notwithstanding any other provision of the ArgoDSM Open Source
-	License, if you modify the ArgoDSM software, your modified version
+	Notwithstanding any other provision of the Eta Scale Open Source
+	License, if you modify the Eta Scale Software, your modified version
 	must prominently offer all users interacting with it an opportunity to
 	receive the corresponding source code of your version.
 	If the interaction happens remotely through a computer network (if
@@ -70,8 +72,8 @@ represent that you have the authority to do so.
 
 5) License for Contributions
 
-	For any of your modifications or other derivations of the ArgoDSM
-	source code ("your Contributions"), you grant Eta Scale AB a
+	For any of your modifications or other derivations of the Eta Scale
+	Software source code ("your Contributions"), you grant Eta Scale AB a
 	non-exclusive, irrevocable, worldwide, no-charge, transferable license
 	to use,	execute, create derivative works of, and distribute
 	(internally and	externally) or otherwise use commercially or
@@ -80,15 +82,15 @@ represent that you have the authority to do so.
 	Except for the rights granted to Eta Scale AB in this paragraph, you
 	reserve all rights, title and interest in and to your Contributions.
 
-6) Non-Severability of the ArgoDSM Open Source License
+6) Non-Severability of the Eta Scale Open Source License
 
-	If any part of the ArgoDSM Open Source License is invalid, or becomes
+	If any part of the Eta Scale Open Source License is invalid, or becomes
 	invalid, then the entire license shall become invalid, and any rights
-	you derived from the ArgoDSM Open Source License shall be null and void.
-	This shall not affect the License for your Contributions that you have
-	given according to Section 5 of the ArgoDSM Open Source License, which
-	shall remain valid even if the ArgoDSM Open Source License itself is
-	invalid, or becomes invalid.
+	you derived from the Eta Scale Open Source License shall be null and
+	void. This shall not affect the License for your Contributions that you
+	have given according to Section 5 of the Eta Scale Open Source License,
+	which shall remain valid even if the Eta Scale Open Source License
+	itself is invalid, or becomes invalid.
 
 7) Choice of Law
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 include_directories ("${PROJECT_SOURCE_DIR}/backend")
 add_subdirectory (backend)

--- a/src/allocators/allocators.cpp
+++ b/src/allocators/allocators.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the default allocators
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "collective_allocator.hpp"

--- a/src/allocators/allocators.h
+++ b/src/allocators/allocators.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides all C allocators for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_allocators_h

--- a/src/allocators/allocators.hpp
+++ b/src/allocators/allocators.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides all C++ allocators for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_allocators_hpp

--- a/src/allocators/collective_allocator.h
+++ b/src/allocators/collective_allocator.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the collective allocator for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_collective_allocators_h

--- a/src/allocators/collective_allocator.hpp
+++ b/src/allocators/collective_allocator.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the collective allocator for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  *
  * @details
  * There are two possible ways of implementing collective allocations:

--- a/src/allocators/dynamic_allocator.h
+++ b/src/allocators/dynamic_allocator.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the dynamic allocator for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_dynamic_allocators_h

--- a/src/allocators/dynamic_allocator.hpp
+++ b/src/allocators/dynamic_allocator.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the dynamic allocator for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  *
  * @details
  * There are two types of dynamic allocators provided by this file.

--- a/src/allocators/generic_allocator.hpp
+++ b/src/allocators/generic_allocator.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a generic allocator template for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  *
  * @details
  * Allocators in C++ are supposed to allocate any type T,

--- a/src/allocators/null_lock.hpp
+++ b/src/allocators/null_lock.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief dummy lock, not intended for public use
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  *
  * @internal
  * @details sometimes templates should be used with and without internal locking, this file provides the neccessary dummy class to allow disabling locking

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file implements some of the basic ArgoDSM calls
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "argo.hpp"

--- a/src/argo.h
+++ b/src/argo.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the full C interface to ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_argo_h

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides the full C++ interface to ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_argo_hpp

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 # which backends to enable?
 option(ARGO_BACKEND_SINGLENODE

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -3,7 +3,7 @@
  * @brief This file provides the backend interface
  * @details The backend interface can be implemented independently
  *          for different interconnects or purposes.
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_backend_backend_hpp

--- a/src/backend/explicit_instantiations.inc.cpp
+++ b/src/backend/explicit_instantiations.inc.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief file listing all template instances in the backend
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "../types/types.hpp"

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(argobackend-mpi mpi.cpp swdsm.cpp)
 target_link_libraries(argobackend-mpi rt)

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief MPI backend implemenation
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "../backend.hpp"

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file implements the MPI-backend of ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 #include "swdsm.h"
 

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief this is a legacy file from the ArgoDSM prototype
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  * @deprecated this file is legacy and will be removed as soon as possible
  * @warning do not rely on functions from this file
  */

--- a/src/backend/singlenode/CMakeLists.txt
+++ b/src/backend/singlenode/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(argobackend-singlenode singlenode.cpp)
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief pseudo-backend implemenation for a single node ArgoDSM system
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "../../data_distribution/data_distribution.hpp"

--- a/src/data_distribution/data_distribution.hpp
+++ b/src/data_distribution/data_distribution.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides an abstraction layer for distributing the shared memory space
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_data_distribution_hpp

--- a/src/mempools/dummy_mempool.hpp
+++ b/src/mempools/dummy_mempool.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a dummy memory pool for testing purposes
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  * @note not intended for production use
  */
 

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a dynamically growing memory pool for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_dynamic_mempool_hpp

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a dynamically growing memory pool for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_global_mempool_hpp

--- a/src/synchronization/broadcast.hpp
+++ b/src/synchronization/broadcast.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a broadcasting facility for a single value
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_communication_broadcast_hpp

--- a/src/synchronization/cohort_lock.hpp
+++ b/src/synchronization/cohort_lock.hpp
@@ -2,7 +2,7 @@
  * @file
  * @brief This file provides a cohort lock for the ArgoDSM system
  * @todo Better documentation
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_cohort_lock_hpp

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a tas lock for the ArgoDSM system based on the TAS lock made by David Klaftenegger
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_global_tas_lock_hpp

--- a/src/synchronization/intranode/mcs_lock.cpp
+++ b/src/synchronization/intranode/mcs_lock.cpp
@@ -3,7 +3,7 @@
  * @brief This file provides an MCS-style lock for the ArgoDSM system
  * @todo Better documentation
  * @todo namespace use and indentation in this file is inconsistent with other files
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include <thread>

--- a/src/synchronization/intranode/mcs_lock.hpp
+++ b/src/synchronization/intranode/mcs_lock.hpp
@@ -3,7 +3,7 @@
  * @brief MCS lock for local use
  * @todo Better documentation
  * @todo namespace use and indentation in this file is inconsistent with other files
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 #ifndef MCS_LOCK_HPP_LDFPXGTZ
 #define MCS_LOCK_HPP_LDFPXGTZ

--- a/src/synchronization/intranode/ticket_lock.hpp
+++ b/src/synchronization/intranode/ticket_lock.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides a (local) ticket lock for intranode locking in the ArgoDSM system
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_local_ticket_lock_hpp

--- a/src/synchronization/synchronization.cpp
+++ b/src/synchronization/synchronization.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file implements synchronization primitives for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "../backend/backend.hpp"

--- a/src/synchronization/synchronization.h
+++ b/src/synchronization/synchronization.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides C bindings for some ArgoDSM synchronization primitives
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_synchronization_h

--- a/src/synchronization/synchronization.hpp
+++ b/src/synchronization/synchronization.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides synchronization primitives for ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_synchronization_hpp

--- a/src/types/types.hpp
+++ b/src/types/types.hpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file defines common types used in ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #ifndef argo_types_types_hpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+# Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_subdirectory(gtest-1.7.0)
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/tests/allocators.cpp
+++ b/tests/allocators.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides unit tests for the ArgoDSM allocators and memory pools
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include <iostream>

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides tests for the backends
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include <chrono>

--- a/tests/barrier.cpp
+++ b/tests/barrier.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides tests for the barrier synchronization
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "argo.hpp"

--- a/tests/lock.cpp
+++ b/tests/lock.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides unit tests for the ArgoDSM locks
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include <iostream>

--- a/tests/omp.cpp
+++ b/tests/omp.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides tests using OpenMP in ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include <iostream>

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides unit tests for the ArgoDSM prefetch mechanism
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include <iostream>

--- a/tests/stlallocation.cpp
+++ b/tests/stlallocation.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides tests using C++ interfaces in ArgoDSM
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "argo.hpp"

--- a/tests/uninitialized.cpp
+++ b/tests/uninitialized.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief This file provides unit tests for accessing ArgoDSM memory in various ways
- * @copyright Eta Scale AB. Licensed under the ArgoDSM Open Source License. See the LICENSE file for details.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
 #include "argo.hpp"


### PR DESCRIPTION
This changes the License name to Eta Scale Open Source License,
which allows the same license text to be used for all projects
of Eta Scale AB.