### PR TITLE
Adds new backend atomics

### DIFF
--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -9,6 +9,10 @@
 #ifndef argo_backend_backend_hpp
 #define argo_backend_backend_hpp argo_backend_backend_hpp
 
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+
 #include "../data_distribution/data_distribution.hpp"
 #include "../types/types.hpp"
 
@@ -84,28 +88,6 @@ namespace argo {
 		using argo::data_distribution::global_ptr;
 
 		/**
-		 * @brief atomic swap operation on a global address
-		 * @param obj pointer to the global object to swap
-		 * @param desired the new value of the global object
-		 * @param order Memory synchronization ordering for this operation
-		 * @return the old value of the global object
-		 * @note Depending on the backend, this might require that type T is trivial.
-		 */
-		template<typename T>
-		T atomic_exchange(global_ptr<T> obj, T desired,
-				atomic::memory_order order = atomic::memory_order::acq_rel);
-
-		/**
-		 * @brief global write operation
-		 * @tparam T type of object to write
-		 * @param obj pointer to the object to write to
-		 * @param value value to store in the object
-		 * @note Depending on the backend, this might require that type T is trivial.
-		 */
-		template<typename T>
-		void store(global_ptr<T> obj, T value);
-
-		/**
 		 * @brief a simple collective barrier
 		 * @param threadcount number of threads on each node that go into the barrier
 		 */
@@ -132,6 +114,326 @@ namespace argo {
 		 *        visible for nodes calling acquire (or other synchronization primitives)
 		 */
 		void release();
+
+		namespace atomic {
+			using namespace argo::atomic;
+
+			/*
+			 * The following atomic functions are implemented by each backend in
+			 * their respective cpp files
+			 */
+
+			/**
+			 * @brief Backend internal type erased atomic exchange function
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param desired Pointer to the object that holds the desired value
+			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+			 * @sa exchange
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _exchange(global_ptr<void> obj, void* desired,
+				std::size_t size, void* output_buffer);
+
+			/**
+			 * @brief Backend internal type erased atomic store function
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param desired Pointer to the object that holds the desired value
+			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+			 * @sa store
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _store(global_ptr<void> obj, void* desired, std::size_t size);
+
+			/**
+			 * @brief Backend internal type erased atomic store function
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param size sizeof(*obj) == sizeof(output_buffer)
+			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
+			 * @sa load
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _load(
+				global_ptr<void> obj, std::size_t size, void* output_buffer);
+
+			/**
+			 * @brief Backend internal type erased atomic CAS function
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param desired Pointer to the object that holds the desired value
+			 * @param expected Pointer to the object that holds the expected value
+			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(*expected) == sizeof(output_buffer)
+			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+			 * @sa compare_exchange
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _compare_exchange(global_ptr<void> obj, void* desired,
+				std::size_t size, void* expected, void* output_buffer);
+
+			/**
+			 * @brief Backend internal type erased atomic (post)increment function for signed integers
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param value Pointer to the object that holds the desired value
+			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+			 * @sa exchange
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _fetch_add_int(global_ptr<void> obj, void* value, std::size_t size,
+				void* output_buffer);
+			/**
+			 * @brief Backend internal type erased atomic (post)increment function for unsigned integers
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param value Pointer to the object that holds the desired value
+			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+			 * @sa exchange
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _fetch_add_uint(global_ptr<void> obj, void* value, std::size_t size,
+				void* output_buffer);
+			/**
+			 * @brief Backend internal type erased atomic (post)increment function for floating point numbers
+			 * @param obj Pointer to the object whose value should be exchanged
+			 * @param value Pointer to the object that holds the desired value
+			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+			 * @sa exchange
+			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+			 */
+			void _fetch_add_float(global_ptr<void> obj, void* value, std::size_t size,
+				void* output_buffer);
+
+			/**
+			 * The following atomic functions are generic interfaces to the
+			 * actual backend implementations
+			 */
+
+			/**
+			 * @brief atomic swap operation on a global address
+			 * @param obj pointer to the global object to swap
+			 * @param desired the new value of the global object
+			 * @param order Memory synchronization ordering for this operation
+			 * @tparam T The type of the object to operate upon
+			 * @tparam U The type of the object to exchange with
+			 * @return the old value of the global object
+			 *
+			 * This function will atomically exchange the old value of the given
+			 * object with the new one and return the old one.
+			 */
+			template<typename T, typename U>
+			T exchange(global_ptr<T> obj, U desired, memory_order order = memory_order::acq_rel) {
+				T out_buffer;
+				static_assert(std::is_convertible<U, T>::value,
+					"It is not possible to implicitly convert \'desired\' to an"
+					" object of type T.");
+				T desired_buffer(desired);
+#if __GNUC__ >= 5 || __clang__
+				static_assert(
+					std::is_trivially_copy_assignable<T>::value,
+					"T must be trivially copy assignable"
+				);
+#endif // __GNUC__ >= 5 || __clang__
+
+				if (order == memory_order::acq_rel || order == memory_order::release)
+					release();
+
+				_exchange(global_ptr<void>(obj), &desired_buffer, sizeof(T), &out_buffer);
+
+				if (order == memory_order::acq_rel || order == memory_order::acquire)
+					acquire();
+
+				return out_buffer;
+			}
+
+			/**
+			 * @brief Atomic store operation on a global address
+			 * @tparam T type of object to write
+			 * @param obj pointer to the object to write to
+			 * @param desired value to store in the object
+			 * @param order Memory synchronization ordering for this operation
+			 * @tparam T The type of the object to operate upon
+			 * @tparam U The type of the object to store
+			 *
+			 * This function will atomically store the given value into the
+			 * given memory location.
+			 */
+			template<typename T, typename U>
+			void store(global_ptr<T> obj, U desired, memory_order order = memory_order::release) {
+				static_assert(std::is_convertible<U, T>::value,
+					"It is not possible to implicitly convert \'desired\' to an"
+					" object of type T.");
+				T desired_buffer(desired);
+#if __GNUC__ >= 5 || __clang__
+				static_assert(
+					std::is_trivially_copy_assignable<T>::value,
+					"T must be trivially copy assignable"
+				);
+#endif // __GNUC__ >= 5 || __clang__
+
+				if (order == memory_order::acq_rel || order == memory_order::release)
+					release();
+
+				_store(global_ptr<void>(obj), &desired_buffer, sizeof(T));
+
+				if (order == memory_order::acq_rel || order == memory_order::acquire)
+					acquire();
+			}
+
+			/**
+			 * @brief Atomic load operation on a global address
+			 * @param obj Pointer to the global object to swap
+			 * @param order Memory synchronization ordering for this operation
+			 * @tparam T The type of the object to operate upon
+			 * @return The value of the global object
+			 *
+			 * This function will atomically load the value from the given
+			 * memory location.
+			 */
+			template<typename T>
+			T load(global_ptr<T> obj, memory_order order = memory_order::acquire) {
+				T out_buffer;
+#if __GNUC__ >= 5 || __clang__
+				static_assert(
+					std::is_trivially_copy_assignable<T>::value,
+					"T must be trivially copy assignable"
+				);
+#endif // __GNUC__ >= 5 || __clang__
+
+				if (order == memory_order::acq_rel || order == memory_order::release)
+					release();
+
+				_load(global_ptr<void>(obj), sizeof(T), &out_buffer);
+
+				if (order == memory_order::acq_rel || order == memory_order::acquire)
+					acquire();
+
+				return out_buffer;
+			}
+
+			/**
+			 * @brief Atomic CAS operation on a global address
+			 * @param obj Pointer to the global object to swap
+			 * @param expected The value to compare against
+			 * @param desired The value to set the object to
+			 * @param order Memory synchronization ordering for this operation
+			 * @tparam T The type of the object to operate upon
+			 * @tparam U The type of the expected object
+			 * @tparam U The type of the desired object
+			 * @return true if successful, false otherwise
+			 *
+			 * This function will atomically swap the old (expected) value of
+			 * the object with the new (desired) one, but only if the actual
+			 * value of the object matches the expected one.
+			 */
+			template <typename T, typename U, typename V>
+			bool compare_exchange(global_ptr<T> obj, U expected, V desired,
+				memory_order order = memory_order::acq_rel) {
+				T out_buffer;
+				static_assert(std::is_convertible<U, T>::value,
+					"It is not possible to implicitly convert \'expected\' to an"
+					" object of type T.");
+				static_assert(std::is_convertible<V, T>::value,
+					"It is not possible to implicitly convert \'desired\' to an"
+					" object of type T.");
+				T expected_buffer(expected);
+				T desired_buffer(desired);
+#if __GNUC__ >= 5 || __clang__
+				static_assert(
+					std::is_trivially_copy_assignable<T>::value,
+					"T must be trivially copy assignable"
+				);
+#endif // __GNUC__ >= 5 || __clang__
+
+				if (order == memory_order::acq_rel || order == memory_order::release)
+					release();
+
+				//XXX: Is this strong or weak? MPI doesn't say anything
+				_compare_exchange(global_ptr<void>(obj), &desired_buffer, sizeof(T),
+					&expected_buffer, &out_buffer);
+
+				if (order == memory_order::acq_rel || order == memory_order::acquire)
+					acquire();
+
+				return out_buffer == expected_buffer;
+			}
+
+			/**
+			 * @brief Atomic fetch and add operation on a global address
+			 * @param obj Pointer to the global object to fetch and add to
+			 * @param value The value to add to the object
+			 * @param order Memory synchronization ordering for this operation
+			 * @tparam T The type of the object to operate upon
+			 * @tparam U The type of the value object
+			 * @return The value of the object BEFORE the add operation
+			 *
+			 * This function will perform an atomic (*obj)+=(*value) operation.
+			 */
+			template <typename T, typename U>
+			T fetch_add(global_ptr<T> obj, U value, memory_order order = memory_order::acq_rel) {
+				T out_buffer;
+				// We need a buffer with the same size as T
+				static_assert(std::is_convertible<U, T>::value,
+					"It is not possible to implicitly convert \'desired\' to an"
+					" object of type T.");
+				T value_buffer(value);
+#if __GNUC__ >= 5 || __clang__
+				static_assert(
+					std::is_trivially_copy_assignable<T>::value,
+					"T must be trivially copy assignable"
+				);
+#endif // __GNUC__ >= 5 || __clang__
+
+				if (order == memory_order::acq_rel || order == memory_order::release)
+					release();
+
+				// The order is important here, as floats are signed as well
+				if (std::is_floating_point<T>::value)
+					_fetch_add_float(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
+				else if (std::is_unsigned<T>::value)
+					_fetch_add_uint(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
+				else if (std::is_signed<T>::value)
+					_fetch_add_int(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
+				else
+					throw std::invalid_argument("Invalid type V for value");
+
+				if (order == memory_order::acq_rel || order == memory_order::acquire)
+					acquire();
+
+				return out_buffer;
+			}
+
+			/**
+			 * @brief Atomic fetch and add operation for pointers on a global address
+			 * @param obj Pointer to the global object to fetch and add to
+			 * @param value The value to add to the object
+			 * @param order Memory synchronization ordering for this operation
+			 * @tparam T The type of the pointer to operate upon
+			 * @tparam U The type of the value object
+			 * @return The value of the pointer BEFORE the add operation
+			 *
+			 * This function will perform an atomic (*obj)+=(*value) operation.
+			 * This is an overload for pointer types, as pointer arithmetic
+			 * works differently than normal integer and floating point
+			 * arithmetic.
+			 */
+			template <typename T, typename U>
+			T* fetch_add(global_ptr<T*> obj, U value, memory_order order = memory_order::acq_rel) {
+				T* out_buffer;
+				// We need a buffer with the same size as the pointer
+				void *value_buffer = reinterpret_cast<char*>(value * sizeof(T));
+
+				if (order == memory_order::acq_rel || order == memory_order::release)
+					release();
+
+				// Do the operation
+				_fetch_add_uint(global_ptr<void>(obj), &value_buffer, sizeof(T*), &out_buffer);
+
+				if (order == memory_order::acq_rel || order == memory_order::acquire)
+					acquire();
+
+				return out_buffer;
+			}
+		} // namespace atomic
 	} // namespace backend
 } // namespace argo
 

--- a/src/backend/explicit_instantiations.inc.cpp
+++ b/src/backend/explicit_instantiations.inc.cpp
@@ -6,41 +6,5 @@
 
 #include "../types/types.hpp"
 
-/**
- * @brief swap boolean flags
- * @return the old value of the flag
- */
-template bool atomic_exchange(global_ptr<bool>, bool, atomic::memory_order);
-
-/**
- * @brief swap chars
- * @return the old value of the char
- */
-template char atomic_exchange(global_ptr<char>, char, atomic::memory_order);
-
-/**
- * @brief swap integers
- * @return the old value of the integer
- */
-template int atomic_exchange(global_ptr<int>, int, atomic::memory_order);
-
-/**
- * @brief swap doubles
- * @return the old value of the double
- */
-template double atomic_exchange(global_ptr<double>, double, atomic::memory_order);
-
-/** @brief set boolean flags */
-template void store(global_ptr<bool>, bool);
-
-/** @brief set char */
-template void store(global_ptr<char>, char);
-
-/** @brief set int */
-template void store(global_ptr<int>, int);
-
-/** @brief set double */
-template void store(global_ptr<double>, double);
-
 /** @brief explicit instantiation for pointers to raw memory */
 template void broadcast(node_id_t, memory_t*);

--- a/src/data_distribution/data_distribution.hpp
+++ b/src/data_distribution/data_distribution.hpp
@@ -7,6 +7,7 @@
 #ifndef argo_data_distribution_hpp
 #define argo_data_distribution_hpp argo_global_lock_hpp
 
+#include <type_traits>
 #include <cstddef>
 
 #include "../types/types.hpp"
@@ -44,6 +45,14 @@ namespace argo {
 					{}
 
 				/**
+				 * @brief Copy constructor between different pointer types
+				 * @param other The pointer to copy from
+				 */
+				template<typename U>
+				explicit global_ptr(global_ptr<U> other)
+					: homenode(other.node()), local_offset(other.offset()) {}
+
+				/**
 				 * @brief get standard pointer
 				 * @return pointer to object this smart pointer is pointing to
 				 * @todo implement
@@ -56,7 +65,7 @@ namespace argo {
 				 * @brief dereference smart pointer
 				 * @return dereferenced object
 				 */
-				T& operator*() const {
+				typename std::add_lvalue_reference<T>::type operator*() const {
 					return *this->get();
 				}
 

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -45,7 +45,7 @@ namespace argo {
 				 *         false otherwise
 				 */
 				bool try_lock() {
-					auto old = backend::atomic_exchange(flag, locked, atomic::memory_order::relaxed);
+					auto old = backend::atomic::exchange(flag, locked, atomic::memory_order::relaxed);
 					if(old == unlocked){
 						backend::acquire();
 						return true;
@@ -60,7 +60,7 @@ namespace argo {
 				 */
 				void unlock() {
 					backend::release();
-					backend::store(flag, unlocked);
+					backend::atomic::store(flag, unlocked);
 				}
 
 				/**


### PR DESCRIPTION
This patch ports a patchset by @SakalisC to ArgoDSM.

The new backend atomics differ from the previous one in two aspects:

1) The templated code has been moved to the common header file, and each
backend implements a non-templated, type-erased version of the
functions. This means that we no longer need to explicitly instantiate
every single atomic function for every single type we use it for. The
type erasure is not a very big disadvantage because the MPI backend
(which is the main backend) requires it anyway.

2) There are now more functions. Specifically, we now have atomic exchange,
store, load, CAS, and fetch&add functions.

In addition to the changes mentioned above, some tests have been added,
as well as a copy constructor to the global_ptr class.