### PR TITLE
Limit cache size

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -218,7 +218,7 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES                = "envvar{1}=@anchor \1 @par \1 \n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,11 +50,15 @@ is protected by locks.
 The first step is adding the ArgoDSM initialization and finalization function.
 Specifically, `argo::init` needs to be run in `main` before any other functions
 are called, and `argo::finalize` should be the last ArgoDSM function called
-before exiting `main`. In the current version of ArgoDSM, `argo::init` has one
-optional argument which indicates the total amount of memory ArgoDSM should
-allocate. When the value is given to `argo::init`, it will be used. If it is
-omitted, the value (in bytes) in the environment variable `ARGO_MEMORY_SIZE`
-will be used to set the total amount of memory available to ArgoDSM.
+before exiting `main`. In the current version of ArgoDSM, `argo::init` has two
+optional arguments which indicate the amount of shared memory (in bytes) ArgoDSM
+should allocate and the desired local cache size, respectively. When the values
+are given to `argo::init`, they will be used. If one or both are omitted, then
+the value (in bytes) in the environment variable `ARGO_MEMORY_SIZE` (for the
+shared memory size) and `ARGO_CACHE_SIZE` (for the local cache size) will be
+used instead. If the environment variables are empty, some default numbers will
+be used. At the time of this writing they are 8GB and 1GB for shared memory and
+local cache size, respectively.
 
 In addition to adding the ArgoDSM initialization and finalization functions,
 there are three main tasks that need to be done to convert a pthreads

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -51,8 +51,10 @@ The first step is adding the ArgoDSM initialization and finalization function.
 Specifically, `argo::init` needs to be run in `main` before any other functions
 are called, and `argo::finalize` should be the last ArgoDSM function called
 before exiting `main`. In the current version of ArgoDSM, `argo::init` has one
-required argument which indicates the total amount of memory ArgoDSM should
-allocate. This will be deprecated in future versions.
+optional argument which indicates the total amount of memory ArgoDSM should
+allocate. When the value is given to `argo::init`, it will be used. If it is
+omitted, the value (in bytes) in the environment variable `ARGO_MEMORY_SIZE`
+will be used to set the total amount of memory available to ArgoDSM.
 
 In addition to adding the ArgoDSM initialization and finalization functions,
 there are three main tasks that need to be done to convert a pthreads

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,11 @@ foreach(src ${allocator_sources})
 	list(APPEND argo_sources allocators/${src})
 endforeach(src)
 
