### PR TITLE
handler() variable redundancy/naming cleanup

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -93,18 +93,17 @@ char * barwindowsused;
 sem_t ibsem;
 
 /*Loading and Prefetching*/
-/** @brief Tracking address of pages that should be loaded by loadthread1 */
-unsigned long *loadline;
-/** @brief Tracking cacheindex of pages that should be loaded by loadthread1 */
-unsigned long *loadtag;
+/**
+ * @brief load into cache helper function
+ * @param tag aligned address to load into the cache
+ * @param line cache entry index to use
+ */
+void load_cache_entry(unsigned long tag, unsigned long line);
+
 /** @brief Tracking address of pages that should be loaded by loadthread2 */
 unsigned long *prefetchline;
 /** @brief Tracking cacheindex of pages that should be loaded by loadthread2 */
 unsigned long *prefetchtag;
-/** @brief loadthread1 waits on this to start loading remote pages */
-sem_t loadstartsem;
-/** @brief signalhandler waits on this to complete a transfer */
-sem_t loadwaitsem;
 /** @brief loadthread2 waits on this to start loading remote pages */
 sem_t prefetchstartsem;
 /** @brief signalhandler waits on this to complete a transfer */
@@ -416,17 +415,14 @@ void handler(int sig, siginfo_t *si, void *unused){
 	tag = cacheControl[startIndex].tag;
 
 	if(state == INVALID || (tag != lineAddr && tag != GLOBAL_NULL)){
-		if(loadline[0] == GLOBAL_NULL && prefetchline[0] != GLOBAL_NULL){
+		if(prefetchline[0] != GLOBAL_NULL){
 			if(prefetchline[0] <= startIndex && startIndex < prefetchline[0]+CACHELINE){
-				loadline[0]= (startIndex+CACHELINE)%cachesize;
-				loadtag[0]=lineAddr+pagesize*CACHELINE;
+				load_cache_entry((lineAddr+pagesize*CACHELINE), ((startIndex+CACHELINE)%cachesize));
 			}
 			else{
-				loadline[0]=cacheIndex%cachesize;
-				loadtag[0]=alignedDistrAddr;
+				load_cache_entry(alignedDistrAddr, (cacheIndex%cachesize));
 			}
 
-			sem_post(&loadstartsem);
 			sem_wait(&prefetchwaitsem);
 			prefetchline[0] = GLOBAL_NULL;
 			prefetchtag[0]= GLOBAL_NULL;
@@ -435,41 +431,14 @@ void handler(int sig, siginfo_t *si, void *unused){
 			stats.loadtime+=t2-t1;
 			return;
 		}
-		else if(prefetchline[0] == GLOBAL_NULL && loadline[0] != GLOBAL_NULL){
-			if(loadline[0] <= startIndex && startIndex < loadline[0]+CACHELINE){
-				prefetchline[0]=(startIndex+CACHELINE)%cachesize;
-				prefetchtag[0]=lineAddr+pagesize*CACHELINE;
-			}
-			else{
-				prefetchline[0]=cacheIndex%cachesize;
-				prefetchtag[0]=alignedDistrAddr;
-			}
-
-			sem_post(&prefetchstartsem);
-			sem_wait(&loadwaitsem);
-			loadline[0] = GLOBAL_NULL;
-			loadtag[0]=GLOBAL_NULL;
-			pthread_mutex_unlock(&cachemutex);
-			double t2 = MPI_Wtime();
-			stats.loadtime+=t2-t1;
-			return;
-		}
 		else{
-			loadline[0]=startIndex%cachesize;
-			loadtag[0]=alignedDistrAddr;
-			sem_post(&loadstartsem);
+			load_cache_entry(alignedDistrAddr, (startIndex%cachesize));
 
 #ifdef DUAL_LOAD
 			prefetchline[0]=(startIndex+CACHELINE)%cachesize;
 			prefetchtag[0]=alignedDistrAddr+CACHELINE*pagesize;
 			sem_post(&prefetchstartsem);
-			sem_wait(&loadwaitsem);
-			loadline[0]=GLOBAL_NULL;
-			loadtag[0]=GLOBAL_NULL;
 #else
-			sem_wait(&loadwaitsem);
-			loadline[0]=GLOBAL_NULL;
-			loadtag[0]=GLOBAL_NULL;
 			prefetchline[0]=GLOBAL_NULL;
 			prefetchtag[0]=GLOBAL_NULL;
 
@@ -490,15 +459,6 @@ void handler(int sig, siginfo_t *si, void *unused){
 		stats.loadtime+=t2-t1;
 		return;
 
-	}
-	else if(loadline[0] != GLOBAL_NULL){
-		sem_wait(&loadwaitsem);
-		loadline[0]=GLOBAL_NULL;
-		loadtag[0] =GLOBAL_NULL;
-		pthread_mutex_unlock(&cachemutex);
-		double t2 = MPI_Wtime();
-		stats.loadtime+=t2-t1;
-		return;
 	}
 
 	unsigned long line = startIndex / CACHELINE;
@@ -619,158 +579,149 @@ void write_back_writebuffer() {
 	sem_post(&ibsem);
 }
 
-void * loadcacheline(void * x){
-	UNUSED_PARAM(x);
+void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
 	int i;
 	unsigned long homenode;
 	unsigned long id = 1 << getID();
 	unsigned long invid = ~id;
-	while(1){
-		sem_wait(&loadstartsem);
-		if(loadtag[0]>=size_of_all){//Trying to access/prefetch out of memory
-			sem_post(&loadwaitsem);
-			continue;
-		}
-		homenode = getHomenode(loadtag[0]);
-		unsigned long cacheIndex = loadline[0];
-		if(cacheIndex >= cachesize){
-			printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
-			sem_post(&loadwaitsem);
-			continue;
-		}
-		sem_wait(&ibsem);
+
+	if(loadtag>=size_of_all){//Trying to access/prefetch out of memory
+		return;
+	}
+	homenode = getHomenode(loadtag);
+	unsigned long cacheIndex = loadline;
+	if(cacheIndex >= cachesize){
+		printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
+		return;
+	}
+	sem_wait(&ibsem);
 
 
-		unsigned long pageAddr = loadtag[0];
-		unsigned long blocksize = pagesize*CACHELINE;
-		unsigned long lineAddr = pageAddr/blocksize;
-		lineAddr *= blocksize;
+	unsigned long pageAddr = loadtag;
+	unsigned long blocksize = pagesize*CACHELINE;
+	unsigned long lineAddr = pageAddr/blocksize;
+	lineAddr *= blocksize;
 
-		unsigned long startidx = cacheIndex/CACHELINE;
-		startidx*=CACHELINE;
-		unsigned long end = startidx+CACHELINE;
+	unsigned long startidx = cacheIndex/CACHELINE;
+	startidx*=CACHELINE;
+	unsigned long end = startidx+CACHELINE;
 
-		if(end>=cachesize){
-			end = cachesize;
-		}
+	if(end>=cachesize){
+		end = cachesize;
+	}
 
-		argo_byte tmpstate = cacheControl[startidx].state;
-		unsigned long tmptag = cacheControl[startidx].tag;
+	argo_byte tmpstate = cacheControl[startidx].state;
+	unsigned long tmptag = cacheControl[startidx].tag;
 
-		if(tmptag == lineAddr && tmpstate != INVALID){
-			sem_post(&ibsem);
-			sem_post(&loadwaitsem);
-			continue;
-		}
-
-
-		void * lineptr = (char*)startAddr + lineAddr;
-
-		if(cacheControl[startidx].tag  != lineAddr){
-			if(cacheControl[startidx].tag  != lineAddr){
-				if(pthread_mutex_trylock(&wbmutex) != 0){
-					sem_post(&ibsem);
-					pthread_mutex_lock(&wbmutex);
-					sem_wait(&ibsem);
-				}
-
-				void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
-				if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
-					argo_byte dirty = cacheControl[startidx].dirty;
-					if(dirty == DIRTY){
-						mprotect(tmpptr2,blocksize,PROT_READ);
-						int j;
-						for(j=0; j < CACHELINE; j++){
-							storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
-						}
-					}
-
-					for(i = 0; i < numtasks; i++){
-						if(barwindowsused[i] == 1){
-							MPI_Win_unlock(i, globalDataWindow[i]);
-							barwindowsused[i] = 0;
-						}
-					}
-
-					cacheControl[startidx].state = INVALID;
-					cacheControl[startidx].tag = lineAddr;
-
-					cacheControl[startidx].dirty=CLEAN;
-					vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
-					mprotect(tmpptr2,blocksize,PROT_NONE);
-				}
-				pthread_mutex_unlock(&wbmutex);
-			}
-		}
-
-
-
-		stats.loads++;
-		unsigned long classidx = get_classification_index(lineAddr);
-		unsigned long tempsharer = 0;
-		unsigned long tempwriter = 0;
-
-		MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-		unsigned long prevsharer = (globalSharers[classidx])&id;
-		MPI_Win_unlock(workrank, sharerWindow);
-		int n;
-		homenode = getHomenode(lineAddr);
-
-		if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
-			MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-			MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
-				homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
-			MPI_Win_unlock(homenode, sharerWindow);
-		}
-
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-		globalSharers[classidx] |= tempsharer;
-		globalSharers[classidx+1] |= tempwriter;
-		MPI_Win_unlock(workrank, sharerWindow);
-
-		unsigned long offset = getOffset(lineAddr);
-		if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
-			unsigned long ownid = tempsharer&invid; // remove own bit
-			unsigned long owner = invalid_node; // initialize to failsafe value
-			for(n=0; n<numtasks; n++) {
-				if(1ul<<n==ownid) {
-					owner = n; //just get rank...
-					break;
-				}
-			}
-			if(owner != invalid_node) {
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-				MPI_Win_unlock(owner, sharerWindow);
-			}
-
-		}
-
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-		MPI_Get(&cacheData[startidx*pagesize],
-						1,
-						cacheblock,
-						homenode,
-						offset, 1,cacheblock,globalDataWindow[homenode]);
-		MPI_Win_unlock(homenode, globalDataWindow[homenode]);
-
-		if(cacheControl[startidx].tag == GLOBAL_NULL){
-			vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
-			cacheControl[startidx].tag = lineAddr;
-		}
-		else{
-			mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
-		}
-		touchedcache[startidx] = 1;
-		cacheControl[startidx].state = VALID;
-
-		cacheControl[startidx].dirty=CLEAN;
-		sem_post(&loadwaitsem);
+	if(tmptag == lineAddr && tmpstate != INVALID){
 		sem_post(&ibsem);
+		return;
+	}
+
+
+	void * lineptr = (char*)startAddr + lineAddr;
+
+	if(cacheControl[startidx].tag  != lineAddr){
+		if(cacheControl[startidx].tag  != lineAddr){
+			if(pthread_mutex_trylock(&wbmutex) != 0){
+				sem_post(&ibsem);
+				pthread_mutex_lock(&wbmutex);
+				sem_wait(&ibsem);
+			}
+
+			void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
+			if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
+				argo_byte dirty = cacheControl[startidx].dirty;
+				if(dirty == DIRTY){
+					mprotect(tmpptr2,blocksize,PROT_READ);
+					int j;
+					for(j=0; j < CACHELINE; j++){
+						storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
+					}
+				}
+
+				for(i = 0; i < numtasks; i++){
+					if(barwindowsused[i] == 1){
+						MPI_Win_unlock(i, globalDataWindow[i]);
+						barwindowsused[i] = 0;
+					}
+				}
+
+				cacheControl[startidx].state = INVALID;
+				cacheControl[startidx].tag = lineAddr;
+
+				cacheControl[startidx].dirty=CLEAN;
+				vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
+				mprotect(tmpptr2,blocksize,PROT_NONE);
+			}
+			pthread_mutex_unlock(&wbmutex);
+		}
+	}
+
+
+
+	stats.loads++;
+	unsigned long classidx = get_classification_index(lineAddr);
+	unsigned long tempsharer = 0;
+	unsigned long tempwriter = 0;
+
+	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
+	unsigned long prevsharer = (globalSharers[classidx])&id;
+	MPI_Win_unlock(workrank, sharerWindow);
+	int n;
+	homenode = getHomenode(lineAddr);
+
+	if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
+		MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
+		MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
+			homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
+		MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
+		MPI_Win_unlock(homenode, sharerWindow);
+	}
+
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
+	globalSharers[classidx] |= tempsharer;
+	globalSharers[classidx+1] |= tempwriter;
+	MPI_Win_unlock(workrank, sharerWindow);
+
+	unsigned long offset = getOffset(lineAddr);
+	if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
+		unsigned long ownid = tempsharer&invid; // remove own bit
+		unsigned long owner = invalid_node; // initialize to failsafe value
+		for(n=0; n<numtasks; n++) {
+			if(1ul<<n==ownid) {
+				owner = n; //just get rank...
+				break;
+			}
+		}
+		if(owner != invalid_node) {
+			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
+			MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
+			MPI_Win_unlock(owner, sharerWindow);
+		}
 
 	}
-	return nullptr;
+
+	MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
+	MPI_Get(&cacheData[startidx*pagesize],
+					1,
+					cacheblock,
+					homenode,
+					offset, 1,cacheblock,globalDataWindow[homenode]);
+	MPI_Win_unlock(homenode, globalDataWindow[homenode]);
+
+	if(cacheControl[startidx].tag == GLOBAL_NULL){
+		vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
+		cacheControl[startidx].tag = lineAddr;
+	}
+	else{
+		mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
+	}
+	touchedcache[startidx] = 1;
+	cacheControl[startidx].state = VALID;
+
+	cacheControl[startidx].dirty=CLEAN;
+	sem_post(&ibsem);
 }
 
 void * prefetchcacheline(void * x){
@@ -1047,9 +998,7 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	}
 
 	prefetchline = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	loadline = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
 	prefetchtag = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
