### PR TITLE
Virtual memory management

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -67,3 +67,21 @@ initialization, destruction is performed. So, instead of accepting
 function argument is accepted, and that is the pointer to the memory that will
 be deallocated.
 
+
+## Virtual Memory Management
+
+To manage the virtual address space for ArgoDSM applications we acquire large
+amounts of virtual memory. There are currently three ways to acquire the
+underlying memory for ArgoDSM, and exactly one must be selected at compile time:
+
+1. POSIX shared memory objects (`-DARGO_VM_SHM`)
+2. `memfd_create` syscall (`-DARGO_VM_MEMFD`)
+3. anonymous remappable memory (`-DARGO_VM_ANONYMOUS`)
+
+Each version has its own downsides:
+1. POSIX shared memory objects are size-limited and require `/dev/shm` support.
+2. `memfd_create` requires Linux kernel version of 3.17+ and memory overcommit.
+3. anonymous remappable memory has a runtime overhead and relies on kernel
+   functionality that is deprecated since Linux version 3.16.
+
+For now, the default is to use POSIX shared memory objects.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,9 +20,44 @@ foreach(src ${synchronization_sources})
 	list(APPEND argo_sources synchronization/${src})
 endforeach(src)
 
+
+# exactly one of these must be enabled. below is some code to ensure this.
+option(ARGO_VM_SHM
+	"Handle virtual addresses using POSIX shared memory. Size-limited." ON)
+option(ARGO_VM_ANONYMOUS
+	"Handle virtual addresses using anonymously-mapped memory. Slow." OFF)
+option(ARGO_VM_MEMFD
+	"Handle virtual addresses using an anonymous memory file. Requires kernel 3.17+." OFF)
+
+set(ARGO_VM_COUNT 0 CACHE INTERNAL "Check for multiple virtual address handlers")
+unset(vm_libs)
+
+if(ARGO_VM_SHM)
+	set(vm_sources shm.cpp)
+	set(vm_libs rt)
+	math(EXPR ARGO_VM_COUNT "${ARGO_VM_COUNT} + 1")
+endif(ARGO_VM_SHM)
+
+if(ARGO_VM_ANONYMOUS)
+	set(vm_sources anonymous.cpp)
+	math(EXPR ARGO_VM_COUNT "${ARGO_VM_COUNT} + 1")
+endif(ARGO_VM_ANONYMOUS)
+
+if(ARGO_VM_MEMFD)
+	set(vm_sources memfd.cpp)
+	math(EXPR ARGO_VM_COUNT "${ARGO_VM_COUNT} + 1")
+endif(ARGO_VM_MEMFD)
+
+if(NOT ARGO_VM_COUNT EQUAL 1)
+	message(FATAL_ERROR "${ARGO_VM_COUNT} virtual address handlers selected. Please select exactly one virtual address handler.")
+endif(NOT ARGO_VM_COUNT EQUAL 1)
+
+foreach(src ${vm_sources})
+	list(APPEND argo_sources virtual_memory/${src})
+endforeach(src)
+
 # add the frontend library
 add_library(argo ${argo_sources})
-
 
 option(ARGO_USE_LIBNUMA
 	"Use libnuma to determine NUMA structure within ArgoDSM" ON)
@@ -30,6 +65,8 @@ if(ARGO_USE_LIBNUMA)
 	target_link_libraries(argo numa)
 	add_definitions(-DARGO_USE_LIBNUMA)
 endif(ARGO_USE_LIBNUMA)
+
+target_link_libraries(argo ${vm_libs})
 
 #install (TARGETS argo DESTINATION bin)
 

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -9,6 +9,9 @@
 #include "allocators/collective_allocator.hpp"
 #include "allocators/dynamic_allocator.hpp"
 
+#include "virtual_memory/virtual_memory.hpp"
+
+namespace vm = argo::virtual_memory;
 namespace mem = argo::mempools;
 namespace alloc = argo::allocators;
 
