### PR TITLE
build shared libraries

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -130,7 +130,7 @@ make install
 
 This step will copy the final ArgoDSM include files to `/usr/local/include` and
 libraries to `/usr/local/lib/`. You can choose a different path above if you
-want, but remember to either set `INCLUDE_PATH`, `LIBRARY_PATH`, and
+want, but remember to either set `LIBRARY_PATH`, `INCLUDE_PATH`, and
 `LD_LIBRARY_PATH` accordingly, or provide the correct paths (`-L`, `-I`, and
 `-Wl,-rpath,`) to your compiler when compiling applications for ArgoDSM.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ respectively are required.
 
 ### Building ArgoDSM
 
+Note: adjust the below commands to your needs, especially `CMAKE_INSTALL_PREFIX`.
+
 ``` bash
 git clone https://github.com/etascale/argodsm.git
 cd argodsm
@@ -40,15 +42,17 @@ mv googletest-release-1.7.0 gtest-1.7.0
 cd ..
 mkdir build
 cd build
-cmake -DARGO_BACKEND_MPI=ON        \
-      -DARGO_BACKEND_SINGLENODE=ON \
-      -DARGO_TESTS=ON              \
-      -DBUILD_DOCUMENTATION=ON     \
-      -DCMAKE_CXX_COMPILER=mpic++  \
-      -DCMAKE_C_COMPILER=mpicc     \
+cmake -DARGO_BACKEND_MPI=ON              \
+      -DARGO_BACKEND_SINGLENODE=ON       \
+      -DARGO_TESTS=ON                    \
+      -DBUILD_DOCUMENTATION=ON           \
+      -DCMAKE_CXX_COMPILER=mpic++        \
+      -DCMAKE_C_COMPILER=mpicc           \
+      -DCMAKE_INSTALL_PREFIX=/usr/local/ \
       ../
 make
 make test
+make install
 ```
 
 Initially, you need to get the ArgoDSM sources. If you already have a tarball,
@@ -86,16 +90,18 @@ the `ccmake` tool. The difference is that the first one accepts all the build
 options as command line arguments, while the second one works interactively.
 Below is an example call to `cmake` with all the recommended command line
 arguments. If you plan on contributing to the ArgoDSM source code, you should
-also enable the `ARGO_DEBUG` option. After generating the makefiles, then just
-build the library and executables with a simple make command.
+also enable the `ARGO_DEBUG` option. Remember to change `CMAKE_INSTALL_PREFIX`
+to a path that you have write access to. After generating the makefiles proceed
+to building the library and executables with a simple make command.
 
 ``` bash
-cmake -DARGO_BACKEND_MPI=ON        \
-      -DARGO_BACKEND_SINGLENODE=ON \
-      -DARGO_TESTS=ON              \
-      -DBUILD_DOCUMENTATION=ON     \
-      -DCMAKE_CXX_COMPILER=mpic++  \
-      -DCMAKE_C_COMPILER=mpicc     \
+cmake -DARGO_BACKEND_MPI=ON              \
+      -DARGO_BACKEND_SINGLENODE=ON       \
+      -DARGO_TESTS=ON                    \
+      -DBUILD_DOCUMENTATION=ON           \
+      -DCMAKE_CXX_COMPILER=mpic++        \
+      -DCMAKE_C_COMPILER=mpicc           \
+      -DCMAKE_INSTALL_PREFIX=/usr/local/ \
       ../
 make
 ```
@@ -117,6 +123,16 @@ Keep in mind that currently even the MPI tests are run on a single node without
 invoking `mpirun`. After running the previous command, you should also run the
 tests with at least 4 nodes. To learn how to run the MPI tests on multiple
 nodes, proceed to the next section.
+
+``` bash
+make install
+```
+
+This step will copy the final ArgoDSM include files to `/usr/local/include` and
+libraries to `/usr/local/lib/`. You can choose a different path above if you
+want, but remember to either set `INCLUDE_PATH`, `LIBRARY_PATH`, and
+`LD_LIBRARY_PATH` accordingly, or provide the correct paths (`-L`, `-I`, and
+`-Wl,-rpath,`) to your compiler when compiling applications for ArgoDSM.
 
 ### Running the Applications
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -176,17 +176,18 @@ The final result of all the changes is this:
 {% include argo_example.cpp %}
 ```
 
-We can now compile the application. We assume that `${ARGO_INSTALL_DIRECTORY}` is
-where you installed ArgoDSM. If the ArgoDSM files are already in your
-`(LD_)LIBRARY_PATH` and include path, you can skip the `-L...` and `-I...`
-switches. If you have no idea what we are talking about, you should ask your
-system administrator.
+We can now compile the application. We assume that `${ARGO_INSTALL_DIRECTORY}`
+is where you installed ArgoDSM. If the ArgoDSM files are already in your
+`LIBRARY_PATH`, `INCLUDE_PATH`, and `LD_LIBRARY_PATH`, you can skip the
+`-L...`, `-I...`, and `-Wl,-rpath,...` switches. If you have no idea what we
+are talking about, you should ask your system administrator.
 
 ``` bash
-mpic++ -O3 -std=c++11 -o argo_example   \
-	-L${ARGO_INSTALL_DIRECTORY}/lib     \
-	-I${ARGO_INSTALL_DIRECTORY}/include \
-	argo_example.cpp -largo -largobackend-mpi
+mpic++ -O3 -std=c++11 -o argo_example            \
+       -L${ARGO_INSTALL_DIRECTORY}/lib           \
+       -I${ARGO_INSTALL_DIRECTORY}/include       \
+       -Wl,-rpath,${ARGO_INSTALL_DIRECTORY}/lib  \
+       argo_example.cpp -largo -largobackend-mpi
 ```
 
 This should produce an executable file that can be run with MPI. For

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(src ${vm_sources})
 endforeach(src)
 
 # add the frontend library
-add_library(argo ${argo_sources})
+add_library(argo SHARED ${argo_sources})
 
 option(ARGO_USE_LIBNUMA
 	"Use libnuma to determine NUMA structure within ArgoDSM" ON)

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
-add_library(argobackend-mpi mpi.cpp swdsm.cpp)
+add_library(argobackend-mpi SHARED mpi.cpp swdsm.cpp)
 
 install(TARGETS argobackend-mpi
 	COMPONENT "Runtime"

--- a/src/backend/singlenode/CMakeLists.txt
+++ b/src/backend/singlenode/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
-add_library(argobackend-singlenode singlenode.cpp)
+add_library(argobackend-singlenode SHARED singlenode.cpp)
 
 install(TARGETS argobackend-singlenode
 	COMPONENT "Runtime"


### PR DESCRIPTION
When using VM_SHM, ArgoDSM requires to link against rt, which we already specify in `CMakeLists.txt`.
However, for static libraries this is not recorded in the final library file, while for dynamically linked libraries it is. This means using ArgoDSM becomes easier if we build only shared libraries. It also avoids similar issues in the future.

To track that compiling works as specified in our tutorial, a corresponding check has been added to jenkins.

Please only approve this PR after testing it a bit, we do not want to break user code with this change.

Fixes #16 