### PR TITLE
ensure MPI progress on release synchronization

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1413,9 +1413,11 @@ void argo_acquire(){
 
 
 void argo_release(){
+	int flag;
 	pthread_mutex_lock(&cachemutex);
 	sem_wait(&ibsem);
 	flushWriteBuffer();
+	MPI_Iprobe(MPI_ANY_SOURCE,MPI_ANY_TAG,workcomm,&flag,MPI_STATUS_IGNORE);
 	sem_post(&ibsem);
 	pthread_mutex_unlock(&cachemutex);
 }


### PR DESCRIPTION
As MPI attempts to delay communication as long as possible
our internal synchronization needs to poke the MPI subsystem
even when no data is read from the network.