### PR TITLE
Remove helper threads

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -93,18 +93,17 @@ char * barwindowsused;
 sem_t ibsem;
 
 /*Loading and Prefetching*/
-/** @brief Tracking address of pages that should be loaded by loadthread1 */
-unsigned long *loadline;
-/** @brief Tracking cacheindex of pages that should be loaded by loadthread1 */
-unsigned long *loadtag;
+/**
+ * @brief load into cache helper function
+ * @param tag aligned address to load into the cache
+ * @param line cache entry index to use
+ */
+void load_cache_entry(unsigned long tag, unsigned long line);
+
 /** @brief Tracking address of pages that should be loaded by loadthread2 */
 unsigned long *prefetchline;
 /** @brief Tracking cacheindex of pages that should be loaded by loadthread2 */
 unsigned long *prefetchtag;
-/** @brief loadthread1 waits on this to start loading remote pages */
-sem_t loadstartsem;
-/** @brief signalhandler waits on this to complete a transfer */
-sem_t loadwaitsem;
 /** @brief loadthread2 waits on this to start loading remote pages */
 sem_t prefetchstartsem;
 /** @brief signalhandler waits on this to complete a transfer */
@@ -416,17 +415,14 @@ void handler(int sig, siginfo_t *si, void *unused){
 	tag = cacheControl[startIndex].tag;
 
 	if(state == INVALID || (tag != lineAddr && tag != GLOBAL_NULL)){
-		if(loadline[0] == GLOBAL_NULL && prefetchline[0] != GLOBAL_NULL){
+		if(prefetchline[0] != GLOBAL_NULL){
 			if(prefetchline[0] <= startIndex && startIndex < prefetchline[0]+CACHELINE){
-				loadline[0]= (startIndex+CACHELINE)%cachesize;
-				loadtag[0]=lineAddr+pagesize*CACHELINE;
+				load_cache_entry((lineAddr+pagesize*CACHELINE), ((startIndex+CACHELINE)%cachesize));
 			}
 			else{
-				loadline[0]=cacheIndex%cachesize;
-				loadtag[0]=alignedDistrAddr;
+				load_cache_entry(alignedDistrAddr, (cacheIndex%cachesize));
 			}
 
-			sem_post(&loadstartsem);
 			sem_wait(&prefetchwaitsem);
 			prefetchline[0] = GLOBAL_NULL;
 			prefetchtag[0]= GLOBAL_NULL;
@@ -435,41 +431,14 @@ void handler(int sig, siginfo_t *si, void *unused){
 			stats.loadtime+=t2-t1;
 			return;
 		}
-		else if(prefetchline[0] == GLOBAL_NULL && loadline[0] != GLOBAL_NULL){
-			if(loadline[0] <= startIndex && startIndex < loadline[0]+CACHELINE){
-				prefetchline[0]=(startIndex+CACHELINE)%cachesize;
-				prefetchtag[0]=lineAddr+pagesize*CACHELINE;
-			}
-			else{
-				prefetchline[0]=cacheIndex%cachesize;
-				prefetchtag[0]=alignedDistrAddr;
-			}
-
-			sem_post(&prefetchstartsem);
-			sem_wait(&loadwaitsem);
-			loadline[0] = GLOBAL_NULL;
-			loadtag[0]=GLOBAL_NULL;
-			pthread_mutex_unlock(&cachemutex);
-			double t2 = MPI_Wtime();
-			stats.loadtime+=t2-t1;
-			return;
-		}
 		else{
-			loadline[0]=startIndex%cachesize;
-			loadtag[0]=alignedDistrAddr;
-			sem_post(&loadstartsem);
+			load_cache_entry(alignedDistrAddr, (startIndex%cachesize));
 
 #ifdef DUAL_LOAD
 			prefetchline[0]=(startIndex+CACHELINE)%cachesize;
 			prefetchtag[0]=alignedDistrAddr+CACHELINE*pagesize;
 			sem_post(&prefetchstartsem);
-			sem_wait(&loadwaitsem);
-			loadline[0]=GLOBAL_NULL;
-			loadtag[0]=GLOBAL_NULL;
 #else
-			sem_wait(&loadwaitsem);
-			loadline[0]=GLOBAL_NULL;
-			loadtag[0]=GLOBAL_NULL;
 			prefetchline[0]=GLOBAL_NULL;
 			prefetchtag[0]=GLOBAL_NULL;
 
@@ -490,15 +459,6 @@ void handler(int sig, siginfo_t *si, void *unused){
 		stats.loadtime+=t2-t1;
 		return;
 
-	}
-	else if(loadline[0] != GLOBAL_NULL){
-		sem_wait(&loadwaitsem);
-		loadline[0]=GLOBAL_NULL;
-		loadtag[0] =GLOBAL_NULL;
-		pthread_mutex_unlock(&cachemutex);
-		double t2 = MPI_Wtime();
-		stats.loadtime+=t2-t1;
-		return;
 	}
 
 	unsigned long line = startIndex / CACHELINE;
@@ -619,158 +579,149 @@ void write_back_writebuffer() {
 	sem_post(&ibsem);
 }
 
-void * loadcacheline(void * x){
-	UNUSED_PARAM(x);
+void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
 	int i;
 	unsigned long homenode;
 	unsigned long id = 1 << getID();
 	unsigned long invid = ~id;
-	while(1){
-		sem_wait(&loadstartsem);
-		if(loadtag[0]>=size_of_all){//Trying to access/prefetch out of memory
-			sem_post(&loadwaitsem);
-			continue;
-		}
-		homenode = getHomenode(loadtag[0]);
-		unsigned long cacheIndex = loadline[0];
-		if(cacheIndex >= cachesize){
-			printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
-			sem_post(&loadwaitsem);
-			continue;
-		}
-		sem_wait(&ibsem);
+
+	if(loadtag>=size_of_all){//Trying to access/prefetch out of memory
+		return;
+	}
+	homenode = getHomenode(loadtag);
+	unsigned long cacheIndex = loadline;
+	if(cacheIndex >= cachesize){
+		printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
+		return;
+	}
+	sem_wait(&ibsem);
 
 
-		unsigned long pageAddr = loadtag[0];
-		unsigned long blocksize = pagesize*CACHELINE;
-		unsigned long lineAddr = pageAddr/blocksize;
-		lineAddr *= blocksize;
+	unsigned long pageAddr = loadtag;
+	unsigned long blocksize = pagesize*CACHELINE;
+	unsigned long lineAddr = pageAddr/blocksize;
+	lineAddr *= blocksize;
 
-		unsigned long startidx = cacheIndex/CACHELINE;
-		startidx*=CACHELINE;
-		unsigned long end = startidx+CACHELINE;
+	unsigned long startidx = cacheIndex/CACHELINE;
+	startidx*=CACHELINE;
+	unsigned long end = startidx+CACHELINE;
 
-		if(end>=cachesize){
-			end = cachesize;
-		}
+	if(end>=cachesize){
+		end = cachesize;
+	}
 
-		argo_byte tmpstate = cacheControl[startidx].state;
-		unsigned long tmptag = cacheControl[startidx].tag;
+	argo_byte tmpstate = cacheControl[startidx].state;
+	unsigned long tmptag = cacheControl[startidx].tag;
 
-		if(tmptag == lineAddr && tmpstate != INVALID){
-			sem_post(&ibsem);
-			sem_post(&loadwaitsem);
-			continue;
-		}
-
-
-		void * lineptr = (char*)startAddr + lineAddr;
-
-		if(cacheControl[startidx].tag  != lineAddr){
-			if(cacheControl[startidx].tag  != lineAddr){
-				if(pthread_mutex_trylock(&wbmutex) != 0){
-					sem_post(&ibsem);
-					pthread_mutex_lock(&wbmutex);
-					sem_wait(&ibsem);
-				}
-
-				void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
-				if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
-					argo_byte dirty = cacheControl[startidx].dirty;
-					if(dirty == DIRTY){
-						mprotect(tmpptr2,blocksize,PROT_READ);
-						int j;
-						for(j=0; j < CACHELINE; j++){
-							storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
-						}
-					}
-
-					for(i = 0; i < numtasks; i++){
-						if(barwindowsused[i] == 1){
-							MPI_Win_unlock(i, globalDataWindow[i]);
-							barwindowsused[i] = 0;
-						}
-					}
-
-					cacheControl[startidx].state = INVALID;
-					cacheControl[startidx].tag = lineAddr;
-
-					cacheControl[startidx].dirty=CLEAN;
-					vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
-					mprotect(tmpptr2,blocksize,PROT_NONE);
-				}
-				pthread_mutex_unlock(&wbmutex);
-			}
-		}
-
-
-
-		stats.loads++;
-		unsigned long classidx = get_classification_index(lineAddr);
-		unsigned long tempsharer = 0;
-		unsigned long tempwriter = 0;
-
-		MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-		unsigned long prevsharer = (globalSharers[classidx])&id;
-		MPI_Win_unlock(workrank, sharerWindow);
-		int n;
-		homenode = getHomenode(lineAddr);
-
-		if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
-			MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-			MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
-				homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
-			MPI_Win_unlock(homenode, sharerWindow);
-		}
-
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-		globalSharers[classidx] |= tempsharer;
-		globalSharers[classidx+1] |= tempwriter;
-		MPI_Win_unlock(workrank, sharerWindow);
-
-		unsigned long offset = getOffset(lineAddr);
-		if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
-			unsigned long ownid = tempsharer&invid; // remove own bit
-			unsigned long owner = invalid_node; // initialize to failsafe value
-			for(n=0; n<numtasks; n++) {
-				if(1ul<<n==ownid) {
-					owner = n; //just get rank...
-					break;
-				}
-			}
-			if(owner != invalid_node) {
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-				MPI_Win_unlock(owner, sharerWindow);
-			}
-
-		}
-
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-		MPI_Get(&cacheData[startidx*pagesize],
-						1,
-						cacheblock,
-						homenode,
-						offset, 1,cacheblock,globalDataWindow[homenode]);
-		MPI_Win_unlock(homenode, globalDataWindow[homenode]);
-
-		if(cacheControl[startidx].tag == GLOBAL_NULL){
-			vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
-			cacheControl[startidx].tag = lineAddr;
-		}
-		else{
-			mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
-		}
-		touchedcache[startidx] = 1;
-		cacheControl[startidx].state = VALID;
-
-		cacheControl[startidx].dirty=CLEAN;
-		sem_post(&loadwaitsem);
+	if(tmptag == lineAddr && tmpstate != INVALID){
 		sem_post(&ibsem);
+		return;
+	}
+
+
+	void * lineptr = (char*)startAddr + lineAddr;
+
+	if(cacheControl[startidx].tag  != lineAddr){
+		if(cacheControl[startidx].tag  != lineAddr){
+			if(pthread_mutex_trylock(&wbmutex) != 0){
+				sem_post(&ibsem);
+				pthread_mutex_lock(&wbmutex);
+				sem_wait(&ibsem);
+			}
+
+			void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
+			if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
+				argo_byte dirty = cacheControl[startidx].dirty;
+				if(dirty == DIRTY){
+					mprotect(tmpptr2,blocksize,PROT_READ);
+					int j;
+					for(j=0; j < CACHELINE; j++){
+						storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
+					}
+				}
+
+				for(i = 0; i < numtasks; i++){
+					if(barwindowsused[i] == 1){
+						MPI_Win_unlock(i, globalDataWindow[i]);
+						barwindowsused[i] = 0;
+					}
+				}
+
+				cacheControl[startidx].state = INVALID;
+				cacheControl[startidx].tag = lineAddr;
+
+				cacheControl[startidx].dirty=CLEAN;
+				vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
+				mprotect(tmpptr2,blocksize,PROT_NONE);
+			}
+			pthread_mutex_unlock(&wbmutex);
+		}
+	}
+
+
+
+	stats.loads++;
+	unsigned long classidx = get_classification_index(lineAddr);
+	unsigned long tempsharer = 0;
+	unsigned long tempwriter = 0;
+
+	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
+	unsigned long prevsharer = (globalSharers[classidx])&id;
+	MPI_Win_unlock(workrank, sharerWindow);
+	int n;
+	homenode = getHomenode(lineAddr);
+
+	if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
+		MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
+		MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
+			homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
+		MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
+		MPI_Win_unlock(homenode, sharerWindow);
+	}
+
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
+	globalSharers[classidx] |= tempsharer;
+	globalSharers[classidx+1] |= tempwriter;
+	MPI_Win_unlock(workrank, sharerWindow);
+
+	unsigned long offset = getOffset(lineAddr);
+	if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
+		unsigned long ownid = tempsharer&invid; // remove own bit
+		unsigned long owner = invalid_node; // initialize to failsafe value
+		for(n=0; n<numtasks; n++) {
+			if(1ul<<n==ownid) {
+				owner = n; //just get rank...
+				break;
+			}
+		}
+		if(owner != invalid_node) {
+			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
+			MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
+			MPI_Win_unlock(owner, sharerWindow);
+		}
 
 	}
-	return nullptr;
+
+	MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
+	MPI_Get(&cacheData[startidx*pagesize],
+					1,
+					cacheblock,
+					homenode,
+					offset, 1,cacheblock,globalDataWindow[homenode]);
+	MPI_Win_unlock(homenode, globalDataWindow[homenode]);
+
+	if(cacheControl[startidx].tag == GLOBAL_NULL){
+		vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
+		cacheControl[startidx].tag = lineAddr;
+	}
+	else{
+		mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
+	}
+	touchedcache[startidx] = 1;
+	cacheControl[startidx].state = VALID;
+
+	cacheControl[startidx].dirty=CLEAN;
+	sem_post(&ibsem);
 }
 
 void * prefetchcacheline(void * x){
@@ -1047,9 +998,7 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	}
 
 	prefetchline = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	loadline = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
 	prefetchtag = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	loadtag = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
 
 	int *workranks = (int *) malloc(sizeof(int)*numtasks);
 	int *procranks = (int *) malloc(sizeof(int)*2);
