### PR TITLE
Cache backend fixes

### DIFF
--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -41,13 +41,14 @@ namespace argo {
 	namespace backend {
 		/**
 		 * @brief initialize backend
-		 * @param size the size of the global memory to initialize
+		 * @param argo_size the size of the global memory to initialize
+		 * @param cache_size the size of the cache used by ArgoDSM in number of bytes, may be unused in some backends
 		 * @warning the signature of this function may change
 		 * @todo maybe this should be tied better to the concrete memory
 		 *       allocated rather than a generic "initialize this size"
 		 *       functionality.
 		 */
-		void init(std::size_t size);
+		void init(std::size_t argo_size, std::size_t cache_size);
 
 		/**
 		 * @brief get ArgoDSM node ID

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -130,8 +130,8 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 
 namespace argo {
 	namespace backend {
-		void init(std::size_t size) {
-			argo_initialize(size);
+		void init(std::size_t argo_size, std::size_t cache_size){
+			argo_initialize(argo_size,cache_size);
 		}
 
 		node_id_t node_id() {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1044,15 +1044,15 @@ void set_sighandler(){
 	sigaction(SIGSEGV, &sa, &old_sigaction);
 }
 
-void argo_initialize(unsigned long long size){
+void argo_initialize(unsigned long long argo_size, size_t cache_size){
 	int i;
 	unsigned long j;
 	initmpi();
 	unsigned long alignment = pagesize*CACHELINE*numtasks;
-	if((size%alignment)>0){
-		size += alignment - 1;
-		size /= alignment;
-		size *= alignment;
+	if((argo_size%alignment)>0){
+		argo_size += alignment - 1;
+		argo_size /= alignment;
+		argo_size *= alignment;
 	}
 
 	startAddr = vm::start_address();
@@ -1065,7 +1065,7 @@ void argo_initialize(unsigned long long size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = size+pagesize*CACHELINE;
+	cachesize = cache_size+pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;
@@ -1107,19 +1107,19 @@ void argo_initialize(unsigned long long size){
 	MPI_Comm_create(MPI_COMM_WORLD,workgroup,&workcomm);
 	MPI_Group_rank(workgroup,&workrank);
 
-	if(size < pagesize*numtasks){
-		size = pagesize*numtasks;
+	if(argo_size < pagesize*numtasks){
+		argo_size = pagesize*numtasks;
 	}
 
 	alignment = CACHELINE*pagesize;
-	if(size % (alignment*numtasks) != 0){
-		size = alignment*numtasks * (1+(size)/(alignment*numtasks));
+	if(argo_size % (alignment*numtasks) != 0){
+		argo_size = alignment*numtasks * (1+(argo_size)/(alignment*numtasks));
 	}
 
 	//Allocate local memory for each node,
-	size_of_all = size; //total distr. global memory
+	size_of_all = argo_size; //total distr. global memory
 	GLOBAL_NULL=size_of_all+1;
-	size_of_chunk = size/(numtasks); //part on each node
+	size_of_chunk = argo_size/(numtasks); //part on each node
 	set_sighandler();
 
 	unsigned long cacheControlSize = sizeof(control_data)*cachesize;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1199,14 +1199,7 @@ void argo_initialize(unsigned long long size){
 								 MPI_INFO_NULL, MPI_COMM_WORLD, &sharerWindow);
 	MPI_Win_create(lockbuffer, pagesize, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &lockWindow);
 
-	memset(pagecopy, 0, cachesize*pagesize);
-	memset(touchedcache, 0, cachesize);
-	memset(globalData, 0, size_of_chunk*sizeof(argo_byte));
-	memset(cacheData, 0, cachesize*pagesize);
-	memset(lockbuffer, 0, pagesize);
-	memset(globalSharers, 0, gwritersize);
-	memset(cacheControl, 0, cachesize*sizeof(control_data));
-
+	//Sets cache control structures to initial state.
 	for(j=0; j<cachesize; j++){
 		cacheControl[j].tag = GLOBAL_NULL;
 		cacheControl[j].state = INVALID;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -138,9 +138,10 @@ void set_sighandler();
 /*ArgoDSM init and finish*/
 /**
  * @brief Initializes ArgoDSM runtime
- * @param size Size of wanted global address space
+ * @param argo_size Size of wanted global address space
+ * @param cache_size Size in bytes of your cache, will be rounded to nearest multiple of cacheline size (in bytes)
  */
-void argo_initialize(unsigned long long size);
+void argo_initialize(unsigned long long argo_size, size_t cache_size);
 
 /**
  * @brief Shutting down ArgoDSM runtime

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -57,7 +57,7 @@ std::size_t memory_size;
 namespace argo {
 	namespace backend {
 
-		void init(std::size_t size) {
+		void init(std::size_t argo_size, std::size_t cache_size){
 			memory = static_cast<char*>(vm::allocate_mappable(4096, size));
 			memory_size = size;
 			using namespace data_distribution;

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -50,7 +50,7 @@ namespace argo {
 				 */
 				global_memory_pool(std::size_t size) {
 					size+=reserved;
-					backend::init(size);
+					backend::init(size, 1<<30); // 1GB of memory for cache as default (= 1<<30 bytes)
 					auto nodes = backend::number_of_nodes();
 					memory = backend::global_base();
 					max_size = backend::global_size();


### PR DESCRIPTION
Removes the unnecessary memsets in the MPI-backend and makes it possible to start a backend with a specified amount of cache.  (Tested on 2 nodes on tintin)