### PR TITLE
handler() variable redundancy/naming cleanup

### DIFF
--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -315,12 +315,6 @@ unsigned long isPowerOf2(unsigned long x);
  */
 unsigned long getCacheIndex(unsigned long addr);
 /**
- * @brief Returns an address correspongint to the page addr is addressing
- * @param addr Address in the global address space
- * @return addr rounded down to nearest multiple of pagesize
- */
-unsigned long alignAddr(unsigned long addr);
-/**
  * @brief Gives homenode for a given address
  * @param addr Address in the global address space
  * @return Process ID of the node backing the memory containing addr


### PR DESCRIPTION
This patch cleans up some redundant variables and confusing naming in the segfault handler function.

Due to my inability to use github nicely, this replaces #34