@@ -1057,7 +1006,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 
 	for(i = 0; i < numtasks; i++){
 		prefetchline[i] = GLOBAL_NULL;
-		loadline[i] = GLOBAL_NULL;
 		workranks[workindex++] = i;
 		procranks[0]=i;
 		procranks[1]=i+1;
@@ -1137,8 +1085,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	tmpcache=lockbuffer;
 	vm::map_memory(tmpcache, pagesize, current_offset, PROT_READ|PROT_WRITE);
 
-	sem_init(&loadwaitsem,0,0);
-	sem_init(&loadstartsem,0,0);
 	sem_init(&prefetchstartsem,0,0);
 	sem_init(&prefetchwaitsem,0,0);
 
@@ -1171,7 +1117,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		cacheControl[j].dirty = CLEAN;
 	}
 
-	pthread_create(&loadthread1,NULL,&loadcacheline,NULL);
 	pthread_create(&loadthread2,NULL,&prefetchcacheline,(void*)NULL);
 	argo_reset_coherence(1);
 }
@@ -1185,7 +1130,6 @@ void argo_finalize(){
 	swdsm_argo_barrier(1);
 	mprotect(startAddr,size_of_all,PROT_WRITE|PROT_READ);
 	MPI_Barrier(MPI_COMM_WORLD);
-	pthread_cancel(loadthread1);
 	pthread_cancel(loadthread2);
 
 	for(i=0; i <numtasks;i++){
@@ -1289,7 +1233,6 @@ void argo_reset_coherence(int n){
 	memset(touchedcache, 0, cachesize);
 
 	for(i=0;i<numtasks;i++){
-		loadline[i] = GLOBAL_NULL;
 		prefetchline[i] = GLOBAL_NULL;
 	}
 	sem_wait(&ibsem);

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -204,12 +204,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
  */
 void storepageDIFF(unsigned long index, unsigned long addr);
 
-/**
- * @brief Loop-function for prefetching pages into global address space
- * @param x unused
- */
-void * prefetchcacheline(void * x);
-
 /*Statistics*/
 /**
  * @brief Clears out all statistics

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -205,12 +205,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
 void storepageDIFF(unsigned long index, unsigned long addr);
 
 /**
- * @brief Loop-function for loading pages into global address space
- * @param x unused
- */
-void * loadcacheline(void * x);
-
-/**
  * @brief Loop-function for prefetching pages into global address space
  * @param x unused
  */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -205,12 +205,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
 void storepageDIFF(unsigned long index, unsigned long addr);
 
 /**
- * @brief Loop-function for writing pages from writebuffer into remote global address space
- * @param x unused
- */
-void *writeloop(void * x);
-
-/**
  * @brief Loop-function for loading pages into global address space
  * @param x unused
  */


### PR DESCRIPTION
This pull requests removes the helper threads for writebuffer writeback, fetching, and prefetching cache entries.

The aim is to reduce complexity of the code base, as these helper threads appear to serve no purpose (other than some POSIX requirements, according to  @magnusandersnorgren, which I believe we likely break at other occasions anyway).

Despite the amount of changes, this pull request aims to not change functionality.
Some previously concurrent events (fetch & prefetch) no longer race and thus code dealing with their ordering has been removed.