+set(env_sources env.cpp)
+foreach(src ${env_sources})
+	list(APPEND argo_sources env/${src})
+endforeach(src)
+
 set(synchronization_sources
 	synchronization.cpp
 	cohort_lock.cpp

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -22,18 +22,19 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY> collectiv
 mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&alloc::default_global_allocator);
 
 namespace argo {
-	void init(std::size_t size) {
+	void init(std::size_t argo_size) {
 		env::init();
 		vm::init();
-		std::size_t requested_size = size;
-		if(requested_size == 0) {
-			requested_size = env::memory_size();
+
+		std::size_t requested_argo_size = argo_size;
+		if(requested_argo_size == 0) {
+			requested_argo_size = env::memory_size();
 		}
 		using mp = mem::global_memory_pool<>;
 		/* add some space for internal use, see issue #22 */
-		requested_size += mp::reserved;
+		requested_argo_size += mp::reserved;
 		/* note: the backend must currently initialize before the mempool can be set */
-		backend::init(requested_size);
+		backend::init(requested_argo_size);
 		default_global_mempool = new mp();
 		argo_reset();
 	}
@@ -53,8 +54,8 @@ namespace argo {
 } // namespace argo
 
 extern "C" {
-	void argo_init(size_t size) {
-		argo::init(size);
+	void argo_init(size_t argo_size) {
+		argo::init(argo_size);
 	}
 
 	void argo_finalize() {

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -22,9 +22,15 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY> collectiv
 mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&alloc::default_global_allocator);
 
 namespace argo {
-	void init(size_t size) {
+	void init(std::size_t size) {
 		vm::init();
-		default_global_mempool = new mem::global_memory_pool<>(size);
+		std::size_t requested_size = size;
+		using mp = mem::global_memory_pool<>;
+		/* add some space for internal use, see issue #22 */
+		requested_size += mp::reserved;
+		/* note: the backend must currently initialize before the mempool can be set */
+		backend::init(requested_size);
+		default_global_mempool = new mp();
 		argo_reset();
 	}
 

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -8,7 +8,7 @@
 
 #include "allocators/collective_allocator.hpp"
 #include "allocators/dynamic_allocator.hpp"
-
+#include "env/env.hpp"
 #include "virtual_memory/virtual_memory.hpp"
 
 namespace vm = argo::virtual_memory;
@@ -23,8 +23,12 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&
 
 namespace argo {
 	void init(std::size_t size) {
+		env::init();
 		vm::init();
 		std::size_t requested_size = size;
+		if(requested_size == 0) {
+			requested_size = env::memory_size();
+		}
 		using mp = mem::global_memory_pool<>;
 		/* add some space for internal use, see issue #22 */
 		requested_size += mp::reserved;

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -22,7 +22,7 @@ mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY> collectiv
 mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS> dynamic_prepool(&alloc::default_global_allocator);
 
 namespace argo {
-	void init(std::size_t argo_size) {
+	void init(std::size_t argo_size, std::size_t cache_size) {
 		env::init();
 		vm::init();
 
@@ -33,8 +33,14 @@ namespace argo {
 		using mp = mem::global_memory_pool<>;
 		/* add some space for internal use, see issue #22 */
 		requested_argo_size += mp::reserved;
+
+		std::size_t requested_cache_size = cache_size;
+		if(requested_cache_size == 0) {
+			requested_cache_size = env::cache_size();
+		}
+
 		/* note: the backend must currently initialize before the mempool can be set */
-		backend::init(requested_argo_size);
+		backend::init(requested_argo_size, requested_cache_size);
 		default_global_mempool = new mp();
 		argo_reset();
 	}
@@ -54,8 +60,8 @@ namespace argo {
 } // namespace argo
 
 extern "C" {
-	void argo_init(size_t argo_size) {
-		argo::init(argo_size);
+	void argo_init(size_t argo_size, size_t cache_size) {
+		argo::init(argo_size, cache_size);
 	}
 
 	void argo_finalize() {

--- a/src/argo.h
+++ b/src/argo.h
@@ -14,11 +14,11 @@
 
 /**
  * @brief initialize ArgoDSM system
- * @param size The desired size of the global memory in bytes, or 0. If the
- *             value is specified as 0, then the value in environment
- *             variable @ref ARGO_MEMORY_SIZE is used instead.
+ * @param argo_size The desired size of the global memory in bytes, or 0. If the
+ *                  value is specified as 0, then the value in environment
+ *                  variable @ref ARGO_MEMORY_SIZE is used instead.
  */
-void argo_init(size_t size);
+void argo_init(size_t argo_size);
 
 /**
  * @brief shut down ArgoDSM system

--- a/src/argo.h
+++ b/src/argo.h
@@ -14,7 +14,9 @@
 
 /**
  * @brief initialize ArgoDSM system
- * @param size the desired size of the global memory in bytes
+ * @param size The desired size of the global memory in bytes, or 0. If the
+ *             value is specified as 0, then the value in environment
+ *             variable @ref ARGO_MEMORY_SIZE is used instead.
  */
 void argo_init(size_t size);
 

--- a/src/argo.h
+++ b/src/argo.h
@@ -17,9 +17,11 @@
  * @param argo_size The desired size of the global memory in bytes, or 0. If the
  *                  value is specified as 0, then the value in environment
  *                  variable @ref ARGO_MEMORY_SIZE is used instead.
+ *                  If @ref ARGO_MEMORY_SIZE is unset, then a default is used.
  * @param cache_size The desired size of the local cache in bytes, or 0. If the
  *                   value is specified as 0, then the value in environment
  *                   variable @ref ARGO_CACHE_SIZE is used instead.
+ *                   If @ref ARGO_CACHE_SIZE is unset, then a default is used.
  */
 void argo_init(size_t argo_size, size_t cache_size);
 

--- a/src/argo.h
+++ b/src/argo.h
@@ -17,8 +17,11 @@
  * @param argo_size The desired size of the global memory in bytes, or 0. If the
  *                  value is specified as 0, then the value in environment
  *                  variable @ref ARGO_MEMORY_SIZE is used instead.
+ * @param cache_size The desired size of the local cache in bytes, or 0. If the
+ *                   value is specified as 0, then the value in environment
+ *                   variable @ref ARGO_CACHE_SIZE is used instead.
  */
-void argo_init(size_t argo_size);
+void argo_init(size_t argo_size, size_t cache_size);
 
 /**
  * @brief shut down ArgoDSM system

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -42,11 +42,11 @@ namespace argo {
 
 	/**
 	 * @brief initialize ArgoDSM system
-	 * @param size The desired size of the global memory in bytes, or 0.
-	 *             If the value is omitted (or specified as 0), then the value in
-	 *             environment variable @ref ARGO_MEMORY_SIZE is used instead.
+	 * @param argo_size The desired size of the global memory in bytes, or 0. If the
+	 *                  value is omitted (or specified as 0), then the value in
+	 *                  environment variable @ref ARGO_MEMORY_SIZE is used instead.
 	 */
-	void init(std::size_t size = 0);
+	void init(std::size_t argo_size = 0);
 
 	/**
 	 * @brief shut down ArgoDSM system

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -45,8 +45,11 @@ namespace argo {
 	 * @param argo_size The desired size of the global memory in bytes, or 0. If the
 	 *                  value is omitted (or specified as 0), then the value in
 	 *                  environment variable @ref ARGO_MEMORY_SIZE is used instead.
+	 * @param cache_size The desired size of the local cache in bytes, or 0. If the
+	 *                   value is omitted (or specified as 0), then the value in
+	 *                   environment variable @ref ARGO_CACHE_SIZE is used instead.
 	 */
-	void init(std::size_t argo_size = 0);
+	void init(std::size_t argo_size = 0, std::size_t cache_size = 0);
 
 	/**
 	 * @brief shut down ArgoDSM system

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -45,9 +45,11 @@ namespace argo {
 	 * @param argo_size The desired size of the global memory in bytes, or 0. If the
 	 *                  value is omitted (or specified as 0), then the value in
 	 *                  environment variable @ref ARGO_MEMORY_SIZE is used instead.
+	 *                  If @ref ARGO_MEMORY_SIZE is unset, then a default is used.
 	 * @param cache_size The desired size of the local cache in bytes, or 0. If the
 	 *                   value is omitted (or specified as 0), then the value in
 	 *                   environment variable @ref ARGO_CACHE_SIZE is used instead.
+	 *                   If @ref ARGO_CACHE_SIZE is unset, then a default is used.
 	 */
 	void init(std::size_t argo_size = 0, std::size_t cache_size = 0);
 

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -7,6 +7,8 @@
 #ifndef argo_argo_hpp
 #define argo_argo_hpp argo_argo_hpp
 
+#include <cstddef>
+
 #include "allocators/allocators.hpp"
 #include "backend/backend.hpp"
 #include "types/types.hpp"
@@ -40,9 +42,11 @@ namespace argo {
 
 	/**
 	 * @brief initialize ArgoDSM system
-	 * @param size the desired size of the global memory in bytes
+	 * @param size The desired size of the global memory in bytes, or 0.
+	 *             If the value is omitted (or specified as 0), then the value in
+	 *             environment variable @ref ARGO_MEMORY_SIZE is used instead.
 	 */
-	void init(size_t size);
+	void init(std::size_t size = 0);
 
 	/**
 	 * @brief shut down ArgoDSM system

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -41,13 +41,13 @@ namespace argo {
 	namespace backend {
 		/**
 		 * @brief initialize backend
-		 * @param size the size of the global memory to initialize
+		 * @param argo_size the size of the global memory to initialize
 		 * @warning the signature of this function may change
 		 * @todo maybe this should be tied better to the concrete memory
 		 *       allocated rather than a generic "initialize this size"
 		 *       functionality.
 		 */
-		void init(std::size_t size);
+		void init(std::size_t argo_size);
 
 		/**
 		 * @brief get ArgoDSM node ID

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -41,13 +41,16 @@ namespace argo {
 	namespace backend {
 		/**
 		 * @brief initialize backend
-		 * @param argo_size the size of the global memory to initialize
+		 * @param argo_size the size (in bytes) of the global memory to initialize
+		 * @param cache_size the size (in bytes) of the cache used by ArgoDSM
 		 * @warning the signature of this function may change
 		 * @todo maybe this should be tied better to the concrete memory
 		 *       allocated rather than a generic "initialize this size"
 		 *       functionality.
+		 * @todo the cache_size parameter is currently needed because cache layout
+		 *       is defined by the backend, which is wrong design-wise.
 		 */
-		void init(std::size_t argo_size);
+		void init(std::size_t argo_size, std::size_t cache_size);
 
 		/**
 		 * @brief get ArgoDSM node ID

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -130,8 +130,8 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 
 namespace argo {
 	namespace backend {
-		void init(std::size_t argo_size) {
-			argo_initialize(argo_size);
+		void init(std::size_t argo_size, std::size_t cache_size){
+			argo_initialize(argo_size, cache_size);
 		}
 
 		node_id_t node_id() {

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -130,8 +130,8 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 
 namespace argo {
 	namespace backend {
-		void init(std::size_t size) {
-			argo_initialize(size);
+		void init(std::size_t argo_size) {
+			argo_initialize(argo_size);
 		}
 
 		node_id_t node_id() {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1010,15 +1010,15 @@ void * argo_gmalloc(unsigned long size){
 	return ptrtmp;
 }
 
-void argo_initialize(unsigned long long size){
+void argo_initialize(unsigned long long argo_size){
 	int i;
 	unsigned long j;
 	initmpi();
 	unsigned long alignment = pagesize*CACHELINE*numtasks;
-	if((size%alignment)>0){
-		size += alignment - 1;
-		size /= alignment;
-		size *= alignment;
+	if((argo_size%alignment)>0){
+		argo_size += alignment - 1;
+		argo_size /= alignment;
+		argo_size *= alignment;
 	}
 
 	startAddr = vm::start_address();
@@ -1031,7 +1031,7 @@ void argo_initialize(unsigned long long size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = size+pagesize*CACHELINE;
+	cachesize = argo_size+pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;
@@ -1073,19 +1073,19 @@ void argo_initialize(unsigned long long size){
 	MPI_Comm_create(MPI_COMM_WORLD,workgroup,&workcomm);
 	MPI_Group_rank(workgroup,&workrank);
 
-	if(size < pagesize*numtasks){
-		size = pagesize*numtasks;
+	if(argo_size < pagesize*numtasks){
+		argo_size = pagesize*numtasks;
 	}
 
 	alignment = CACHELINE*pagesize;
-	if(size % (alignment*numtasks) != 0){
-		size = alignment*numtasks * (1+(size)/(alignment*numtasks));
+	if(argo_size % (alignment*numtasks) != 0){
+		argo_size = alignment*numtasks * (1+(argo_size)/(alignment*numtasks));
 	}
 
 	//Allocate local memory for each node,
-	size_of_all = size; //total distr. global memory
+	size_of_all = argo_size; //total distr. global memory
 	GLOBAL_NULL=size_of_all+1;
-	size_of_chunk = size/(numtasks); //part on each node
+	size_of_chunk = argo_size/(numtasks); //part on each node
 	sig::signal_handler<SIGSEGV>::install_argo_handler(&handler);
 
 	unsigned long cacheControlSize = sizeof(control_data)*cachesize;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1031,7 +1031,13 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = cache_size+pagesize*CACHELINE;
+	cachesize = 0;
+	if(cache_size > argo_size) {
+		cachesize += argo_size;
+	} else {
+		cachesize += cache_size;
+	}
+	cachesize += pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1010,7 +1010,7 @@ void * argo_gmalloc(unsigned long size){
 	return ptrtmp;
 }
 
-void argo_initialize(unsigned long long argo_size){
+void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	int i;
 	unsigned long j;
 	initmpi();
@@ -1031,7 +1031,7 @@ void argo_initialize(unsigned long long argo_size){
 		pthread_barrier_init(&threadbarrier[i],NULL,i);
 	}
 
-	cachesize = argo_size+pagesize*CACHELINE;
+	cachesize = cache_size+pagesize*CACHELINE;
 	cachesize /= pagesize;
 	cachesize /= CACHELINE;
 	cachesize *= CACHELINE;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -138,9 +138,9 @@ void set_sighandler();
 /*ArgoDSM init and finish*/
 /**
  * @brief Initializes ArgoDSM runtime
- * @param size Size of wanted global address space
+ * @param argo_size Size of wanted global address space
  */
-void argo_initialize(unsigned long long size);
+void argo_initialize(unsigned long long argo_size);
 
 /**
  * @brief Shutting down ArgoDSM runtime

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -138,9 +138,10 @@ void set_sighandler();
 /*ArgoDSM init and finish*/
 /**
  * @brief Initializes ArgoDSM runtime
- * @param argo_size Size of wanted global address space
+ * @param argo_size Size of wanted global address space in bytes
+ * @param cache_size Size in bytes of your cache, will be rounded to nearest multiple of cacheline size (in bytes)
  */
-void argo_initialize(unsigned long long argo_size);
+void argo_initialize(std::size_t argo_size, std::size_t cache_size);
 
 /**
  * @brief Shutting down ArgoDSM runtime

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -73,11 +73,11 @@ void singlenode_handler(int sig, siginfo_t*, void*) {
 namespace argo {
 	namespace backend {
 
-		void init(std::size_t size) {
-			memory = static_cast<char*>(vm::allocate_mappable(4096, size));
-			memory_size = size;
+		void init(std::size_t argo_size) {
+			memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
+			memory_size = argo_size;
 			using namespace data_distribution;
-			naive_data_distribution<0>::set_memory_space(nodes, memory, size);
+			naive_data_distribution<0>::set_memory_space(nodes, memory, argo_size);
 			sig::signal_handler<SIGSEGV>::install_argo_handler(&singlenode_handler);
 		}
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -52,7 +52,7 @@ const std::size_t nodes = 1;
 char* memory;
 
 /**
- * @brief total memory size
+ * @brief total memory size in bytes
  * @deprecated this is to mimic the prototype and mpi backend
  */
 std::size_t memory_size;
@@ -73,7 +73,10 @@ void singlenode_handler(int sig, siginfo_t*, void*) {
 namespace argo {
 	namespace backend {
 
-		void init(std::size_t argo_size) {
+		void init(std::size_t argo_size, std::size_t cache_size){
+			/** @todo the cache_size parameter is not needed
+			 *        and should not be part of the backend interface */
+			(void)(cache_size);
 			memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
 			memory_size = argo_size;
 			using namespace data_distribution;

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -1,0 +1,95 @@
+/**
+ * @file
+ * @brief This file implements the handling of environment variables
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "env.hpp"
+
+namespace {
+	/* file constants */
+	/**
+	 * @brief default requested memory size (if environment variable is unset)
+	 * @see @ref ARGO_MEMORY_SIZE
+	 */
+	const std::size_t default_memory_size = 8ul*(1ul<<30); // default: 8GB
+
+	/**
+	 * @brief environment variable used for requesting memory size
+	 * @see @ref ARGO_MEMORY_SIZE
+	 */
+	const std::string env_memory_size = "ARGO_MEMORY_SIZE";
+
+	/** @brief error message string */
+	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
+	/** @brief error message string */
+	const std::string msg_illegal_format = "An environment variable could not be converted to a number: ";
+	/** @brief error message string */
+	const std::string msg_out_of_range = "An environment variable contains a number outside the possible range: ";
+
+	/* file variables */
+	/**
+	 * @brief memory size requested through the environment variable @ref ARGO_MEMORY_SIZE
+	 */
+	std::size_t value_memory_size;
+
+	/** @brief flag to allow checking that environment variables have been read before accessing their values */
+	bool is_initialized = false;
+
+	/* helper functions */
+	/** @brief throw an exception if argo::env::init() has not yet been called */
+	void assert_initialized() {
+		if(!is_initialized) {
+			throw std::logic_error(msg_uninitialized);
+		}
+	}
+
+	/**
+	 * @brief parse an environment variable
+	 * @param name the environment variable to parse
+	 * @param fallback the default value to use if the environment variable is undefined
+	 * @return a pair <env_used, value>, where env_used is true iff the environment variable is set,
+	 *         and value is either the value of the environment variable or the fallback value.
+	 */
+	std::pair<bool, std::size_t> parse_env(std::string name, std::size_t fallback) {
+		auto env_value = std::getenv(name.c_str());
+		try {
+			if(env_value != nullptr) {
+				return std::make_pair(true, std::stoul(env_value));
+			} else {
+				return std::make_pair(false, fallback);
+			}
+		} catch (const std::invalid_argument& e) {
+			// environment variable exists, but value is not convertable to an unsigned long
+			std::cerr << msg_illegal_format << name << std::endl;
+			throw;
+		} catch (const std::out_of_range& e) {
+			// environment variable exists, but value is out of range
+			std::cerr << msg_out_of_range << name << std::endl;
+			throw;
+		}
+	}
+
+} // unnamed namespace
+
+namespace argo {
+	namespace env {
+		void init() {
+			value_memory_size = parse_env(env_memory_size, default_memory_size).second;
+
+			is_initialized = true;
+		}
+
+		std::size_t memory_size() {
+			assert_initialized();
+			return value_memory_size;
+		}
+
+	} // namespace env
+} // namespace argo

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -21,10 +21,22 @@ namespace {
 	const std::size_t default_memory_size = 8ul*(1ul<<30); // default: 8GB
 
 	/**
+	 * @brief default requested cache size (if environment variable is unset)
+	 * @see @ref ARGO_CACHE_SIZE
+	 */
+	const std::size_t default_cache_size = 1ul<<30; // default: 1GB
+
+	/**
 	 * @brief environment variable used for requesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
 	const std::string env_memory_size = "ARGO_MEMORY_SIZE";
+
+	/**
+	 * @brief environment variable used for requesting cache size
+	 * @see @ref ARGO_CACHE_SIZE
+	 */
+	const std::string env_cache_size = "ARGO_CACHE_SIZE";
 
 	/** @brief error message string */
 	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
@@ -38,6 +50,11 @@ namespace {
 	 * @brief memory size requested through the environment variable @ref ARGO_MEMORY_SIZE
 	 */
 	std::size_t value_memory_size;
+
+	/**
+	 * @brief cache size requested through the environment variable @ref ARGO_CACHE_SIZE
+	 */
+	std::size_t value_cache_size;
 
 	/** @brief flag to allow checking that environment variables have been read before accessing their values */
 	bool is_initialized = false;
@@ -82,6 +99,7 @@ namespace argo {
 	namespace env {
 		void init() {
 			value_memory_size = parse_env(env_memory_size, default_memory_size).second;
+			value_cache_size = parse_env(env_cache_size, default_cache_size).second;
 
 			is_initialized = true;
 		}
@@ -89,6 +107,11 @@ namespace argo {
 		std::size_t memory_size() {
 			assert_initialized();
 			return value_memory_size;
+		}
+
+		std::size_t cache_size() {
+			assert_initialized();
+			return value_cache_size;
 		}
 
 	} // namespace env

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * @brief This file provides facilities for handling environment variables
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef argo_env_env_hpp
+#define argo_env_env_hpp argo_env_env_hpp
+
+#include <cstddef>
+
+/**
+ * @page envvars Environment Variables
+ *
+ * @envvar{ARGO_MEMORY_SIZE} request a specific memory size in bytes
+ * @details This environment variable is only used if argo::init() is called with no parameter (or value 0).
+ *          It can be accessed through argo::env::memory_size() after argo::env::init() has been called.
+ */
+
+namespace argo {
+	/**
+	 * @brief namespace for environment variable handling functionality
+	 * @note argo::env::init() must be called before other functions in this
+	 *       namespace work correctly
+	 */
+	namespace env {
+		/**
+		 * @brief read and store environment variables used by ArgoDSM
+		 * @details the environment is only read once, to avoid having
+		 *          to check that values are not changing later
+		 */
+		void init();
+
+		/**
+		 * @brief get the memory size requested by environment variable
+		 * @return the requested memory size in bytes
+		 * @see @ref ARGO_MEMORY_SIZE
+		 */
+		std::size_t memory_size();
+
+	} // namespace env
+} // namespace argo
+
+#endif

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -13,8 +13,9 @@
  * @page envvars Environment Variables
  *
  * @envvar{ARGO_MEMORY_SIZE} request a specific memory size in bytes
- * @details This environment variable is only used if argo::init() is called with no parameter (or value 0).
- *          It can be accessed through argo::env::memory_size() after argo::env::init() has been called.
+ * @details This environment variable is only used if argo::init() is called with no
+ *          argo_size parameter (or it has value 0). It can be accessed through
+ *          @ref argo::env::memory_size() after argo::env::init() has been called.
  */
 
 namespace argo {

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -16,6 +16,11 @@
  * @details This environment variable is only used if argo::init() is called with no
  *          argo_size parameter (or it has value 0). It can be accessed through
  *          @ref argo::env::memory_size() after argo::env::init() has been called.
+ *
+ * @envvar{ARGO_CACHE_SIZE} request a specific cache size in bytes
+ * @details This environment variable is only used if argo::init() is called with no
+ *          cache_size parameter (or it has value 0). It can be accessed through
+ *          @ref argo::env::cache_size() after argo::env::init() has been called.
  */
 
 namespace argo {
@@ -39,6 +44,12 @@ namespace argo {
 		 */
 		std::size_t memory_size();
 
+		/**
+		 * @brief get the cache size requested by environment variable
+		 * @return the requested cache size in bytes
+		 * @see @ref ARGO_CACHE_SIZE
+		 */
+		std::size_t cache_size();
 	} // namespace env
 } // namespace argo
 

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -46,11 +46,8 @@ namespace argo {
 				static const std::size_t reserved = 4096;
 				/**
 				 * @brief Default constructor: initializes memory on heap and sets offset to 0
-				 * @param size The amount of memory in the pool
 				 */
-				global_memory_pool(std::size_t size) {
-					size+=reserved;
-					backend::init(size);
+				global_memory_pool() {
 					auto nodes = backend::number_of_nodes();
 					memory = backend::global_base();
 					max_size = backend::global_size();


### PR DESCRIPTION
This PR supersedes #19, which I accidentally broke.

This patch contains several commits:

d5b1670 gives the responsibility of initialising everything to argo::init()
32cbb09  adds the option to use an environment variable to set the memory size used
3187658 only renames arguments from size to argo_size
f08ae31 limits the cache size to a value also optionally set through argo::init() or an environment variable
32bbf41 limits the cache size to the total memory size, if it is smaller than the requested memory size

The main changes in 3187658 and f08ae31 are taken from #14, but split into two commits for readability.
Note that this pull request does not contain all features from #14, as it only deals with commit
60e68ce.