-	loadtag = (unsigned long *) malloc(sizeof(unsigned long)*numtasks);
 
 	int *workranks = (int *) malloc(sizeof(int)*numtasks);
 	int *procranks = (int *) malloc(sizeof(int)*2);
@@ -1057,7 +1006,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 
 	for(i = 0; i < numtasks; i++){
 		prefetchline[i] = GLOBAL_NULL;
-		loadline[i] = GLOBAL_NULL;
 		workranks[workindex++] = i;
 		procranks[0]=i;
 		procranks[1]=i+1;
@@ -1137,8 +1085,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	tmpcache=lockbuffer;
 	vm::map_memory(tmpcache, pagesize, current_offset, PROT_READ|PROT_WRITE);
 
-	sem_init(&loadwaitsem,0,0);
-	sem_init(&loadstartsem,0,0);
 	sem_init(&prefetchstartsem,0,0);
 	sem_init(&prefetchwaitsem,0,0);
 
@@ -1171,7 +1117,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		cacheControl[j].dirty = CLEAN;
 	}
 
-	pthread_create(&loadthread1,NULL,&loadcacheline,NULL);
 	pthread_create(&loadthread2,NULL,&prefetchcacheline,(void*)NULL);
 	argo_reset_coherence(1);
 }
@@ -1185,7 +1130,6 @@ void argo_finalize(){
 	swdsm_argo_barrier(1);
 	mprotect(startAddr,size_of_all,PROT_WRITE|PROT_READ);
 	MPI_Barrier(MPI_COMM_WORLD);
-	pthread_cancel(loadthread1);
 	pthread_cancel(loadthread2);
 
 	for(i=0; i <numtasks;i++){
@@ -1289,7 +1233,6 @@ void argo_reset_coherence(int n){
 	memset(touchedcache, 0, cachesize);
 
 	for(i=0;i<numtasks;i++){
-		loadline[i] = GLOBAL_NULL;
 		prefetchline[i] = GLOBAL_NULL;
 	}
 	sem_wait(&ibsem);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -3,6 +3,8 @@
  * @brief This file implements the MPI-backend of ArgoDSM
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
+#include<cstddef>
+
 #include "signal/signal.hpp"
 #include "virtual_memory/virtual_memory.hpp"
 #include "swdsm.h"
@@ -295,14 +297,14 @@ void init_mpi_cacheblock(void){
 	MPI_Type_commit(&cacheblock);
 }
 
-unsigned long alignAddr(unsigned long addr){
-	unsigned long mod = addr % pagesize;
-	if(addr % pagesize != 0){
-		addr = addr - mod;
-	}
-	addr /= pagesize;
-	addr *= pagesize;
-	return addr;
+/**
+ * @brief align an offset into a memory region to the beginning of its size block
+ * @param offset the pointer or offset
+ * @param size the size of each block
+ * @return the beginning of the block of size size where offset is located
+ */
+inline std::size_t align_backwards(std::size_t offset, std::size_t size) {
+	return (offset / size) * size;
 }
 
 void handler(int sig, siginfo_t *si, void *unused){
@@ -312,19 +314,18 @@ void handler(int sig, siginfo_t *si, void *unused){
 
 	unsigned long tag;
 	argo_byte owner,state;
-	unsigned long distrAddr =  (unsigned long)((unsigned long)(si->si_addr) - (unsigned long)(startAddr));
+	/* compute offset in distributed memory in bytes, always positive */
+	std::size_t access_offset = static_cast<char*>(si->si_addr) - static_cast<char*>(startAddr);
 
-	unsigned long alignedDistrAddr = alignAddr(distrAddr);
-	unsigned long remCACHELINE = alignedDistrAddr % (CACHELINE*pagesize);
-	unsigned long lineAddr = alignedDistrAddr - remCACHELINE;
-	unsigned long classidx = get_classification_index(lineAddr);
+	/* align access offset to cacheline */
+	std::size_t aligned_access_offset = align_backwards(access_offset, CACHELINE*pagesize);
+	unsigned long classidx = get_classification_index(aligned_access_offset);
 
-	unsigned long * localAlignedAddr = (unsigned long *)((char*)startAddr + lineAddr);
-	unsigned long startIndex = getCacheIndex(lineAddr);
-	alignedDistrAddr = lineAddr;
-
-	unsigned long homenode = getHomenode(lineAddr);
-	unsigned long offset = getOffset(lineAddr);
+	/* compute start pointer of cacheline. char* has byte-wise arithmetics */
+	char* aligned_access_ptr = reinterpret_cast<char*>(startAddr) + aligned_access_offset;
+	unsigned long startIndex = getCacheIndex(aligned_access_offset);
+	unsigned long homenode = getHomenode(aligned_access_offset);
+	unsigned long offset = getOffset(aligned_access_offset);
 	unsigned long id = 1 << getID();
 	unsigned long invid = ~id;
 
@@ -364,7 +365,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 			}
 			/* set page to permit reads and map it to the page cache */
 			/** @todo Set cache offset to a variable instead of calculating it here */
-			vm::map_memory(localAlignedAddr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ);
+			vm::map_memory(aligned_access_ptr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ);
 
 		}
 		else{
@@ -400,7 +401,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 				}
 			}
 			/* set page to permit read/write and map it to the page cache */
-			vm::map_memory(localAlignedAddr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ|PROT_WRITE);
+			vm::map_memory(aligned_access_ptr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ|PROT_WRITE);
 
 		}
 		sem_post(&ibsem);
@@ -411,10 +412,10 @@ void handler(int sig, siginfo_t *si, void *unused){
 	state  = cacheControl[startIndex].state;
 	tag = cacheControl[startIndex].tag;
 
-	if(state == INVALID || (tag != lineAddr && tag != GLOBAL_NULL)){
-		load_cache_entry(alignedDistrAddr, (startIndex%cachesize));
+	if(state == INVALID || (tag != aligned_access_offset && tag != GLOBAL_NULL)) {
+		load_cache_entry(aligned_access_offset, (startIndex%cachesize));
 #ifdef DUAL_LOAD
-		prefetch_cache_entry((alignedDistrAddr+CACHELINE*pagesize), ((startIndex+CACHELINE)%cachesize));
+		prefetch_cache_entry((aligned_access_offset+CACHELINE*pagesize), ((startIndex+CACHELINE)%cachesize));
 #endif
 		pthread_mutex_unlock(&cachemutex);
 		double t2 = MPI_Wtime();
@@ -483,11 +484,10 @@ void handler(int sig, siginfo_t *si, void *unused){
 		}
 	}
 	sem_post(&ibsem);
-	unsigned char * real = (unsigned char *)(localAlignedAddr);
 	unsigned char * copy = (unsigned char *)(pagecopy + line*pagesize);
-	memcpy(copy,real,CACHELINE*pagesize);
+	memcpy(copy,aligned_access_ptr,CACHELINE*pagesize);
 	addToWriteBuffer(startIndex);
-	mprotect(localAlignedAddr, pagesize*CACHELINE,PROT_WRITE|PROT_READ);
+	mprotect(aligned_access_ptr, pagesize*CACHELINE,PROT_WRITE|PROT_READ);
 	pthread_mutex_unlock(&cachemutex);
 	double t2 = MPI_Wtime();
 	stats.storetime += t2-t1;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -204,12 +204,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
  */
 void storepageDIFF(unsigned long index, unsigned long addr);
 
-/**
- * @brief Loop-function for prefetching pages into global address space
- * @param x unused
- */
-void * prefetchcacheline(void * x);
-
 /*Statistics*/
 /**
  * @brief Clears out all statistics

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -205,12 +205,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
 void storepageDIFF(unsigned long index, unsigned long addr);
 
 /**
- * @brief Loop-function for loading pages into global address space
- * @param x unused
- */
-void * loadcacheline(void * x);
-
-/**
  * @brief Loop-function for prefetching pages into global address space
  * @param x unused
  */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -205,12 +205,6 @@ void addToWriteBuffer(unsigned long cacheIndex);
 void storepageDIFF(unsigned long index, unsigned long addr);
 
 /**
- * @brief Loop-function for writing pages from writebuffer into remote global address space
- * @param x unused
- */
-void *writeloop(void * x);
-
-/**
  * @brief Loop-function for loading pages into global address space
  * @param x unused
  */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -319,12 +319,6 @@ unsigned long getCacheIndex(unsigned long addr);
  * @param addr Address in the global address space
  * @return addr rounded down to nearest multiple of pagesize
  */
-unsigned long alignAddr(unsigned long addr);
-/**
- * @brief Gives homenode for a given address
- * @param addr Address in the global address space
- * @return Process ID of the node backing the memory containing addr
- */
 unsigned long getHomenode(unsigned long addr);
 /**
  * @brief Gets the offset of an address on the local nodes part of the global memory


### PR DESCRIPTION
This patch cleans up some redundant variables and confusing naming in the segfault handler function.