### PR TITLE
fix access to private remote pages

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -770,7 +770,7 @@ void * loadcacheline(void * x){
 		unsigned long offset = getOffset(lineAddr);
 		if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
 			unsigned long ownid = tempsharer&invid; // remove own bit
-			static const unsigned long invalid_owner = static_cast<unsigned long>(-1);
+			constexpr unsigned long invalid_owner = static_cast<unsigned long>(-1);
 			unsigned long owner = invalid_owner; // initialize to failsafe value
 			for(n=0; n<numtasks; n++) {
 				if(1ul<<n==ownid) {
@@ -926,7 +926,7 @@ void * prefetchcacheline(void * x){
 		unsigned long offset = getOffset(lineAddr);
 		if(isPowerOf2((tempsharer)&invid) && prevsharer == 0){ //Other private. but may not have loaded page yet.
 			unsigned long ownid = tempsharer&invid; // remove own bit
-			static const unsigned long invalid_owner = static_cast<unsigned long>(-1);
+			constexpr unsigned long invalid_owner = static_cast<unsigned long>(-1);
 			unsigned long owner = invalid_owner; // initialize to failsafe value
 			for(n=0; n<numtasks; n++) {
 				if(1ul<<n == ownid) {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -143,6 +143,11 @@ unsigned long GLOBAL_NULL;
 /** @brief  Statistics */
 argo_statistics stats;
 
+namespace {
+	/** @brief constant for invalid ArgoDSM node */
+	constexpr unsigned long invalid_node = static_cast<unsigned long>(-1);
+}
+
 unsigned long isPowerOf2(unsigned long x){
   unsigned long retval =  ((x & (x - 1)) == 0); //Checks if x is power of 2 (or zero)
   return retval;
@@ -770,15 +775,14 @@ void * loadcacheline(void * x){
 		unsigned long offset = getOffset(lineAddr);
 		if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
 			unsigned long ownid = tempsharer&invid; // remove own bit
-			constexpr unsigned long invalid_owner = static_cast<unsigned long>(-1);
-			unsigned long owner = invalid_owner; // initialize to failsafe value
+			unsigned long owner = invalid_node; // initialize to failsafe value
 			for(n=0; n<numtasks; n++) {
 				if(1ul<<n==ownid) {
 					owner = n; //just get rank...
 					break;
 				}
 			}
-			if(owner != invalid_owner) {
+			if(owner != invalid_node) {
 				MPI_Win_lock(MPI_LOCK_SHARED, owner, 0, sharerWindow);
 				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
 				MPI_Win_unlock(owner, sharerWindow);
@@ -926,15 +930,14 @@ void * prefetchcacheline(void * x){
 		unsigned long offset = getOffset(lineAddr);
 		if(isPowerOf2((tempsharer)&invid) && prevsharer == 0){ //Other private. but may not have loaded page yet.
 			unsigned long ownid = tempsharer&invid; // remove own bit
-			constexpr unsigned long invalid_owner = static_cast<unsigned long>(-1);
-			unsigned long owner = invalid_owner; // initialize to failsafe value
+			unsigned long owner = invalid_node; // initialize to failsafe value
 			for(n=0; n<numtasks; n++) {
 				if(1ul<<n == ownid) {
 					owner = n; //just get rank...
 					break;
 				}
 			}
-			if(owner != invalid_owner) {
+			if(owner != invalid_node) {
 				MPI_Win_lock(MPI_LOCK_SHARED, owner, 0, sharerWindow);
 				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
 				MPI_Win_unlock(owner, sharerWindow);


### PR DESCRIPTION
When accessing a private page on a remote homenode, it could happen that
an undefined node would be accessed. As the node is in private state, no
access is actually needed.