@@ -20,6 +23,7 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&
 
 namespace argo {
 	void init(size_t size) {
+		vm::init();
 		default_global_mempool = new mem::global_memory_pool<>(size);
 		argo_reset();
 	}

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(argobackend-mpi mpi.cpp swdsm.cpp)
-target_link_libraries(argobackend-mpi rt)
 
 install(TARGETS argobackend-mpi
 	COMPONENT "Runtime"

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1065,8 +1065,8 @@ void argo_initialize(unsigned long long size){
 	initmpi();
 	unsigned long alignment = pagesize*CACHELINE*numtasks;
 	if((size%alignment)>0){
+		size += alignment - 1;
 		size /= alignment;
-		size++;
 		size *= alignment;
 	}
 

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -659,6 +659,7 @@ void *writeloop(void * x){
 		sem_post(&ibsem);
 		sem_post(&writerwaitsem);
 	}
+	return nullptr;
 }
 
 void * loadcacheline(void * x){
@@ -815,6 +816,7 @@ void * loadcacheline(void * x){
 		sem_post(&ibsem);
 
 	}
+	return nullptr;
 }
 
 void * prefetchcacheline(void * x){
@@ -966,6 +968,7 @@ void * prefetchcacheline(void * x){
 		sem_post(&prefetchwaitsem);
 		sem_post(&ibsem);
 	}
+	return nullptr;
 }
 
 

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -3,7 +3,10 @@
  * @brief This file implements the MPI-backend of ArgoDSM
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
+#include "virtual_memory/virtual_memory.hpp"
 #include "swdsm.h"
+
+namespace vm = argo::virtual_memory;
 
 /*Treads*/
 /** @brief Thread loads data into cache */
@@ -36,7 +39,7 @@ unsigned long classificationSize;
 /** @brief  Tracks if a page is touched this epoch*/
 argo_byte * touchedcache;
 /** @brief  The local page cache*/
-argo_byte * cacheData;
+char* cacheData;
 /** @brief Copy of the local cache to keep twinpages for later being able to DIFF stores */
 char * pagecopy;
 /** @brief Protects the pagecache */
@@ -107,12 +110,6 @@ sem_t prefetchstartsem;
 /** @brief signalhandler waits on this to complete a transfer */
 sem_t prefetchwaitsem;
 
-/*Backing file*/
-/** @brief  Filename for file backing cache*/
-char filename[MPI_MAX_PROCESSOR_NAME];
-/** @brief  file descriptor for backing file*/
-unsigned int fd;
-
 /*Global lock*/
 /** @brief  Local flags we spin on for the global lock*/
 unsigned long * lockbuffer;
@@ -131,7 +128,7 @@ pthread_mutex_t gmallocmutex = PTHREAD_MUTEX_INITIALIZER;
 /** @brief  Points to start of global address space*/
 void * startAddr;
 /** @brief  Points to start of global address space this process is serving */
-argo_byte * globalData;
+char* globalData;
 /** @brief  Size of global address space*/
 unsigned long size_of_all;
 /** @brief  Size of this process part of global address space*/
@@ -396,11 +393,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 			}
 			/* set page to permit reads and map it to the page cache */
 			/** @todo Set cache offset to a variable instead of calculating it here */
-			localAlignedAddr = (unsigned long *)mmap(localAlignedAddr,pagesize*CACHELINE,PROT_READ,MAP_SHARED|MAP_FIXED,fd,cacheoffset+offset);
-			if(localAlignedAddr== MAP_FAILED){
-				printf("mmap failed in ArgoDSM address %p errno:%d - likely due to out of memory or too many memory mappings per process (check errno) \n",localAlignedAddr,errno);
-				exit(EXIT_FAILURE);
-			}
+			vm::map_memory(localAlignedAddr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ);
 
 		}
 		else{
@@ -436,11 +429,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 				}
 			}
 			/* set page to permit read/write and map it to the page cache */
-			localAlignedAddr =  (unsigned long *) mmap(localAlignedAddr,pagesize*CACHELINE,PROT_READ|PROT_WRITE,MAP_SHARED|MAP_FIXED,fd,cacheoffset+offset);
-			if(localAlignedAddr== MAP_FAILED){
-				printf("mmap failed in ArgoDSM address %p errno:%d - likely due to out of memory or too many memory mappings per process (check errno) \n",localAlignedAddr,errno);
-				exit(EXIT_FAILURE);
-			}
+			vm::map_memory(localAlignedAddr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ|PROT_WRITE);
 
 		}
 		sem_post(&ibsem);
@@ -563,7 +552,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 		/* register and get latest sharers / writers */
 		MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
 		MPI_Get_accumulate(&id, 1,MPI_LONG,&writers,1,MPI_LONG,homenode,
-											 classidx+1,1,MPI_LONG,MPI_BOR,sharerWindow);
+			classidx+1,1,MPI_LONG,MPI_BOR,sharerWindow);
 		MPI_Get(&sharers,1, MPI_LONG, homenode, classidx, 1,MPI_LONG,sharerWindow);
 		MPI_Win_unlock(homenode, sharerWindow);
 		/* We get result of accumulation before operation so we need to account for that */
