### PR TITLE
fixes argument-dependent lookup

### DIFF
--- a/src/allocators/dynamic_allocator.hpp
+++ b/src/allocators/dynamic_allocator.hpp
@@ -178,6 +178,23 @@ namespace argo {
 				}
 		};
 
+		/**
+		 * @brief test dynamic allocators for equality
+		 * @return always true
+		 */
+		template<typename T, typename U>
+		bool operator==(const dynamic_allocator<T>&, const dynamic_allocator<U>&) {
+			return true;
+		}
+
+		/**
+		 * @brief test dynamic allocators for inequality
+		 * @return always false
+		 */
+		template<typename T, typename U>
+		bool operator!=(const dynamic_allocator<T>&, const dynamic_allocator<U>&) {
+			return false;
+		}
 
 	} // namespace allocators
 
@@ -344,23 +361,5 @@ namespace argo {
 	}
 
 } // namespace argo
-
-/**
- * @brief test dynamic allocators for equality
- * @return always true
- */
-template<typename T, typename U>
-bool operator==(const argo::allocators::dynamic_allocator<T>&, const argo::allocators::dynamic_allocator<U>&) {
-	return true;
-}
-
-/**
- * @brief test dynamic allocators for inequality
- * @return always false
- */
-template<typename T, typename U>
-bool operator!=(const argo::allocators::dynamic_allocator<T>&, const argo::allocators::dynamic_allocator<U>&) {
-	return false;
-}
 
 #endif /* argo_dynamic_allocators_hpp */


### PR DESCRIPTION
on some compilers, the argument-dependent loopup for operator==() is
implemented such that it does not consider namespace ::.
To work correctly on such compilers, the operator== is moved into the
namespace of the compared object, which works correctly there.