### PR TITLE
Ensure that lockWindow and workcomm are freed

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1215,6 +1215,8 @@ void argo_finalize(){
 		MPI_Win_free(&globalDataWindow[i]);
 	}
 	MPI_Win_free(&sharerWindow);
+	MPI_Win_free(&lockWindow);
+	MPI_Comm_free(&workcomm);
 	MPI_Finalize();
 	return;
 }


### PR DESCRIPTION
The latest version of Intel MPI allows master to compile without
this fix, but will fail in MPI_Finalize due to "Device or resource
busy". Ensuring that lockWindow and workcomm are properly freed
before calling MPI_Finalize fixes this issue.