### PR TITLE
Limit cache size

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -218,7 +218,7 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES                = "envvar{1}=@anchor \1 @par \1 \n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -51,8 +51,10 @@ The first step is adding the ArgoDSM initialization and finalization function.
 Specifically, `argo::init` needs to be run in `main` before any other functions
 are called, and `argo::finalize` should be the last ArgoDSM function called
 before exiting `main`. In the current version of ArgoDSM, `argo::init` has one
-required argument which indicates the total amount of memory ArgoDSM should
-allocate. This will be deprecated in future versions.
+optional argument which indicates the total amount of memory ArgoDSM should
+allocate. When the value is given to `argo::init`, it will be used. If it is
+omitted, the value (in bytes) in the environment variable `ARGO_MEMORY_SIZE`
+will be used to set the total amount of memory available to ArgoDSM.
 
 In addition to adding the ArgoDSM initialization and finalization functions,
 there are three main tasks that need to be done to convert a pthreads

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,11 +50,15 @@ is protected by locks.
 The first step is adding the ArgoDSM initialization and finalization function.
 Specifically, `argo::init` needs to be run in `main` before any other functions
 are called, and `argo::finalize` should be the last ArgoDSM function called
-before exiting `main`. In the current version of ArgoDSM, `argo::init` has one
-optional argument which indicates the total amount of memory ArgoDSM should
-allocate. When the value is given to `argo::init`, it will be used. If it is
-omitted, the value (in bytes) in the environment variable `ARGO_MEMORY_SIZE`
-will be used to set the total amount of memory available to ArgoDSM.
+before exiting `main`. In the current version of ArgoDSM, `argo::init` has two
+optional arguments which indicate the total amount of memory ArgoDSM should
+allocate and the desired local cache size, respectively. When the values are
+given to `argo::init`, they will be used. If one or both are omitted, then the
+value (in bytes) in the environment variable `ARGO_MEMORY_SIZE` (for the first
+total memory size) and `ARGO_CACHE_SIZE` (for the local cache size) will be used
+instead. If the environment variables are empty, some default numbers will be
+used. At the time of this writing they are 8GB and 1GB for total memory and
+local cache size, respectively.
 
 In addition to adding the ArgoDSM initialization and finalization functions,
 there are three main tasks that need to be done to convert a pthreads

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,11 @@ foreach(src ${allocator_sources})
 	list(APPEND argo_sources allocators/${src})
 endforeach(src)
 