@@ -619,7 +608,8 @@ unsigned long getHomenode(unsigned long addr){
 }
 
 unsigned long getOffset(unsigned long addr){
-	unsigned long offset = addr - (getHomenode(addr))*size_of_chunk;//offset in local memory on remote node (homenode
+	//offset in local memory on remote node (homenode)
+	unsigned long offset = addr - (getHomenode(addr))*size_of_chunk;
 	if(offset >=size_of_chunk){
 		exit(EXIT_FAILURE);
 	}
@@ -739,7 +729,7 @@ void * loadcacheline(void * x){
 					cacheControl[startidx].tag = lineAddr;
 
 					cacheControl[startidx].dirty=CLEAN;
-					lineptr =  mmap(lineptr, blocksize, PROT_NONE,MAP_SHARED|MAP_FIXED,fd,pagesize*startidx);
+					vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
 					mprotect(tmpptr2,blocksize,PROT_NONE);
 				}
 				pthread_mutex_unlock(&wbmutex);
@@ -761,7 +751,8 @@ void * loadcacheline(void * x){
 
 		if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
 			MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-			MPI_Get_accumulate(&id, 1,MPI_LONG,&tempsharer,1,MPI_LONG,homenode,classidx,1,MPI_LONG,MPI_BOR,sharerWindow);
+			MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
+				homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
 			MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
 			MPI_Win_unlock(homenode, sharerWindow);
 		}
@@ -798,11 +789,7 @@ void * loadcacheline(void * x){
 		MPI_Win_unlock(homenode, globalDataWindow[homenode]);
 
 		if(cacheControl[startidx].tag == GLOBAL_NULL){
-			lineptr =  mmap(lineptr, blocksize, PROT_READ,MAP_SHARED|MAP_FIXED,fd,pagesize*startidx);
-			if(lineptr== MAP_FAILED){
-				printf("MMAP failed %p errno:%d\n",lineptr,errno);
-				exit(EXIT_FAILURE);
-			}
+			vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
 			cacheControl[startidx].tag = lineAddr;
 		}
 		else{
@@ -896,7 +883,7 @@ void * prefetchcacheline(void * x){
 					cacheControl[startidx].tag = lineAddr;
 					cacheControl[startidx].dirty=CLEAN;
 
-					lineptr =  mmap(lineptr, blocksize, PROT_NONE,MAP_SHARED|MAP_FIXED,fd,pagesize*startidx);
+					vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
 					mprotect(tmpptr2,blocksize,PROT_NONE);
 
 				}
@@ -917,7 +904,8 @@ void * prefetchcacheline(void * x){
 
 		if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
 			MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-			MPI_Get_accumulate(&id, 1,MPI_LONG,&tempsharer,1,MPI_LONG,homenode,classidx,1,MPI_LONG,MPI_BOR,sharerWindow);
+			MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
+				homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
 			MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
 			MPI_Win_unlock(homenode, sharerWindow);
 		}
@@ -946,16 +934,13 @@ void * prefetchcacheline(void * x){
 		}
 
 		MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-		MPI_Get(&cacheData[startidx*pagesize],1,cacheblock,homenode, offset, 1,cacheblock,globalDataWindow[homenode]);
+		MPI_Get(&cacheData[startidx*pagesize], 1, cacheblock, homenode,
+			offset, 1, cacheblock, globalDataWindow[homenode]);
 		MPI_Win_unlock(homenode, globalDataWindow[homenode]);
 
 
 		if(cacheControl[startidx].tag == GLOBAL_NULL){
-			lineptr =  mmap(lineptr, blocksize, PROT_READ,MAP_SHARED|MAP_FIXED,fd,pagesize*startidx);
-			if(lineptr== MAP_FAILED){
-				printf("MMAP failed %p errno:%d\n",lineptr,errno);
-				exit(EXIT_FAILURE);
-			}
+			vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
 			cacheControl[startidx].tag = lineAddr;
 		}
 		else{
@@ -1070,11 +1055,10 @@ void argo_initialize(unsigned long long size){
 		size *= alignment;
 	}
 
-	startAddr = mmap((void *)(pagesize*2000000000L), size, PROT_NONE, MAP_ANON|MAP_SHARED, 0, 0);
-	if(startAddr == (void *) -1){
-		printf("startmap error  errno %d  tried to allocate :%llu bytes    startaddr:%lu\n",errno,size,pagesize*2000000000L);
-		exit(EXIT_FAILURE);
-	}
+	startAddr = vm::start_address();
+#ifdef ARGO_PRINT_STATISTICS
+	printf("maximum virtual memory: %ld GiB\n", vm::size() >> 30);
+#endif
 
 	threadbarrier = (pthread_barrier_t *) malloc(sizeof(pthread_barrier_t)*(NUM_THREADS+1));
 	for(i = 1; i <= NUM_THREADS; i++){
@@ -1151,96 +1135,46 @@ void argo_initialize(unsigned long long size){
 	gwritersize *= pagesize;
 
 	cacheoffset = pagesize*cachesize+cacheControlSize;
-	globalData= (argo_byte *) memalign(pagesize,size_of_chunk);
-	if(globalData == NULL){
-		printf("memalign error out of memory\n");
-		exit(EXIT_FAILURE);
-	}
 
-	cacheData = (argo_byte*)memalign(pagesize, cachesize*pagesize);
-	if(cacheData == NULL){
-		printf("memalign error out of memory\n");
-		exit(EXIT_FAILURE);
-	}
-
-	cacheControl = (control_data *) memalign(pagesize,cacheControlSize);
-	if(cacheControl == NULL){
-		printf("memalign error out of memory\n");
-		exit(EXIT_FAILURE);
-	}
+	globalData = static_cast<char*>(vm::allocate_mappable(pagesize, size_of_chunk));
+	cacheData = static_cast<char*>(vm::allocate_mappable(pagesize, cachesize*pagesize));
+	cacheControl = static_cast<control_data*>(vm::allocate_mappable(pagesize, cacheControlSize));
 
 	touchedcache = (argo_byte *)malloc(cachesize);
 	if(touchedcache == NULL){
-		printf("memalign error out of memory\n");
+		printf("malloc error out of memory\n");
 		exit(EXIT_FAILURE);
 	}
 
-	lockbuffer = (unsigned long *) memalign(pagesize,pagesize);
-	if(lockbuffer == NULL){
-		printf("memalign error out of memory\n");
-		exit(EXIT_FAILURE);
-	}
-
-	pagecopy = (char*) memalign(pagesize,cachesize*pagesize);
-	if(pagecopy == NULL){
-		printf("memalign error out of memory\n");
-		exit(EXIT_FAILURE);
-	}
-
-	globalSharers = (unsigned long *)memalign(pagesize,gwritersize);
-	if(globalSharers == NULL){
-		printf("memalign error out of memory\n");
-		exit(EXIT_FAILURE);
-	}
+	lockbuffer = static_cast<unsigned long*>(vm::allocate_mappable(pagesize, pagesize));
+	pagecopy = static_cast<char*>(vm::allocate_mappable(pagesize, cachesize*pagesize));
+	globalSharers = static_cast<unsigned long*>(vm::allocate_mappable(pagesize, gwritersize));
 
 	char processor_name[MPI_MAX_PROCESSOR_NAME];
 	int name_len;
 	MPI_Get_processor_name(processor_name, &name_len);
 
-	sprintf(filename, "argocache%d", rank);
-	fd = shm_open(filename,O_RDWR|O_CREAT,0664);
 	MPI_Barrier(MPI_COMM_WORLD);
-	unsigned long filesize = cachesize*pagesize*CACHELINE+cacheControlSize+size_of_chunk+pagesize+gwritersize+pagesize;
-	if(ftruncate(fd,filesize)) {
-		/// @todo this needs to be handled
-		exit(EXIT_FAILURE);
-	}
 
-	void * tmpcache;
+	void* tmpcache;
 	tmpcache=cacheData;
-	tmpcache =  mmap(tmpcache , pagesize*cachesize, PROT_READ|PROT_WRITE,MAP_SHARED|MAP_FIXED,fd,0);
-	if(tmpcache == (void *) -1){
-		printf("1mmap error  errno%d\n",errno);
-		exit(EXIT_FAILURE);
-	}
+	vm::map_memory(tmpcache, pagesize*cachesize, 0, PROT_READ|PROT_WRITE);
 
+	std::size_t current_offset = pagesize*cachesize;
 	tmpcache=cacheControl;
-	tmpcache =  mmap(tmpcache , cacheControlSize, PROT_READ|PROT_WRITE,MAP_SHARED|MAP_FIXED,fd,pagesize*cachesize );
-	if(tmpcache == (void *) -1){
-		printf("3mmap cachecontrol error  errno%d\n",errno);
-		exit(EXIT_FAILURE);
-	}
+	vm::map_memory(tmpcache, cacheControlSize, current_offset, PROT_READ|PROT_WRITE);
 
+	current_offset += cacheControlSize;
 	tmpcache=globalData;
-	tmpcache =  mmap(tmpcache , size_of_chunk, PROT_READ|PROT_WRITE,MAP_SHARED|MAP_FIXED,fd,pagesize*cachesize + cacheControlSize);
-	if(tmpcache == (void *) -1){
-		printf("4mmap error  errno%d  tmpacache:%p   size :%lu   offset:%lu\n",errno,tmpcache,size_of_chunk,pagesize*cachesize + cacheControlSize);
-		exit(EXIT_FAILURE);
-	}
+	vm::map_memory(tmpcache, size_of_chunk, current_offset, PROT_READ|PROT_WRITE);
 
+	current_offset += size_of_chunk;
 	tmpcache=globalSharers;
-	tmpcache =  mmap(tmpcache ,gwritersize , PROT_READ|PROT_WRITE,MAP_SHARED|MAP_FIXED,fd,pagesize*cachesize + cacheControlSize+size_of_chunk);
-	if(tmpcache == (void *) -1){
-		printf("global sharers mmap error  errno%d\n",errno);
-		exit(EXIT_FAILURE);
-	}
+	vm::map_memory(tmpcache, gwritersize, current_offset, PROT_READ|PROT_WRITE);
 
+	current_offset += gwritersize;
 	tmpcache=lockbuffer;
-	tmpcache =  mmap(tmpcache ,pagesize , PROT_READ|PROT_WRITE,MAP_SHARED|MAP_FIXED,fd,pagesize*cachesize + cacheControlSize+size_of_chunk+gwritersize);
-	if(tmpcache == (void *) -1){
-		printf("lockbuffer mmap error lockbuffer errno%d\n",errno);
-		exit(EXIT_FAILURE);
-	}
+	vm::map_memory(tmpcache, pagesize, current_offset, PROT_READ|PROT_WRITE);
 
 	sem_init(&loadwaitsem,0,0);
 	sem_init(&loadstartsem,0,0);
@@ -1483,13 +1417,13 @@ void storepageDIFF(unsigned long index, unsigned long addr){
 		}
 		else{
 			if(cnt > 0){
-				MPI_Put(&real[(i)-cnt] ,cnt, MPI_BYTE, homenode, offset+((i)-cnt), cnt, MPI_BYTE, globalDataWindow[homenode]);
+				MPI_Put(&real[i-cnt], cnt, MPI_BYTE, homenode, offset+(i-cnt), cnt, MPI_BYTE, globalDataWindow[homenode]);
 				cnt = 0;
 			}
 		}
 	}
 	if(cnt > 0){
-		MPI_Put(&real[(i)-cnt] ,cnt, MPI_BYTE, homenode, offset+((i)-cnt), cnt, MPI_BYTE, globalDataWindow[homenode]);
+		MPI_Put(&real[i-cnt], cnt, MPI_BYTE, homenode, offset+(i-cnt), cnt, MPI_BYTE, globalDataWindow[homenode]);
 	}
 	stats.stores++;
 }
@@ -1499,7 +1433,8 @@ void printStatistics(){
 	printf("# PROCESS ID %d \n",workrank);
 	printf("cachesize:%ld,CACHELINE:%ld wbsize:%ld\n",cachesize,CACHELINE,writebuffersize);
 	printf("     writebacktime+=(t2-t1): %lf\n",stats.writebacktime);
-	printf("# Storetime : %lf , loadtime :%lf flushtime:%lf, writebacktime: %lf\n",stats.storetime,stats.loadtime,stats.flushtime, stats.writebacktime);
+	printf("# Storetime : %lf , loadtime :%lf flushtime:%lf, writebacktime: %lf\n",
+		stats.storetime, stats.loadtime, stats.flushtime, stats.writebacktime);
 	printf("# Barriertime : %lf, selfinvtime %lf\n",stats.barriertime, stats.selfinvtime);
 	printf("stores:%lu, loads:%lu, barriers:%lu\n",stats.stores,stats.loads,stats.barriers);
 	printf("Locks:%d\n",stats.locks);

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -10,27 +10,29 @@
 #define argo_swdsm_h argo_swdsm_h
 
 /* Includes */
+#include <cstdint>
 #include <type_traits>
-#include "mpi.h"
-#include "argo.h"
-#include <stdio.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <malloc.h>
+#include <math.h>
+#include <mpi.h>
 #include <pthread.h>
+#include <omp.h>
+#include <semaphore.h>
+#include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
-#include <math.h>
-#include <omp.h>
-#include <signal.h>
-#include <malloc.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <assert.h>
-#include <semaphore.h>
-#include <unistd.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
 
+#include "argo.h"
 /** @brief Granularity of coherence unit / pagesize  */
 #define GRAN 4096L //page size.
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -4,16 +4,19 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
-#include "../../data_distribution/data_distribution.hpp"
-#include "../../synchronization/global_tas_lock.hpp"
-#include "../../types/types.hpp"
+#include "data_distribution/data_distribution.hpp"
+#include "synchronization/global_tas_lock.hpp"
+#include "types/types.hpp"
+#include "virtual_memory/virtual_memory.hpp"
 #include "../backend.hpp"
 
 #include <atomic>
 #include <condition_variable>
-#include <mutex>
 #include <cstddef>
 #include <cstring>
+#include <mutex>
+
+namespace vm = argo::virtual_memory;
 
 /** @brief a lock for atomically executed operations */
 std::mutex atomic_op_mutex;
@@ -55,7 +58,7 @@ namespace argo {
 	namespace backend {
 
 		void init(std::size_t size) {
-			memory = new char[size];
+			memory = static_cast<char*>(vm::allocate_mappable(4096, size));
 			memory_size = size;
 			using namespace data_distribution;
 			naive_data_distribution<0>::set_memory_space(nodes, memory, size);

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -21,10 +21,8 @@ namespace {
 	/* file constants */
 	/** @todo hardcoded start address */
 	const char* ARGO_START = (char*) 0x200000000000l;
-	/** @todo hardcoded end address */
-	const char* ARGO_END   = (char*) 0x600000000000l;
 	/** @todo hardcoded size */
-	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+	const ptrdiff_t ARGO_SIZE = 0x80000000000l;
 
 	/** @brief error message string */
 	const std::string msg_insufficient_memory = "ArgoDSM anonymous mappable memory is insufficient.";
@@ -48,7 +46,7 @@ namespace argo {
 	namespace virtual_memory {
 		void init() {
 			/** @todo check desired range is free */
-			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED|MAP_NORESERVE;
 			backing_addr = static_cast<char*>(
 				::mmap((void*)ARGO_START, ARGO_SIZE, PROT_NONE, flags, -1, 0)
 				);
@@ -57,7 +55,7 @@ namespace argo {
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
 				exit(EXIT_FAILURE);
 			}
-			char* virtual_addr = (char*) 0x300000000000l;
+			char* virtual_addr = (char*) ARGO_START + ARGO_SIZE/2l;
 			backing_offset = 0;
 			file_offset = virtual_addr - backing_addr;
 		}

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file
+ * @brief This file implements the virtual memory and virtual address handling
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include <cerrno>
+#include <cstddef>
+#include <fcntl.h>
+#include <iostream>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <system_error>
+#include <unistd.h>
+#include "virtual_memory.hpp"
+
+namespace {
+	/* file constants */
+	/** @todo hardcoded start address */
+	const char* ARGO_START = (char*) 0x200000000000l;
+	/** @todo hardcoded end address */
+	const char* ARGO_END   = (char*) 0x600000000000l;
+	/** @todo hardcoded size */
+	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+
+	/** @brief error message string */
+	const std::string msg_insufficient_memory = "ArgoDSM anonymous mappable memory is insufficient.";
+	/** @brief error message string */
+	const std::string msg_mprotect_fail = "ArgoDSM could not mprotect anonymous mapping";
+	/** @brief error message string */
+	const std::string msg_invalid_remap = "ArgoDSM encountered an invalid mapping attempt in virtual address space";
+	/** @brief error message string */
+	const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
+
+	/* file variables */
+	/** @brief the address at which the backing storage space starts */
+	char* backing_addr;
+	/** @brief the current offset into the backing storage space */
+	std::size_t backing_offset;
+	/** @brief the offset within the memory region controlled to the beginning of the virtual address space */
+	std::size_t file_offset;
+}
+
+namespace argo {
+	namespace virtual_memory {
+		void init() {
+			/** @todo check desired range is free */
+			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+			backing_addr = static_cast<char*>(
+				::mmap((void*)ARGO_START, ARGO_SIZE, PROT_NONE, flags, -1, 0)
+				);
+			if(backing_addr == MAP_FAILED) {
+				std::cerr << msg_main_mmap_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+			char* virtual_addr = (char*) 0x300000000000l;
+			backing_offset = 0;
+			file_offset = virtual_addr - backing_addr;
+		}
+
+		void* start_address() {
+			return backing_addr + file_offset;
+		}
+
+		std::size_t size() {
+			return ARGO_SIZE/4;
+		}
+
+		void* allocate_mappable(std::size_t alignment, std::size_t size) {
+			/* compute next free well-aligned offset */
+			backing_offset = ((backing_offset + alignment - 1)/alignment);
+			backing_offset *= alignment;
+
+			/* check it is within size limits */
+			if(backing_offset > argo::virtual_memory::size()) {
+				std::cerr << msg_insufficient_memory << std::endl;
+				throw std::system_error(std::make_error_code(std::errc::not_enough_memory), msg_insufficient_memory);
+				return nullptr;
+			}
+			char* r = backing_addr + backing_offset;
+			/* mark memory as used */
+			backing_offset += size;
+
+			/* make memory writable */
+			int err = mprotect(r, size, PROT_READ|PROT_WRITE);
+			if(err) {
+				std::cerr << msg_mprotect_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
+				return nullptr;
+			}
+			return r;
+		}
+
+		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+			/**@todo move pagesize 4096 to hw module */
+			int err = remap_file_pages(addr, size, 0, (file_offset + offset)/4096, 0);
+			if(err) {
+				std::cerr << msg_invalid_remap << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_invalid_remap);
+				exit(EXIT_FAILURE);
+			}
+			err = mprotect(addr, size, prot);
+			if(err) {
+				std::cerr << msg_mprotect_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
+				exit(EXIT_FAILURE);
+			}
+		}
+	} // namespace virtual_memory
+} // namespace argo

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * @brief This file implements the virtual memory and virtual address handling
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <system_error>
+#include <unistd.h>
+#include "virtual_memory.hpp"
+
+namespace {
+	/* file constants */
+	/** @todo hardcoded start address */
+	const char* ARGO_START = (char*) 0x200000000000l;
+	/** @todo hardcoded end address */
+	const char* ARGO_END   = (char*) 0x600000000000l;
+	/** @todo hardcoded size */
+	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+
+	/** @brief error message string */
+	const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
+	/** @brief error message string */
+	const std::string msg_mmap_fail = "ArgoDSM failed to map in virtual address space.";
+	/** @brief error message string */
+	const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
+
+	/* file variables */
+	/** @brief a file descriptor for backing the virtual address space used by ArgoDSM */
+	int fd;
+	/** @brief the address at which the virtual address space used by ArgoDSM starts */
+	void* start_addr;
+}
+
+namespace argo {
+	namespace virtual_memory {
+		void init() {
+			fd = syscall(__NR_memfd_create,"argocache", 0);
+			if(ftruncate(fd, ARGO_SIZE)) {
+				std::cerr << msg_main_mmap_fail << std::endl;
+				/** @todo do something? */
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+			/** @todo check desired range is free */
+			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+			start_addr = ::mmap((void*)ARGO_START, ARGO_SIZE, PROT_NONE, flags, -1, 0);
+			if(start_addr == MAP_FAILED) {
+				std::cerr << msg_main_mmap_fail << std::endl;
+				/** @todo do something? */
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+		}
+
+		void* start_address() {
+			return start_addr;
+		}
+
+		std::size_t size() {
+			return ARGO_SIZE/2;
+		}
+
+		void* allocate_mappable(std::size_t alignment, std::size_t size) {
+			auto p = aligned_alloc(alignment, size);
+			if(p == nullptr) {
+				std::cerr << msg_alloc_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_alloc_fail);
+				return nullptr;
+			}
+			return p;
+		}
+
+		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+			auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
+			if(p == MAP_FAILED) {
+				std::cerr << msg_mmap_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+		}
+	} // namespace virtual_memory
+} // namespace argo

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -69,10 +69,11 @@ namespace argo {
 		}
 
 		void* allocate_mappable(std::size_t alignment, std::size_t size) {
-			auto p = aligned_alloc(alignment, size);
-			if(p == nullptr) {
+			void* p;
+			auto r = posix_memalign(&p, alignment, size);
+			if(r || p == nullptr) {
 				std::cerr << msg_alloc_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_alloc_fail);
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
 				return nullptr;
 			}
 			return p;

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -26,6 +26,8 @@ namespace {
 	const char* ARGO_END   = (char*) 0x600000000000l;
 	/** @todo hardcoded size */
 	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+	/** @todo hardcoded maximum size */
+	const ptrdiff_t ARGO_SIZE_LIMIT = 0x80000000000l;
 
 	/** @brief error message string */
 	const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
@@ -50,8 +52,9 @@ namespace argo {
 			struct statvfs b;
 			statvfs("/dev/shm", &b);
 			avail = b.f_bavail * b.f_bsize;
-			if(avail > static_cast<unsigned long>(ARGO_SIZE)/2u)
-				avail = ARGO_SIZE/2;
+			if(avail > static_cast<unsigned long>(ARGO_SIZE_LIMIT)) {
+				avail = ARGO_SIZE_LIMIT;
+			}
 			std::string filename = "/argocache" + std::to_string(getpid());
 			fd = shm_open(filename.c_str(), O_RDWR|O_CREAT, 0644);
 			if(shm_unlink(filename.c_str())) {

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -1,0 +1,104 @@
+/**
+ * @file
+ * @brief This file implements the virtual memory and virtual address handling
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdlib>
+#include <fcntl.h>
+#include <iostream>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <system_error>
+#include <unistd.h>
+#include "virtual_memory.hpp"
+
+namespace {
+	/* file constants */
+	/** @todo hardcoded start address */
+	const char* ARGO_START = (char*) 0x200000000000l;
+	/** @todo hardcoded end address */
+	const char* ARGO_END   = (char*) 0x600000000000l;
+	/** @todo hardcoded size */
+	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+
+	/** @brief error message string */
+	const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
+	/** @brief error message string */
+	const std::string msg_mmap_fail = "ArgoDSM failed to map in virtual address space.";
+	/** @brief error message string */
+	const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
+
+	/* file variables */
+	/** @brief a file descriptor for backing the virtual address space used by ArgoDSM */
+	int fd;
+	/** @brief the address at which the virtual address space used by ArgoDSM starts */
+	void* start_addr;
+	/** @brief the size of the ArgoDSM virtual address space */
+	std::size_t avail;
+}
+
+namespace argo {
+	namespace virtual_memory {
+		void init() {
+			/* find maximum filesize */
+			struct statvfs b;
+			statvfs("/dev/shm", &b);
+			avail = b.f_bavail * b.f_bsize;
+			if(avail > static_cast<unsigned long>(ARGO_SIZE)/2u)
+				avail = ARGO_SIZE/2;
+			std::string filename = "/argocache" + std::to_string(getpid());
+			fd = shm_open(filename.c_str(), O_RDWR|O_CREAT, 0644);
+			if(shm_unlink(filename.c_str())) {
+				std::cerr << msg_main_mmap_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+			if(ftruncate(fd, avail)) {
+				std::cerr << msg_main_mmap_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+			/** @todo check desired range is free */
+			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+			start_addr = ::mmap((void*)ARGO_START, avail, PROT_NONE, flags, -1, 0);
+			if(start_addr == MAP_FAILED) {
+				std::cerr << msg_main_mmap_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+		}
+
+		void* start_address() {
+			return start_addr;
+		}
+
+		std::size_t size() {
+			return avail;
+		}
+
+		void* allocate_mappable(std::size_t alignment, std::size_t size) {
+			auto p = aligned_alloc(alignment, size);
+			if(p == nullptr) {
+				std::cerr << msg_alloc_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_alloc_fail);
+				return nullptr;
+			}
+			return p;
+		}
+
+		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+			auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
+			if(p == MAP_FAILED) {
+				std::cerr << msg_mmap_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
+				exit(EXIT_FAILURE);
+			}
+		}
+	} // namespace virtual_memory
+} // namespace argo

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -83,10 +83,11 @@ namespace argo {
 		}
 
 		void* allocate_mappable(std::size_t alignment, std::size_t size) {
-			auto p = aligned_alloc(alignment, size);
-			if(p == nullptr) {
+			void* p;
+			auto r = posix_memalign(&p, alignment, size);
+			if(r || p == nullptr) {
 				std::cerr << msg_alloc_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_alloc_fail);
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
 				return nullptr;
 			}
 			return p;

--- a/src/virtual_memory/virtual_memory.hpp
+++ b/src/virtual_memory/virtual_memory.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file
+ * @brief This file provides facilities for handling virtual memory and virtual address space
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef argo_virtual_memory_virtual_memory_hpp
+#define argo_virtual_memory_virtual_memory_hpp argo_virtual_memory_virtual_memory_hpp
+
+#include <utility>
+
+namespace argo {
+	namespace virtual_memory {
+		/**
+		 * @brief initialize the ArgoDSM virtual address space
+		 * @todo virtual address space handling should be wrapped into an object
+		 */
+		void init();
+
+		/**
+		 * @brief get a pointer to the ArgoDSM virtual memory
+		 * @return the pointer to ArgoDSM virtual memory
+		 */
+		void* start_address();
+
+		/**
+		 * @brief get size of the ArgoDSM virtual memory
+		 * @return the size of the ArgoDSM virtual memory
+		 */
+		std::size_t size();
+
+		/**
+		 * @brief allocate memory that can be mapped into ArgoDSM virtual address space later
+		 * @param alignment the alignment of the allocation
+		 * @param size size of the allocation
+		 * @return a pointer to the new memory allocation
+		 * @details this will allocate memory that is guaranteed to work with map_memory().
+		 *          Any memory allocated through other means may not be possible to map
+		 *          into the visible ArgoDSM virtual memory space later.
+		 */
+		void* allocate_mappable(std::size_t alignment, std::size_t size);
+
+		/**
+		 * @brief map memory into ArgoDSM virtual address space
+		 * @param addr the address to map to
+		 * @param size the size of the mapping
+		 * @param offset the offset into the backing memory
+		 * @param prot protection flags for the mapping
+		 */
+		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot);
+	} // namespace virtual_memory
+} // namespace argo
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ endfunction(enable_openmp)
 # Unit Tests
 ################################
 # Add test cpp file
+forall_backends(trivialTests trivial.cpp)
 forall_backends(allocatorsTests allocators.cpp)
 forall_backends(prefetchTests prefetch.cpp)
 forall_backends(ompTests omp.cpp)

--- a/tests/trivial.cpp
+++ b/tests/trivial.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * @brief This file provides unit tests for trivial sanity checks when using ArgoDSM
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include "argo.hpp"
+#include "backend/backend.hpp"
+#include "gtest/gtest.h"
+
+/** @brief ArgoDSM memory size */
+std::size_t size = 1<<28;
+namespace mem = argo::mempools;
+
+/**
+ * @brief Unittest that checks nothing.
+ * @note this test verifies that linking a trivial ArgoDSM program works
+ */
+TEST(trivialTest, alwaysPassl) {
+	ASSERT_TRUE(true);
+}
+
+/**
+ * @brief The main function that runs the tests
+ * @param argc Number of command line arguments
+ * @param argv Command line arguments
+ * @return 0 if success
+ */
+int main(int argc, char **argv) {
+	argo::init(size);
+	::testing::InitGoogleTest(&argc, argv);
+	auto res = RUN_ALL_TESTS();
+	argo::finalize();
+	return res;
+}


### PR DESCRIPTION
This branch adds virtual memory management modules to avoid cluttering /dev/shm with temporary files.
Additionally, it fixes some minor bugs:
- doxygen-style comments where normal comments are appropriate
- a rounding problem that causes ArgoDSM to round up memory significantly more than needed.
- functions that are used with Pthreads but did not conform to the signature of pthread_create
