### PR TITLE
Run tests for the MPI backend through mpirun

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 include_directories("${PROJECT_SOURCE_DIR}/src")
 add_subdirectory(src)
 
+set(ARGO_TESTS_NPROCS 2 CACHE STRING "Number of ArgoDSM nodes to execute with make test")
+if(NOT ARGO_TESTS_NPROCS MATCHES "^[1-8]$")
+	message(FATAL_ERROR "ARGO_TESTS_NPROCS must be a number from 1 to 8.")
+endif()
+
 option(ARGO_TESTS
 	"Build tests for ArgoDSM" ON)
 if(ARGO_TESTS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,10 +119,15 @@ library, as well as *exactly* one of the backend libraries.
 make test
 ```
 
-Keep in mind that currently even the MPI tests are run on a single node without
-invoking `mpirun`. After running the previous command, you should also run the
-tests with at least 4 nodes. To learn how to run the MPI tests on multiple
-nodes, proceed to the next section.
+This step executes the ArgoDSM tests. Tests for the MPI backend are run on two
+ArgoDSM software nodes by default. This number can be changed through setting
+the `ARGO_TESTS_NPROCS` CMake option to any number from 1 to 8. Keep in mind
+that some MPI distributions may not allow executing more processes than the
+number of physical cores in the system. Please note that some issues are only
+encountered when running with more than two ArgoDSM nodes or on multiple
+hardware nodes. For this reason it is highly recommended to run the MPI tests
+on at least four hardware nodes when possible. Refer to the next section to
+learn how to run applications on multiple hardware nodes.
 
 ``` bash
 make install

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,8 +14,13 @@ function(forall_backends target)
 			OUTPUT_NAME "${target}"
 			RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${BACKEND}"
 			)
+		if(${BACKEND} STREQUAL "mpi")
+			set(TEST_PARAMETERS mpirun -n ${ARGO_TESTS_NPROCS})
+		else()
+			set(TEST_PARAMETERS "")
+		endif()
 		add_test(${target}-${BACKEND}
-			${CMAKE_BINARY_DIR}/bin/${BACKEND}/${target})
+			${TEST_PARAMETERS} ${CMAKE_BINARY_DIR}/bin/${BACKEND}/${target})
 	endforeach(BACKEND)
 endfunction(forall_backends)
 

--- a/tests/allocators.cpp
+++ b/tests/allocators.cpp
@@ -17,11 +17,10 @@
 #include "backend/backend.hpp"
 #include "gtest/gtest.h"
 
-//std::size_t size = 1<<30;
-/**
- * @brief ArgoDSM Memory Size
- */
-long size = 1073741824L;
+/** @brief ArgoDSM memory size */
+constexpr std::size_t size = 1<<30;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size/8;
 
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
@@ -480,7 +479,7 @@ TEST_F(AllocatorTest, NewInitialization) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -24,6 +24,9 @@ using global_intptr = typename argo::data_distribution::global_ptr<int*>;
 
 /** @brief ArgoDSM memory size */
 constexpr std::size_t size = 1<<20; // 1MB
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size;
+
 /** @brief Time to wait before assuming a deadlock has occured */
 constexpr std::chrono::minutes deadlock_threshold{1}; // Choosen for no reason
 
@@ -386,7 +389,7 @@ TEST_F(backendTest, atomicFetchAddPointer) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/barrier.cpp
+++ b/tests/barrier.cpp
@@ -12,6 +12,9 @@
 
 /** @brief ArgoDSM memory size */
 constexpr std::size_t size = 1<<30;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size/8;
+
 /** @brief Maximum number of threads to run in the stress tests */
 constexpr int max_threads = 128;
 
@@ -86,7 +89,7 @@ INSTANTIATE_TEST_CASE_P(threadCount, barrierTest, ::testing::Range(0, max_thread
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/lock.cpp
+++ b/tests/lock.cpp
@@ -22,8 +22,11 @@
 #include <limits.h>
 #include "gtest/gtest.h"
 
-/** @brief Amount of memory initialized by ArgoDSM */
-size_t size = 1<<20;
+/** @brief ArgoDSM memory size */
+constexpr std::size_t size = 1<<20;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size;
+
 /** @brief number of threads to spawn for some of the tests */
 constexpr int nThreads = 16;
 /** @brief number of itereations to run for some of the tests */
@@ -257,7 +260,7 @@ TEST_F(LockTest,StressCohortLock) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/omp.cpp
+++ b/tests/omp.cpp
@@ -21,7 +21,10 @@
 #define ITER 10
 
 /** @brief ArgoDSM memory size */
-std::size_t size = 1<<30;
+constexpr std::size_t size = 1<<30;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size/8;
+
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
 
@@ -91,7 +94,7 @@ TEST_F(ompTest, WriteAndRead) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -17,7 +17,10 @@
 #include "gtest/gtest.h"
 
 /** @brief ArgoDSM memory size */
-std::size_t size = 1<<30;
+constexpr std::size_t size = 1<<30;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size/8;
+
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
 
@@ -59,7 +62,7 @@ TEST_F(PrefetchTest, OutOfBounds) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/stlallocation.cpp
+++ b/tests/stlallocation.cpp
@@ -12,6 +12,8 @@
 
 /** @brief ArgoDSM memory size */
 constexpr std::size_t size = 1<<30;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size/8;
 
 /**
  * @brief Class for the gtests fixture tests. Will reset the allocators to a clean state for every test
@@ -90,7 +92,7 @@ TEST_F(cppTest, simpleVector) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/trivial.cpp
+++ b/tests/trivial.cpp
@@ -9,7 +9,10 @@
 #include "gtest/gtest.h"
 
 /** @brief ArgoDSM memory size */
-std::size_t size = 1<<28;
+constexpr std::size_t size = 1<<20;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size;
+
 namespace mem = argo::mempools;
 
 /**
@@ -27,7 +30,7 @@ TEST(trivialTest, alwaysPassl) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();

--- a/tests/uninitialized.cpp
+++ b/tests/uninitialized.cpp
@@ -9,7 +9,10 @@
 #include "gtest/gtest.h"
 
 /** @brief ArgoDSM memory size */
-std::size_t size = 1<<28;
+constexpr std::size_t size = 1<<28;
+/** @brief ArgoDSM cache size */
+constexpr std::size_t cache_size = size/2;
+
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
 
@@ -50,7 +53,7 @@ TEST_F(UninitializedAccessTest, ReadUninitializedSinglenode) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	argo::init(size);
+	argo::init(size, cache_size);
 	::testing::InitGoogleTest(&argc, argv);
 	auto res = RUN_ALL_TESTS();
 	argo::finalize();


### PR DESCRIPTION
This pull request ensures that all tests for the MPI backend are run through mpirun. By default, each test is run using _two_ ArgoDSM software nodes. This can be changed by setting the `ARGO_TESTS_NPROCS` CMake option to any number between 1 and 8.

The purpose of this is change is to expose the whole backend during tests, as running on at least two nodes is required in order to ensure that the `handler()`, `load_cache_entry()` and `prefetch_cache_entry()` are fully executed at some point.

In order to still be able to run `make test` on most machines using multiple software nodes, the ArgoDSM cache size for the tests using 256MB or more memory is significantly reduced in order to avoid allocating too much local memory for the cache. Additionally, in order to avoid cluttering the output file (`Testing/Temporary/LastTest.log`), output is suppressed for all nodes besides node 0.