### PR TITLE
Coherence fix

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1266,6 +1266,7 @@ void self_invalidation(){
 				flushWriteBuffer();
 				flushed = 1;
 			}
+			MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
 			if(
 				 // node is single writer
 				 (globalSharers[classidx+1]==id)
@@ -1273,10 +1274,12 @@ void self_invalidation(){
 				 // No writer and assert that the node is a sharer
 				 ((globalSharers[classidx+1]==0) && ((globalSharers[classidx]&id)==id))
 				 ){
+				MPI_Win_unlock(workrank, sharerWindow);
 				touchedcache[i] =1;
 				/*nothing - we keep the pages, SD is done in flushWB*/
 			}
 			else{ //multiple writer or SO
+				MPI_Win_unlock(workrank, sharerWindow);
 				cacheControl[i].dirty=CLEAN;
 				cacheControl[i].state = INVALID;
 				touchedcache[i] =0;


### PR DESCRIPTION
The current use of MPI_LOCK_SHARED on updates to the cache metadata allows for a race condition when multiple nodes are attempting to declare themselves writers of an entry at the same time. This can lead to lost updates, where some node does not know about other nodes also writing to a page, ultimately leading to loss of coherence.

This patch contains two commits:
In the first, MPI_LOCK_EXCLUSIVE is applied to read-modify-write operations, which should avoid the lost update issue.
The second commit adds MPI_LOCK_EXCLUSIVE to another read-only instance of the same window.