### PR TITLE
Fix a bug which caused 0-byte allocations to be registered

### DIFF
--- a/src/allocators/generic_allocator.hpp
+++ b/src/allocators/generic_allocator.hpp
@@ -220,9 +220,11 @@ namespace argo {
 						allocation = static_cast<T*>(mempool->reserve(n*sizeof(T)));
 					} catch (typename MemoryPool::bad_alloc) {
 						auto avail = mempool->available();
-						allocation = static_cast<T*>(mempool->reserve(avail));
-						freelist[avail].push(allocation);
-						allocation_size.insert({{allocation, n}});
+						if(avail > 0) {
+							allocation = static_cast<T*>(mempool->reserve(avail));
+							freelist[avail].push(allocation);
+							allocation_size.insert({{allocation, n}});
+						}
 						try {
 							mempool->grow(n*sizeof(T));
 						}catch(std::bad_alloc){


### PR DESCRIPTION
When growing a mempool by invoking another allocator,
the remaining memory is put into a freelist.
This code was even triggered when there was no remaining memory.
This resulted in wasted memory for the information, but also
associated size information with the nullptr when the pool is
first initialized.