+set(env_sources env.cpp)
+foreach(src ${env_sources})
+	list(APPEND argo_sources env/${src})
+endforeach(src)
+
 set(synchronization_sources
 	synchronization.cpp
 	cohort_lock.cpp

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -8,7 +8,7 @@
 
 #include "allocators/collective_allocator.hpp"
 #include "allocators/dynamic_allocator.hpp"
-
+#include "env/env.hpp"
 #include "virtual_memory/virtual_memory.hpp"
 
 namespace vm = argo::virtual_memory;
@@ -23,8 +23,12 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&
 
 namespace argo {
 	void init(std::size_t size) {
+		env::init();
 		vm::init();
 		std::size_t requested_size = size;
+		if(requested_size == 0) {
+			requested_size = env::memory_size();
+		}
 		using mp = mem::global_memory_pool<>;
 		requested_size += mp::reserved;
 		backend::init(requested_size);

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -22,16 +22,17 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY> collectiv
 mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&alloc::default_global_allocator);
 
 namespace argo {
-	void init(std::size_t size) {
+	void init(std::size_t argo_size) {
 		env::init();
 		vm::init();
-		std::size_t requested_size = size;
-		if(requested_size == 0) {
-			requested_size = env::memory_size();
+
+		std::size_t requested_argo_size = argo_size;
+		if(requested_argo_size == 0) {
+			requested_argo_size = env::memory_size();
 		}
 		using mp = mem::global_memory_pool<>;
-		requested_size += mp::reserved;
-		backend::init(requested_size);
+		requested_argo_size += mp::reserved;
+		backend::init(requested_argo_size);
 		default_global_mempool = new mp();
 		argo_reset();
 	}
@@ -51,8 +52,8 @@ namespace argo {
 } // namespace argo
 
 extern "C" {
-	void argo_init(size_t size) {
-		argo::init(size);
+	void argo_init(size_t argo_size) {
+		argo::init(argo_size);
 	}
 
 	void argo_finalize() {

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -22,9 +22,13 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY> collectiv
 mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&alloc::default_global_allocator);
 
 namespace argo {
-	void init(size_t size) {
+	void init(std::size_t size) {
 		vm::init();
-		default_global_mempool = new mem::global_memory_pool<>(size);
+		std::size_t requested_size = size;
+		using mp = mem::global_memory_pool<>;
+		requested_size += mp::reserved;
+		backend::init(requested_size);
+		default_global_mempool = new mp();
 		argo_reset();
 	}
 

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -22,7 +22,7 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY> collectiv
 mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&alloc::default_global_allocator);
 
 namespace argo {
-	void init(std::size_t argo_size) {
+	void init(std::size_t argo_size, std::size_t cache_size) {
 		env::init();
 		vm::init();
 
@@ -32,7 +32,13 @@ namespace argo {
 		}
 		using mp = mem::global_memory_pool<>;
 		requested_argo_size += mp::reserved;
-		backend::init(requested_argo_size);
+
+		std::size_t requested_cache_size = cache_size;
+		if(requested_cache_size == 0) {
+			requested_cache_size = env::cache_size();
+		}
+
+		backend::init(requested_argo_size, requested_cache_size);
 		default_global_mempool = new mp();
 		argo_reset();
 	}
@@ -52,8 +58,8 @@ namespace argo {
 } // namespace argo
 
 extern "C" {
-	void argo_init(size_t argo_size) {
-		argo::init(argo_size);
+	void argo_init(size_t argo_size, size_t cache_size) {
+		argo::init(argo_size, cache_size);
 	}
 
 	void argo_finalize() {

--- a/src/argo.h
+++ b/src/argo.h
@@ -15,8 +15,9 @@
 /**
  * @brief initialize ArgoDSM system
  * @param argo_size the desired size of the global memory in bytes
+ * @param cache_size the desired size of the local cache in bytes
  */
-void argo_init(size_t argo_size = 0);
+void argo_init(size_t argo_size = 0, size_t cache_size = 0);
 
 /**
  * @brief shut down ArgoDSM system

--- a/src/argo.h
+++ b/src/argo.h
@@ -14,9 +14,9 @@
 
 /**
  * @brief initialize ArgoDSM system
- * @param size the desired size of the global memory in bytes
+ * @param argo_size the desired size of the global memory in bytes
  */
-void argo_init(size_t size = 0);
+void argo_init(size_t argo_size = 0);
 
 /**
  * @brief shut down ArgoDSM system

--- a/src/argo.h
+++ b/src/argo.h
@@ -16,7 +16,7 @@
  * @brief initialize ArgoDSM system
  * @param size the desired size of the global memory in bytes
  */
-void argo_init(size_t size);
+void argo_init(size_t size = 0);
 
 /**
  * @brief shut down ArgoDSM system

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -42,11 +42,11 @@ namespace argo {
 
 	/**
 	 * @brief initialize ArgoDSM system
-	 * @param size The desired size of the global memory in bytes, or 0.
-	 *             If the value is omitted (or specified as 0), then the value in
-	 *             environment variable @ref ARGO_MEMORY_SIZE is used instead.
+	 * @param argo_size The desired size of the global memory in bytes, or 0. If the
+	 *                  value is omitted (or specified as 0), then the value in
+	 *                  environment variable @ref ARGO_MEMORY_SIZE is used instead.
 	 */
-	void init(std::size_t size = 0);
+	void init(std::size_t argo_size = 0);
 
 	/**
 	 * @brief shut down ArgoDSM system

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -45,8 +45,11 @@ namespace argo {
 	 * @param argo_size The desired size of the global memory in bytes, or 0. If the
 	 *                  value is omitted (or specified as 0), then the value in
 	 *                  environment variable @ref ARGO_MEMORY_SIZE is used instead.
+	 * @param cache_size The desired size of the local cache in bytes, or 0. If the
+	 *                   value is omitted (or specified as 0), then the value in
+	 *                   environment variable @ref ARGO_CACHE_SIZE is used instead.
 	 */
-	void init(std::size_t argo_size = 0);
+	void init(std::size_t argo_size = 0, std::size_t cache_size = 0);
 
 	/**
 	 * @brief shut down ArgoDSM system

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -7,6 +7,8 @@
 #ifndef argo_argo_hpp
 #define argo_argo_hpp argo_argo_hpp
 
+#include <cstddef>
+
 #include "allocators/allocators.hpp"
 #include "backend/backend.hpp"
 #include "types/types.hpp"
@@ -40,9 +42,11 @@ namespace argo {
 
 	/**
 	 * @brief initialize ArgoDSM system
-	 * @param size the desired size of the global memory in bytes
+	 * @param size The desired size of the global memory in bytes, or 0.
+	 *             If the value is omitted (or specified as 0), then the value in
+	 *             environment variable @ref ARGO_MEMORY_SIZE is used instead.
 	 */
-	void init(size_t size);
+	void init(std::size_t size = 0);
 
 	/**
 	 * @brief shut down ArgoDSM system

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -41,13 +41,13 @@ namespace argo {
 	namespace backend {
 		/**
 		 * @brief initialize backend
-		 * @param size the size of the global memory to initialize
+		 * @param argo_size the size of the global memory to initialize
 		 * @warning the signature of this function may change
 		 * @todo maybe this should be tied better to the concrete memory
 		 *       allocated rather than a generic "initialize this size"
 		 *       functionality.
 		 */
-		void init(std::size_t size);
+		void init(std::size_t argo_size);
 
 		/**
 		 * @brief get ArgoDSM node ID

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -41,13 +41,16 @@ namespace argo {
 	namespace backend {
 		/**
 		 * @brief initialize backend
-		 * @param argo_size the size of the global memory to initialize
+		 * @param argo_size the size (in bytes) of the global memory to initialize
+		 * @param cache_size the size (in bytes) of the cache used by ArgoDSM
 		 * @warning the signature of this function may change
 		 * @todo maybe this should be tied better to the concrete memory
 		 *       allocated rather than a generic "initialize this size"
 		 *       functionality.
+		 * @todo the cache_size parameter is currently needed because cache layout
+		 *       is defined by the backend, which is wrong design-wise.
 		 */
-		void init(std::size_t argo_size);
+		void init(std::size_t argo_size, std::size_t cache_size);
 
 		/**
 		 * @brief get ArgoDSM node ID

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -130,8 +130,8 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 
 namespace argo {
 	namespace backend {
-		void init(std::size_t argo_size) {
-			argo_initialize(argo_size);
+		void init(std::size_t argo_size, std::size_t cache_size){
+			argo_initialize(argo_size, cache_size);
 		}
 
 		node_id_t node_id() {

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -130,8 +130,8 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 
 namespace argo {
 	namespace backend {
-		void init(std::size_t size) {
-			argo_initialize(size);
+		void init(std::size_t argo_size) {
+			argo_initialize(argo_size);
 		}
 
 		node_id_t node_id() {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1010,15 +1010,15 @@ void * argo_gmalloc(unsigned long size){
 	return ptrtmp;
 }
 
-void argo_initialize(unsigned long long size){
+void argo_initialize(unsigned long long argo_size){
 	int i;
 	unsigned long j;
 	initmpi();
 	unsigned long alignment = pagesize*CACHELINE*numtasks;
-	if((size%alignment)>0){
-		size += alignment - 1;
-		size /= alignment;
-		size *= alignment;
+	if((argo_size%alignment)>0){
+		argo_size += alignment - 1;
+		argo_size /= alignment;
+		argo_size *= alignment;
 	}
 
 	startAddr = vm::start_address();
@@ -1031,7 +1031,7 @@ void argo_initialize(unsigned long long size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = size+pagesize*CACHELINE;
+	cachesize = argo_size+pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;
@@ -1073,19 +1073,19 @@ void argo_initialize(unsigned long long size){
 	MPI_Comm_create(MPI_COMM_WORLD,workgroup,&workcomm);
 	MPI_Group_rank(workgroup,&workrank);
 
-	if(size < pagesize*numtasks){
-		size = pagesize*numtasks;
+	if(argo_size < pagesize*numtasks){
+		argo_size = pagesize*numtasks;
 	}
 
 	alignment = CACHELINE*pagesize;
-	if(size % (alignment*numtasks) != 0){
-		size = alignment*numtasks * (1+(size)/(alignment*numtasks));
+	if(argo_size % (alignment*numtasks) != 0){
+		argo_size = alignment*numtasks * (1+(argo_size)/(alignment*numtasks));
 	}
 
 	//Allocate local memory for each node,
-	size_of_all = size; //total distr. global memory
+	size_of_all = argo_size; //total distr. global memory
 	GLOBAL_NULL=size_of_all+1;
-	size_of_chunk = size/(numtasks); //part on each node
+	size_of_chunk = argo_size/(numtasks); //part on each node
 	sig::signal_handler<SIGSEGV>::install_argo_handler(&handler);
 
 	unsigned long cacheControlSize = sizeof(control_data)*cachesize;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1031,7 +1031,13 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = cache_size+pagesize*CACHELINE;
+	cachesize = 0;
+	if(cache_size > argo_size) {
+		cachesize += argo_size;
+	} else {
+		cachesize += cache_size;
+	}
+	cachesize += pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1010,7 +1010,7 @@ void * argo_gmalloc(unsigned long size){
 	return ptrtmp;
 }
 
-void argo_initialize(unsigned long long argo_size){
+void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	int i;
 	unsigned long j;
 	initmpi();
@@ -1031,7 +1031,7 @@ void argo_initialize(unsigned long long argo_size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = argo_size+pagesize*CACHELINE;
+	cachesize = cache_size+pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -56,10 +56,7 @@ unsigned long  *writebuffer;
 unsigned long  writebufferstart;
 /** @brief Least recent entry in the writebuffer*/
 unsigned long  writebufferend;
-/** @brief Writethread wait on this to start a write from the writebuffer */
-//sem_t writerwaitsem;
-/** @brief Writethread signals this when writing from writebuffer is done */
-//sem_t writerstartsem;
+/** @brief writeback from writebuffer helper function */
 void write_unloop();
 /** @brief Lock for the writebuffer*/
 pthread_mutex_t wbmutex = PTHREAD_MUTEX_INITIALIZER;
@@ -96,25 +93,19 @@ char * barwindowsused;
 sem_t ibsem;
 
 /*Loading and Prefetching*/
-/** @brief Tracking address of pages that should be loaded by loadthread1 */
-//unsigned long *loadline;
-/** @brief Tracking cacheindex of pages that should be loaded by loadthread1 */
-//unsigned long *loadtag;
-void loadcacheline_unloop(unsigned long, unsigned long);
+/**
+ * @brief load into cache helper function
+ * @param tag I don't know
+ * @param line I have no clue
+ */
+void loadcacheline_unloop(unsigned long tag, unsigned long line);
 
-/** @brief Tracking address of pages that should be loaded by loadthread2 */
-//unsigned long *prefetchline;
-/** @brief Tracking cacheindex of pages that should be loaded by loadthread2 */
-//unsigned long *prefetchtag;
-/** @brief loadthread1 waits on this to start loading remote pages */
-//sem_t loadstartsem;
-/** @brief signalhandler waits on this to complete a transfer */
-//sem_t loadwaitsem;
-/** @brief loadthread2 waits on this to start loading remote pages */
-//sem_t prefetchstartsem;
-/** @brief signalhandler waits on this to complete a transfer */
-//sem_t prefetchwaitsem;
-void prefetchcacheline_unloop(long unsigned int, long unsigned int);
+/**
+ * @brief another load into cache helper function, which duplicates a lot of code
+ * @param tag I don't know
+ * @param line I have no clue
+ */
+void prefetchcacheline_unloop(unsigned long tag, unsigned long line);
 
 /*Global lock*/
 /** @brief  Local flags we spin on for the global lock*/
@@ -213,8 +204,6 @@ void addToWriteBuffer(unsigned long cacheIndex){
 	if(wbendplusone == writebufferstart ){ // Buffer is full wait for slot to be empty
 		double t1 = MPI_Wtime();
 		write_unloop();
-		//sem_post(&writerstartsem);
-		//sem_wait(&writerwaitsem);
 		double t4 = MPI_Wtime();
 		stats.writebacks+=CACHELINE;
 		stats.writebacktime+=(t4-t1);
@@ -331,8 +320,6 @@ void handler(int sig, siginfo_t *si, void *unused){
 
 	unsigned long * localAlignedAddr = (unsigned long *)((char*)startAddr + lineAddr);
 	unsigned long startIndex = getCacheIndex(lineAddr);
-	//unsigned long cacheIndex = getCacheIndex(alignedDistrAddr);
-	//cacheIndex = startIndex;
 	alignedDistrAddr = lineAddr;
 
 	unsigned long homenode = getHomenode(lineAddr);
@@ -424,81 +411,15 @@ void handler(int sig, siginfo_t *si, void *unused){
 	tag = cacheControl[startIndex].tag;
 
 	if(state == INVALID || (tag != lineAddr && tag != GLOBAL_NULL)){
-		/*if(prefetchline[0] != GLOBAL_NULL){
-			if(prefetchline[0] <= startIndex && startIndex < prefetchline[0]+CACHELINE){
-				loadcacheline_unloop((lineAddr+pagesize*CACHELINE), ((startIndex+CACHELINE)%cachesize));
-			}
-			else{
-				loadcacheline_unloop(alignedDistrAddr, (cacheIndex%cachesize));
-			}
-
-			sem_wait(&prefetchwaitsem);
-			prefetchline[0] = GLOBAL_NULL;
-			//prefetchtag[0]= GLOBAL_NULL;
-			pthread_mutex_unlock(&cachemutex);
-			double t2 = MPI_Wtime();
-			stats.loadtime+=t2-t1;
-			return;
-		}*/
-		/*else if(prefetchline[0] == GLOBAL_NULL && loadline[0] != GLOBAL_NULL){
-			// no thread is prefetching yet, but some thread is loading. 
-			// calls the prefetcher and waits for the load to finish
-			if(loadline[0] <= startIndex && startIndex < loadline[0]+CACHELINE){
-				prefetchline[0]=(startIndex+CACHELINE)%cachesize;
-				prefetchtag[0]=lineAddr+pagesize*CACHELINE;
-			}
-			else{
-				prefetchline[0]=cacheIndex%cachesize;
-				prefetchtag[0]=alignedDistrAddr;
-			}
-			sem_post(&prefetchstartsem);
-			//sem_wait(&loadwaitsem);
-			//loadline[0] = GLOBAL_NULL;
-			//loadtag[0]=GLOBAL_NULL;
-			pthread_mutex_unlock(&cachemutex);
-			double t2 = MPI_Wtime();
-			stats.loadtime+=t2-t1;
-			return;
-		}*/
 		loadcacheline_unloop(alignedDistrAddr, (startIndex%cachesize));
 #ifdef DUAL_LOAD
 		prefetchcacheline_unloop((alignedDistrAddr+CACHELINE*pagesize), ((startIndex+CACHELINE)%cachesize));
-		//sem_wait(&loadwaitsem);
-		//loadline[0]=GLOBAL_NULL;
-		//loadtag[0]=GLOBAL_NULL;
-#else
-		//sem_wait(&loadwaitsem);
-		//loadline[0]=GLOBAL_NULL;
-		//loadtag[0]=GLOBAL_NULL;
-		//prefetchline[0]=GLOBAL_NULL;
-		//prefetchtag[0]=GLOBAL_NULL;
-
 #endif
 		pthread_mutex_unlock(&cachemutex);
 		double t2 = MPI_Wtime();
 		stats.loadtime+=t2-t1;
 		return;
 	}
-
-	/*if(prefetchline[0] != GLOBAL_NULL){
-		sem_wait(&prefetchwaitsem);
-		prefetchline[0] = GLOBAL_NULL;
-		//prefetchtag[0]=GLOBAL_NULL;
-		pthread_mutex_unlock(&cachemutex);
-		double t2 = MPI_Wtime();
-		stats.loadtime+=t2-t1;
-		return;
-
-	}*/
-	/*else if(loadline[0] != GLOBAL_NULL){
-		//sem_wait(&loadwaitsem);
-		//loadline[0]=GLOBAL_NULL;
-		//loadtag[0] =GLOBAL_NULL;
-		pthread_mutex_unlock(&cachemutex);
-		double t2 = MPI_Wtime();
-		stats.loadtime+=t2-t1;
-		return;
-	}*/
 
 	unsigned long line = startIndex / CACHELINE;
 	line *= CACHELINE;
@@ -617,43 +538,6 @@ void write_unloop() {
 	writebufferstart = (writebufferstart+1)%writebuffersize;
 	sem_post(&ibsem);
 }
-/*
-void *writeloop(void * x){
-	UNUSED_PARAM(x);
-	unsigned long i;
-	unsigned long oldstart;
-	unsigned long idx,tag;
-
-	while(1){
-
-		sem_wait(&writerstartsem);
-		sem_wait(&ibsem);
-
-		oldstart = writebufferstart;
-		i = oldstart;
-		idx = writebuffer[i];
-		tag = cacheControl[idx].tag;
-		writebuffer[i] = GLOBAL_NULL;
-		if(tag != GLOBAL_NULL && idx != GLOBAL_NULL && cacheControl[idx].dirty == DIRTY){
-			mprotect((char*)startAddr+tag,CACHELINE*pagesize,PROT_READ);
-			for(i = 0; i <CACHELINE; i++){
-				storepageDIFF(idx+i,tag+pagesize*i);
-				cacheControl[idx+i].dirty = CLEAN;
-			}
-		}
-		for(i = 0; i < (unsigned long)numtasks; i++){
-			if(barwindowsused[i] == 1){
-				MPI_Win_unlock(i, globalDataWindow[i]);
-				barwindowsused[i] = 0;
-			}
-		}
-		writebufferstart = (writebufferstart+1)%writebuffersize;
-		sem_post(&ibsem);
-		sem_post(&writerwaitsem);
-	}
-	return nullptr;
-}
-*/
 
 void loadcacheline_unloop(unsigned long loadtag, unsigned long loadline) {
 	int i;
@@ -799,161 +683,6 @@ void loadcacheline_unloop(unsigned long loadtag, unsigned long loadline) {
 	cacheControl[startidx].dirty=CLEAN;
 	sem_post(&ibsem);
 }
-/*
-void * loadcacheline(void * x){
-	UNUSED_PARAM(x);
-	int i;
-	unsigned long homenode;
-	unsigned long id = 1 << getID();
-	unsigned long invid = ~id;
-	while(1){
-		sem_wait(&loadstartsem);
-		if(loadtag[0]>=size_of_all){//Trying to access/prefetch out of memory
-			sem_post(&loadwaitsem);
-			continue;
-		}
-		homenode = getHomenode(loadtag[0]);
-		unsigned long cacheIndex = loadline[0];
-		if(cacheIndex >= cachesize){
-			printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
-			sem_post(&loadwaitsem);
-			continue;
-		}
-		sem_wait(&ibsem);
-
-
-		unsigned long pageAddr = loadtag[0];
-		unsigned long blocksize = pagesize*CACHELINE;
-		unsigned long lineAddr = pageAddr/blocksize;
-		lineAddr *= blocksize;
-
-		unsigned long startidx = cacheIndex/CACHELINE;
-		startidx*=CACHELINE;
-		unsigned long end = startidx+CACHELINE;
-
-		if(end>=cachesize){
-			end = cachesize;
-		}
-
-		argo_byte tmpstate = cacheControl[startidx].state;
-		unsigned long tmptag = cacheControl[startidx].tag;
-
-		if(tmptag == lineAddr && tmpstate != INVALID){
-			sem_post(&ibsem);
-			sem_post(&loadwaitsem);
-			continue;
-		}
-
-
-		void * lineptr = (char*)startAddr + lineAddr;
-
-		if(cacheControl[startidx].tag  != lineAddr){
-			if(cacheControl[startidx].tag  != lineAddr){
-				if(pthread_mutex_trylock(&wbmutex) != 0){
-					sem_post(&ibsem);
-					pthread_mutex_lock(&wbmutex);
-					sem_wait(&ibsem);
-				}
-
-				void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
-				if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
-					argo_byte dirty = cacheControl[startidx].dirty;
-					if(dirty == DIRTY){
-						mprotect(tmpptr2,blocksize,PROT_READ);
-						int j;
-						for(j=0; j < CACHELINE; j++){
-							storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
-						}
-					}
-
-					for(i = 0; i < numtasks; i++){
-						if(barwindowsused[i] == 1){
-							MPI_Win_unlock(i, globalDataWindow[i]);
-							barwindowsused[i] = 0;
-						}
-					}
-
-					cacheControl[startidx].state = INVALID;
-					cacheControl[startidx].tag = lineAddr;
-
-					cacheControl[startidx].dirty=CLEAN;
-					vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
-					mprotect(tmpptr2,blocksize,PROT_NONE);
-				}
-				pthread_mutex_unlock(&wbmutex);
-			}
-		}
-
-
-
-		stats.loads++;
-		unsigned long classidx = get_classification_index(lineAddr);
-		unsigned long tempsharer = 0;
-		unsigned long tempwriter = 0;
-
-		MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-		unsigned long prevsharer = (globalSharers[classidx])&id;
-		MPI_Win_unlock(workrank, sharerWindow);
-		int n;
-		homenode = getHomenode(lineAddr);
-
-		if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
-			MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-			MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
-				homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
-			MPI_Win_unlock(homenode, sharerWindow);
-		}
-
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-		globalSharers[classidx] |= tempsharer;
-		globalSharers[classidx+1] |= tempwriter;
-		MPI_Win_unlock(workrank, sharerWindow);
-
-		unsigned long offset = getOffset(lineAddr);
-		if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
-			unsigned long ownid = tempsharer&invid; // remove own bit
-			unsigned long owner = invalid_node; // initialize to failsafe value
-			for(n=0; n<numtasks; n++) {
-				if(1ul<<n==ownid) {
-					owner = n; //just get rank...
-					break;
-				}
-			}
-			if(owner != invalid_node) {
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-				MPI_Win_unlock(owner, sharerWindow);
-			}
-
-		}
-
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-		MPI_Get(&cacheData[startidx*pagesize],
-						1,
-						cacheblock,
-						homenode,
-						offset, 1,cacheblock,globalDataWindow[homenode]);
-		MPI_Win_unlock(homenode, globalDataWindow[homenode]);
-
-		if(cacheControl[startidx].tag == GLOBAL_NULL){
-			vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
-			cacheControl[startidx].tag = lineAddr;
-		}
-		else{
-			mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
-		}
-		touchedcache[startidx] = 1;
-		cacheControl[startidx].state = VALID;
-
-		cacheControl[startidx].dirty=CLEAN;
-		sem_post(&loadwaitsem);
-		sem_post(&ibsem);
-
-	}
-	return nullptr;
-}
-*/
 
 void prefetchcacheline_unloop(unsigned long prefetchtag, unsigned long prefetchline) {
 	int i;
@@ -1095,157 +824,6 @@ void prefetchcacheline_unloop(unsigned long prefetchtag, unsigned long prefetchl
 	cacheControl[startidx].dirty=CLEAN;
 	sem_post(&ibsem);
 }
-/*
-void * prefetchcacheline(void * x){
-	UNUSED_PARAM(x);
-	int i;
-	unsigned long homenode;
-	unsigned long id = 1 << getID();
-	unsigned long invid = ~id;
-	while(1){
-		sem_wait(&prefetchstartsem);
-		if(prefetchtag[0]>=size_of_all){//Trying to access/prefetch out of memory
-			sem_post(&prefetchwaitsem);
-			continue;
-		}
-
-
-		homenode = getHomenode(prefetchtag[0]);
-		unsigned long cacheIndex = prefetchline[0];
-		if(cacheIndex >= cachesize){
-			printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
-			sem_post(&prefetchwaitsem);
-			continue;
-		}
-
-
-		sem_wait(&ibsem);
-		unsigned long pageAddr = prefetchtag[0];
-		unsigned long blocksize = pagesize*CACHELINE;
-		unsigned long lineAddr = pageAddr/blocksize;
-		lineAddr *= blocksize;
-		unsigned long startidx = cacheIndex/CACHELINE;
-		startidx*=CACHELINE;
-		unsigned long end = startidx+CACHELINE;
-
-		if(end>=cachesize){
-			end = cachesize;
-		}
-		argo_byte tmpstate = cacheControl[startidx].state;
-		unsigned long tmptag = cacheControl[startidx].tag;
-		if(tmptag == lineAddr && tmpstate != INVALID){ //trying to load already valid ..
-			sem_post(&ibsem);
-			sem_post(&prefetchwaitsem);
-			continue;
-		}
-
-
-		void * lineptr = (char*)startAddr + lineAddr;
-
-		if(cacheControl[startidx].tag  != lineAddr){
-			if(cacheControl[startidx].tag  != lineAddr){
-				if(pthread_mutex_trylock(&wbmutex) != 0){
-					sem_post(&ibsem);
-					pthread_mutex_lock(&wbmutex);
-					sem_wait(&ibsem);
-				}
-
-				void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
-				if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
-					argo_byte dirty = cacheControl[startidx].dirty;
-					if(dirty == DIRTY){
-						mprotect(tmpptr2,blocksize,PROT_READ);
-						int j;
-						for(j=0; j < CACHELINE; j++){
-							storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
-						}
-					}
-
-					for(i = 0; i < numtasks; i++){
-						if(barwindowsused[i] == 1){
-							MPI_Win_unlock(i, globalDataWindow[i]);
-							barwindowsused[i] = 0;
-						}
-					}
-
-
-					cacheControl[startidx].state = INVALID;
-					cacheControl[startidx].tag = lineAddr;
-					cacheControl[startidx].dirty=CLEAN;
-
-					vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
-					mprotect(tmpptr2,blocksize,PROT_NONE);
-
-				}
-				pthread_mutex_unlock(&wbmutex);
-
-			}
-		}
-
-		stats.loads++;
-		unsigned long classidx = get_classification_index(lineAddr);
-		unsigned long tempsharer = 0;
-		unsigned long tempwriter = 0;
-		MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-		unsigned long prevsharer = (globalSharers[classidx])&id;
-		MPI_Win_unlock(workrank, sharerWindow);
-		int n;
-		homenode = getHomenode(lineAddr);
-
-		if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
-			MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-			MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
-				homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
-			MPI_Win_unlock(homenode, sharerWindow);
-		}
-
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-		globalSharers[classidx] |= tempsharer;
-		globalSharers[classidx+1] |= tempwriter;
-		MPI_Win_unlock(workrank, sharerWindow);
-
-		unsigned long offset = getOffset(lineAddr);
-		if(isPowerOf2((tempsharer)&invid) && prevsharer == 0){ //Other private. but may not have loaded page yet.
-			unsigned long ownid = tempsharer&invid; // remove own bit
-			unsigned long owner = invalid_node; // initialize to failsafe value
-			for(n=0; n<numtasks; n++) {
-				if(1ul<<n == ownid) {
-					owner = n; //just get rank...
-					break;
-				}
-			}
-			if(owner != invalid_node) {
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-				MPI_Win_unlock(owner, sharerWindow);
-			}
-
-		}
-
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-		MPI_Get(&cacheData[startidx*pagesize], 1, cacheblock, homenode,
-			offset, 1, cacheblock, globalDataWindow[homenode]);
-		MPI_Win_unlock(homenode, globalDataWindow[homenode]);
-
-
-		if(cacheControl[startidx].tag == GLOBAL_NULL){
-			vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
-			cacheControl[startidx].tag = lineAddr;
-		}
-		else{
-			mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
-		}
-
-		touchedcache[startidx] = 1;
-		cacheControl[startidx].state = VALID;
-		cacheControl[startidx].dirty=CLEAN;
-		sem_post(&prefetchwaitsem);
-		sem_post(&ibsem);
-	}
-	return nullptr;
-}
-*/
 
 void initmpi(){
 	int ret,initialized,thread_status;
@@ -1369,18 +947,11 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		barwindowsused[i] = 0;
 	}
 
-	//prefetchline = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	//loadline = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	//prefetchtag = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	//loadtag = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-
 	int *workranks = (int *) malloc(sizeof(int)*numtasks);
 	int *procranks = (int *) malloc(sizeof(int)*2);
 	int workindex = 0;
 
 	for(i = 0; i < numtasks; i++){
-		//prefetchline[i] = GLOBAL_NULL;
-		//loadline[i] = GLOBAL_NULL;
 		workranks[workindex++] = i;
 		procranks[0]=i;
 		procranks[1]=i+1;
@@ -1460,14 +1031,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	tmpcache=lockbuffer;
 	vm::map_memory(tmpcache, pagesize, current_offset, PROT_READ|PROT_WRITE);
 
-	//sem_init(&loadwaitsem,0,0);
-	//sem_init(&loadstartsem,0,0);
-	//sem_init(&prefetchstartsem,0,0);
-	//sem_init(&prefetchwaitsem,0,0);
-
-	//sem_init(&writerstartsem,0,0);
-	//sem_init(&writerwaitsem,0,0);
-
 	sem_init(&ibsem,0,1);
 	sem_init(&globallocksem,0,1);
 
@@ -1497,9 +1060,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		cacheControl[j].dirty = CLEAN;
 	}
 
-	//pthread_create(&loadthread1,NULL,&loadcacheline,NULL);
-	//pthread_create(&loadthread2,NULL,&prefetchcacheline,(void*)NULL);
-	//pthread_create(&writethread,NULL,&writeloop,(void*)NULL);
 	argo_reset_coherence(1);
 }
 
@@ -1512,9 +1072,6 @@ void argo_finalize(){
 	swdsm_argo_barrier(1);
 	mprotect(startAddr,size_of_all,PROT_WRITE|PROT_READ);
 	MPI_Barrier(MPI_COMM_WORLD);
-	//pthread_cancel(loadthread1);
-	//pthread_cancel(loadthread2);
-	//pthread_cancel(writethread);
 
 	for(i=0; i <numtasks;i++){
 		if(i==workrank){
@@ -1608,16 +1165,11 @@ void swdsm_argo_barrier(int n){ //BARRIER
 }
 
 void argo_reset_coherence(int n){
-	int i;
 	unsigned long j;
 	stats.writebacks = 0;
 	stats.stores = 0;
 	memset(touchedcache, 0, cachesize);
 
-	for(i=0;i<numtasks;i++){
-		//loadline[i] = GLOBAL_NULL;
-		//prefetchline[i] = GLOBAL_NULL;
-	}
 	sem_wait(&ibsem);
 	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
 	for(j = 0; j < classificationSize; j++){

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -138,9 +138,9 @@ void set_sighandler();
 /*ArgoDSM init and finish*/
 /**
  * @brief Initializes ArgoDSM runtime
- * @param size Size of wanted global address space
+ * @param argo_size Size of wanted global address space
  */
-void argo_initialize(unsigned long long size);
+void argo_initialize(unsigned long long argo_size);
 
 /**
  * @brief Shutting down ArgoDSM runtime

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -138,9 +138,10 @@ void set_sighandler();
 /*ArgoDSM init and finish*/
 /**
  * @brief Initializes ArgoDSM runtime
- * @param argo_size Size of wanted global address space
+ * @param argo_size Size of wanted global address space in bytes
+ * @param cache_size Size in bytes of your cache, will be rounded to nearest multiple of cacheline size (in bytes)
  */
-void argo_initialize(unsigned long long argo_size);
+void argo_initialize(std::size_t argo_size, std::size_t cache_size);
 
 /**
  * @brief Shutting down ArgoDSM runtime

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -204,24 +204,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
  */
 void storepageDIFF(unsigned long index, unsigned long addr);
 
-/**
- * @brief Loop-function for writing pages from writebuffer into remote global address space
- * @param x unused
- */
-void *writeloop(void * x);
-
-/**
- * @brief Loop-function for loading pages into global address space
- * @param x unused
- */
-void * loadcacheline(void * x);
-
-/**
- * @brief Loop-function for prefetching pages into global address space
- * @param x unused
- */
-void * prefetchcacheline(void * x);
-
 /*Statistics*/
 /**
  * @brief Clears out all statistics

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -52,7 +52,7 @@ const std::size_t nodes = 1;
 char* memory;
 
 /**
- * @brief total memory size
+ * @brief total memory size in bytes
  * @deprecated this is to mimic the prototype and mpi backend
  */
 std::size_t memory_size;
@@ -73,7 +73,10 @@ void singlenode_handler(int sig, siginfo_t*, void*) {
 namespace argo {
 	namespace backend {
 
-		void init(std::size_t argo_size) {
+		void init(std::size_t argo_size, std::size_t cache_size){
+			/** @todo the cache_size parameter is not needed
+			 *        and should not be part of the backend interface */
+			(void)(cache_size);
 			memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
 			memory_size = argo_size;
 			using namespace data_distribution;

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -73,12 +73,11 @@ void singlenode_handler(int sig, siginfo_t*, void*) {
 namespace argo {
 	namespace backend {
 
-		void init(std::size_t size) {
-			memory = static_cast<char*>(vm::allocate_mappable(4096, size));
-			memory_size = size;
+		void init(std::size_t argo_size) {
+			memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
+			memory_size = argo_size;
 			using namespace data_distribution;
-			naive_data_distribution<0>::set_memory_space(nodes, memory, size);
-			sig::signal_handler<SIGSEGV>::install_argo_handler(&singlenode_handler);
+			naive_data_distribution<0>::set_memory_space(nodes, memory, argo_size);
 		}
 
 		node_id_t node_id() {

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file
+ * @brief This file implements the handling of environment variables
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "env.hpp"
+
+namespace {
+	/* file constants */
+	/**
+	 * @brief default requested memory size (if environment variable is unset)
+	 * @see @ref ARGO_MEMORY_SIZE
+	 */
+	const std::size_t default_memory_size = 8ul*(1ul<<30); // default: 8GB
+
+	/**
+	 * @brief environment variable used for requesting memory size
+	 * @see @ref ARGO_MEMORY_SIZE
+	 */
+	const std::string env_memory_size = "ARGO_MEMORY_SIZE";
+
+	/** @brief error message string */
+	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
+	/** @brief error message string */
+	const std::string msg_illegal_format = "An environment variable could not be converted to a number: ";
+	/** @brief error message string */
+	const std::string msg_out_of_range = "An environment variable contains a number outside the possible range: ";
+
+	/* file variables */
+	/**
+	 * @brief memory size requested through the environment variable @ref ARGO_MEMORY_SIZE
+	 */
+	std::size_t value_memory_size;
+
+	/** @brief flag to allow checking that environment variables have been read before accessing their values */
+	bool is_initialized = false;
+
+	/* helper functions */
+	/** @brief throw an exception if argo::env::init() has not yet been called */
+	void check_initialized() {
+		if(!is_initialized) {
+			throw std::logic_error(msg_uninitialized);
+		}
+	}
+
+	/**
+	 * @brief parse an environment variable
+	 * @param name the environment variable to parse
+	 * @param fallback the default value to use if the environment variable is undefined
+	 * @return the value of the environment variable
+	 */
+	std::size_t parse_env(std::string name, std::size_t fallback) {
+		auto env_value = std::getenv(name.c_str());
+		try {
+			if(env_value != nullptr) {
+				return std::stoul(name);
+			} else {
+				return fallback;
+			}
+		} catch (const std::invalid_argument& e) {
+			// environment variable exists, but value is not convertable to an unsigned long
+			std::cerr << msg_illegal_format << name << std::endl;
+			throw;
+		} catch (const std::out_of_range& e) {
+			// environment variable exists, but value is out of range
+			std::cerr << msg_out_of_range << name << std::endl;
+			throw;
+		}
+	}
+
+} // unnamed namespace
+
+namespace argo {
+	namespace env {
+		void init() {
+			value_memory_size = parse_env(env_memory_size, default_memory_size);
+
+			is_initialized = true;
+		}
+
+		std::size_t memory_size() {
+			check_initialized();
+			return value_memory_size;
+		}
+
+	} // namespace env
+} // namespace argo

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -20,10 +20,22 @@ namespace {
 	const std::size_t default_memory_size = 8ul*(1ul<<30); // default: 8GB
 
 	/**
+	 * @brief default requested cache size (if environment variable is unset)
+	 * @see @ref ARGO_CACHE_SIZE
+	 */
+	const std::size_t default_cache_size = 1ul<<30; // default: 1GB
+
+	/**
 	 * @brief environment variable used for requesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
 	const std::string env_memory_size = "ARGO_MEMORY_SIZE";
+
+	/**
+	 * @brief environment variable used for requesting cache size
+	 * @see @ref ARGO_CACHE_SIZE
+	 */
+	const std::string env_cache_size = "ARGO_CACHE_SIZE";
 
 	/** @brief error message string */
 	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
@@ -37,6 +49,11 @@ namespace {
 	 * @brief memory size requested through the environment variable @ref ARGO_MEMORY_SIZE
 	 */
 	std::size_t value_memory_size;
+
+	/**
+	 * @brief cache size requested through the environment variable @ref ARGO_CACHE_SIZE
+	 */
+	std::size_t value_cache_size;
 
 	/** @brief flag to allow checking that environment variables have been read before accessing their values */
 	bool is_initialized = false;
@@ -80,6 +97,7 @@ namespace argo {
 	namespace env {
 		void init() {
 			value_memory_size = parse_env(env_memory_size, default_memory_size);
+			value_cache_size = parse_env(env_cache_size, default_cache_size);
 
 			is_initialized = true;
 		}
@@ -87,6 +105,11 @@ namespace argo {
 		std::size_t memory_size() {
 			check_initialized();
 			return value_memory_size;
+		}
+
+		std::size_t cache_size() {
+			check_initialized();
+			return value_cache_size;
 		}
 
 	} // namespace env

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * @brief This file provides facilities for handling environment variables
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef argo_env_env_hpp
+#define argo_env_env_hpp argo_env_env_hpp
+
+#include <cstddef>
+
+/**
+ * @page envvars Environment Variables
+ *
+ * @envvar{ARGO_MEMORY_SIZE} request a specific memory size in bytes
+ * @details This environment variable is only used if argo::init() is called with no parameter (or value 0).
+ *          It can be accessed through argo::env::memory_size() after argo::env::init() has been called.
+ */
+
+namespace argo {
+	/**
+	 * @brief namespace for environment variable handling functionality
+	 * @note argo::env::init() must be called before other functions in this
+	 *       namespace work correctly
+	 */
+	namespace env {
+		/**
+		 * @brief read and store environment variables used by ArgoDSM
+		 * @details the environment is only read once, to avoid having
+		 *          to check that values are not changing later
+		 */
+		void init();
+
+		/**
+		 * @brief get the memory size requested by environment variable
+		 * @return the requested memory size in bytes
+		 * @see @ref ARGO_MEMORY_SIZE
+		 */
+		std::size_t memory_size();
+
+	} // namespace env
+} // namespace argo
+
+#endif

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -13,8 +13,9 @@
  * @page envvars Environment Variables
  *
  * @envvar{ARGO_MEMORY_SIZE} request a specific memory size in bytes
- * @details This environment variable is only used if argo::init() is called with no parameter (or value 0).
- *          It can be accessed through argo::env::memory_size() after argo::env::init() has been called.
+ * @details This environment variable is only used if argo::init() is called with no
+ *          argo_size parameter (or it has value 0). It can be accessed through
+ *          @ref argo::env::memory_size() after argo::env::init() has been called.
  */
 
 namespace argo {

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -16,6 +16,11 @@
  * @details This environment variable is only used if argo::init() is called with no
  *          argo_size parameter (or it has value 0). It can be accessed through
  *          @ref argo::env::memory_size() after argo::env::init() has been called.
+ *
+ * @envvar{ARGO_CACHE_SIZE} request a specific cache size in bytes
+ * @details This environment variable is only used if argo::init() is called with no
+ *          cache_size parameter (or it has value 0). It can be accessed through
+ *          @ref argo::env::cache_size() after argo::env::init() has been called.
  */
 
 namespace argo {
@@ -39,6 +44,12 @@ namespace argo {
 		 */
 		std::size_t memory_size();
 
+		/**
+		 * @brief get the cache size requested by environment variable
+		 * @return the requested cache size in bytes
+		 * @see @ref ARGO_CACHE_SIZE
+		 */
+		std::size_t cache_size();
 	} // namespace env
 } // namespace argo
 

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -46,11 +46,8 @@ namespace argo {
 				static const std::size_t reserved = 4096;
 				/**
 				 * @brief Default constructor: initializes memory on heap and sets offset to 0
-				 * @param size The amount of memory in the pool
 				 */
-				global_memory_pool(std::size_t size) {
-					size+=reserved;
-					backend::init(size);
+				global_memory_pool() {
 					auto nodes = backend::number_of_nodes();
 					memory = backend::global_base();
 					max_size = backend::global_size();


### PR DESCRIPTION
This patch contains several commits:

e6b1460 gives the responsibility of initialising everything to argo::init()
d1c9285 adds the option to use an environment variable to set the memory size used
87ef1b1 only renames arguments from `size` to `argo_size`
d762963 limits the cache size to a value also optionally set through argo::init() or an environment variable
b859ed3 limits the cache size to the total memory size, if it is smaller than the requested memory size

The main changes in 87ef1b1 and d762963 are taken from #14, but split into two commits for readability.
Note that this pull request does not contain all features from #14, as it only deals with commit 
60e68ce. 