### PR TITLE
Improved loading and prefetching functionality

### DIFF
--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -80,6 +80,15 @@ namespace argo {
 		 */
 		std::size_t global_size();
 
+		/**
+		 * @brief Check if a an address is cached or node local
+		 * @param addr the address to verify cache status on
+		 * @return True if the page is either cached on the node
+		 * or locally backed on the node, otherwise false.
+		 * @warning THIS IS FOR TESTING, DO NOT USE
+		 * @todo THIS SHOULD BE BAKED IN TO A CACHE CLASS
+		 */
+		bool is_cached(void* addr);
 
 		/**
 		 * @brief global memory space address

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -213,7 +213,8 @@ namespace argo {
 			/**
 			 * @brief Backend internal type erased atomic store function
 			 * @param desired Pointer to the object that holds the desired value
-			 * @param size == sizeof(*desired)
+			 * @param count Number of element from desired to store
+			 * @param size size of each element in desired
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa store to public window section
@@ -222,11 +223,13 @@ namespace argo {
 			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
 			 */
 			void _store_public_owners_dir(const void* desired,
-				const std::size_t size, const std::size_t rank, const std::size_t disp);
+				const std::size_t size, const std::size_t count,
+				const std::size_t rank, const std::size_t disp);
 
 			/**
 			 * @brief Backend internal type erased atomic store function
 			 * @param desired The desired value to be stored
+			 * @param count Number of element from desired to store
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa store to private window section
@@ -235,7 +238,7 @@ namespace argo {
 			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
 			 */
 			void _store_local_owners_dir(const std::size_t* desired,
-				const std::size_t rank, const std::size_t disp);
+				const std::size_t count, const std::size_t rank, const std::size_t disp);
 
 			/**
 			 * @brief Backend internal type erased atomic store function
@@ -264,7 +267,8 @@ namespace argo {
 			/**
 			 * @brief Backend internal type erased atomic load function
 			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
-			 * @param size == sizeof(*output_buffer)
+			 * @param size Size of an element to load
+			 * @param count Number of element to load
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa load from public window section
@@ -273,11 +277,13 @@ namespace argo {
 			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
 			 */
 			void _load_public_owners_dir(void* output_buffer,
-				const std::size_t size, const std::size_t rank, const std::size_t disp);
+				const std::size_t size, const std::size_t count,
+				const std::size_t rank, const std::size_t disp);
 
 			/**
 			 * @brief Backend internal type erased atomic load function
 			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
+			 * @param count Number of element to load
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa load from private window section
@@ -286,7 +292,7 @@ namespace argo {
 			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
 			 */
 			void _load_local_owners_dir(void* output_buffer,
-				const std::size_t rank, const std::size_t disp);
+				const std::size_t count, const std::size_t rank, const std::size_t disp);
 				
 			/**
 			 * @brief Backend internal type erased atomic load function

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -222,8 +222,8 @@ namespace argo {
 			/**
 			 * @brief Backend internal type erased atomic store function
 			 * @param desired Pointer to the object that holds the desired value
-			 * @param count Number of element from desired to store
-			 * @param size size of each element in desired
+			 * @param count Number of elements from desired to store
+			 * @param size Size of each element in desired
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa store to public window section
@@ -238,7 +238,7 @@ namespace argo {
 			/**
 			 * @brief Backend internal type erased atomic store function
 			 * @param desired The desired value to be stored
-			 * @param count Number of element from desired to store
+			 * @param count Number of elements from desired to store
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa store to private window section
@@ -277,7 +277,7 @@ namespace argo {
 			 * @brief Backend internal type erased atomic load function
 			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
 			 * @param size Size of an element to load
-			 * @param count Number of element to load
+			 * @param count Number of elements to load
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa load from public window section
@@ -292,7 +292,7 @@ namespace argo {
 			/**
 			 * @brief Backend internal type erased atomic load function
 			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
-			 * @param count Number of element to load
+			 * @param count Number of elements to load
 			 * @param rank Rank of target window to which operation will be performed
 			 * @param disp Displacement from start of window to beginning of target buffer
 			 * @sa load from private window section

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -227,19 +227,20 @@ namespace argo {
 			}
 
 			void _store_public_owners_dir(const void* desired,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
+					const std::size_t size, const std::size_t count,
+					const std::size_t rank, const std::size_t disp) {
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-				MPI_Put(desired, 3, t_type, rank, disp, 3, t_type, owners_dir_window);
+				MPI_Put(desired, count, t_type, rank, disp, count, t_type, owners_dir_window);
 				MPI_Win_unlock(rank, owners_dir_window);
 			}
 
 			void _store_local_owners_dir(const std::size_t* desired,
-					const std::size_t rank, const std::size_t disp) {
+					const std::size_t count, const std::size_t rank, const std::size_t disp) {
 				// Perform the store operation
 				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-				std::copy(desired, desired + 3, &global_owners_dir[disp]);
+				std::copy(desired, desired + count, &global_owners_dir[disp]);
 				MPI_Win_unlock(rank, owners_dir_window);
 			}
 
@@ -264,19 +265,22 @@ namespace argo {
 			}
 
 			void _load_public_owners_dir(void* output_buffer,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
+					const std::size_t size, const std::size_t count,
+					const std::size_t rank, const std::size_t disp) {
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the load operation
 				MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
-				MPI_Get(output_buffer, 3, t_type, rank, disp, 3, t_type, owners_dir_window);
+				MPI_Get(output_buffer, count, t_type, rank, disp, count, t_type, owners_dir_window);
 				MPI_Win_unlock(rank, owners_dir_window);
 			}
 
 			void _load_local_owners_dir(void* output_buffer,
-					const std::size_t rank, const std::size_t disp) {
+					const std::size_t count, const std::size_t rank, const std::size_t disp) {
 				// Perform the load operation
 				MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
-				*(static_cast<std::size_t*>(output_buffer)) = global_owners_dir[disp];
+				std::copy(&global_owners_dir[disp],
+						&global_owners_dir[disp+count],
+						static_cast<std::size_t*>(output_buffer));
 				MPI_Win_unlock(rank, owners_dir_window);
 			}
 

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -176,6 +176,11 @@ namespace argo {
 			return argo_get_global_size();
 		}
 
+		bool is_cached(void* addr) {
+			return _is_cached(reinterpret_cast<std::size_t>(addr));
+		}
+
+
 		void finalize() {
 			argo_finalize();
 		}

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -4,6 +4,7 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 #include<cstddef>
+#include<vector>
 
 #include "env/env.hpp"
 #include "signal/signal.hpp"
@@ -17,13 +18,6 @@ namespace vm = argo::virtual_memory;
 namespace sig = argo::signal;
 namespace env = argo::env;
 
-/*Threads*/
-/** @brief Thread loads data into cache */
-pthread_t loadthread1;
-/** @brief Thread loads data into cache with an overlapping request (some parts are done in parallel) */
-pthread_t loadthread2;
-/** @brief Thread writes data remotely if parts of writebuffer */
-pthread_t writethread;
 /** @brief For matching threads to more sensible thread IDs */
 pthread_t tid[NUM_THREADS] = {0};
 
@@ -92,18 +86,10 @@ sem_t ibsem;
 /*Loading and Prefetching*/
 /**
  * @brief load into cache helper function
- * @param tag aligned address to load into the cache
- * @param line cache entry index to use
+ * @param aligned_access_offset memory offset to load into the cache
+ * @pre aligned_access_offset must be aligned as CACHELINE*pagesize
  */
-void load_cache_entry(unsigned long tag, unsigned long line);
-
-/**
- * @brief prefetch into cache helper function, which duplicates a lot of code
- * @param tag aligned address to prefetch into the cache
- * @param line cache entry index to use
- * @todo this function duplicates a lot of code from load_cache_entry(), this should be fixed
- */
-void prefetch_cache_entry(unsigned long tag, unsigned long line);
+void load_cache_entry(std::size_t aligned_access_offset);
 
 /*Global lock*/
 /** @brief  Local flags we spin on for the global lock*/
@@ -354,10 +340,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 	tag = cacheControl[startIndex].tag;
 
 	if(state == INVALID || (tag != aligned_access_offset && tag != GLOBAL_NULL)) {
-		load_cache_entry(aligned_access_offset, (startIndex%cachesize));
-#if DUAL_LOAD == 1
-		prefetch_cache_entry((aligned_access_offset+CACHELINE*pagesize), ((startIndex+CACHELINE)%cachesize));
-#endif
+		load_cache_entry(aligned_access_offset);
 		pthread_mutex_unlock(&cachemutex);
 		double t2 = MPI_Wtime();
 		stats.loadtime+=t2-t1;
@@ -470,280 +453,235 @@ unsigned long getOffset(unsigned long addr, char cloc){
 	return offset;
 }
 
-void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
-	int i;
-	unsigned long homenode;
-	unsigned long id = 1 << getID();
-	unsigned long invid = ~id;
+void load_cache_entry(std::size_t aligned_access_offset) {
 
-	if(loadtag>=size_of_all){//Trying to access/prefetch out of memory
+	if(aligned_access_offset >= size_of_all){ // Not an ArgoDSM address, do not handle this
 		return;
 	}
-	homenode = getHomenode(loadtag);
-	unsigned long cacheIndex = loadline;
-	if(cacheIndex >= cachesize){
-		printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
-		return;
-	}
+
+	/* Assign node bit IDs */
+	const std::uintptr_t node_id_bit = 1 << getID();
+	const std::uintptr_t node_id_inv_bit = ~node_id_bit;
+
+	/* Calculate start values and store some parameters */
+	const std::size_t block_size = pagesize*CACHELINE;
+	const std::size_t cache_index = getCacheIndex(aligned_access_offset);
+	const std::size_t start_index = align_backwards(cache_index, CACHELINE);
+	std::size_t end_index = start_index+CACHELINE;
+	const std::size_t load_node = getHomenode(aligned_access_offset);
+
 	sem_wait(&ibsem);
 
-
-	unsigned long pageAddr = loadtag;
-	unsigned long blocksize = pagesize*CACHELINE;
-	unsigned long lineAddr = pageAddr/blocksize;
-	lineAddr *= blocksize;
-
-	unsigned long startidx = cacheIndex/CACHELINE;
-	startidx*=CACHELINE;
-	unsigned long end = startidx+CACHELINE;
-
-	if(end>=cachesize){
-		end = cachesize;
-	}
-
-	argo_byte tmpstate = cacheControl[startidx].state;
-	unsigned long tmptag = cacheControl[startidx].tag;
-
-	if(tmptag == lineAddr && tmpstate != INVALID){
+	/* Return if requested cache entry is already up to date. */
+	if(cacheControl[start_index].tag == aligned_access_offset &&
+			cacheControl[start_index].state != INVALID){
 		sem_post(&ibsem);
 		return;
 	}
 
-
-	void * lineptr = (char*)startAddr + lineAddr;
-
-	if(cacheControl[startidx].tag  != lineAddr){
-		if(cacheControl[startidx].tag  != lineAddr){
-
-			void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
-			if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
-				argo_byte dirty = cacheControl[startidx].dirty;
-				if(dirty == DIRTY){
-					mprotect(tmpptr2,blocksize,PROT_READ);
-					int j;
-					for(j=0; j < CACHELINE; j++){
-						storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
-					}
-					argo_write_buffer->erase(startidx);
-				}
-
-				for(i = 0; i < numtasks; i++){
-					if(barwindowsused[i] == 1){
-						MPI_Win_unlock(i, globalDataWindow[i]);
-						barwindowsused[i] = 0;
-					}
-				}
-
-				cacheControl[startidx].state = INVALID;
-				cacheControl[startidx].tag = lineAddr;
-
-				cacheControl[startidx].dirty=CLEAN;
-				vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
-				mprotect(tmpptr2,blocksize,PROT_NONE);
-			}
-		}
-	}
-
-
-
-	stats.loads++;
-	unsigned long classidx = get_classification_index(lineAddr);
-	unsigned long tempsharer = 0;
-	unsigned long tempwriter = 0;
-
-	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-	unsigned long prevsharer = (globalSharers[classidx])&id;
-	MPI_Win_unlock(workrank, sharerWindow);
-	int n;
-	homenode = getHomenode(lineAddr);
-
-	if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-		MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
-			homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-		MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
-		MPI_Win_unlock(homenode, sharerWindow);
-	}
-
-	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-	globalSharers[classidx] |= tempsharer;
-	globalSharers[classidx+1] |= tempwriter;
-	MPI_Win_unlock(workrank, sharerWindow);
-
-	unsigned long offset = getOffset(lineAddr);
-	if(isPowerOf2((tempsharer)&invid) && tempsharer != id && prevsharer == 0){ //Other private. but may not have loaded page yet.
-		unsigned long ownid = tempsharer&invid; // remove own bit
-		unsigned long owner = invalid_node; // initialize to failsafe value
-		for(n=0; n<numtasks; n++) {
-			if(1ul<<n==ownid) {
-				owner = n; //just get rank...
+	/* Adjust end_index to ensure the whole chunk to fetch is on the same node */
+	for(	std::size_t i = start_index+CACHELINE, p = CACHELINE;
+			i < start_index+LOAD_PAGES;
+			i+=CACHELINE, p+=CACHELINE){
+		const std::size_t temp_addr = aligned_access_offset + p*block_size;
+		/* Increase end_index if it is within bounds and on the same node */
+		if(temp_addr < size_of_all && i < cachesize){
+			const std::size_t temp_node = getHomenode(temp_addr);
+			if(temp_node == load_node){
+				end_index+=CACHELINE;
+			}else{
 				break;
 			}
+		}else{
+			/* Stop when either condition is not satisfied */
+			break;
 		}
-		if(owner != invalid_node) {
-			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-			MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Win_unlock(owner, sharerWindow);
+	}
+
+	/* Allocate space for loading things */
+	bool new_sharer = false;
+	const std::size_t fetch_size = end_index - start_index;
+	const std::size_t classification_size = fetch_size*2;
+
+	/* For each page to load, true if page should be cached else false */
+	std::vector<bool> pages_to_load(fetch_size);
+	/* For each page to update in the cache, true if page has
+	 * already been handled else false */
+	std::vector<bool> handled_pages(fetch_size);
+	/* Contains classification index for each page to load */
+	std::vector<std::size_t> classification_index_array(fetch_size);
+	/* Store sharer state from local node temporarily */
+	std::vector<std::uintptr_t> local_sharers(fetch_size);
+	/* Store content of remote Pyxis directory temporarily */
+	std::vector<std::uintptr_t> remote_sharers(classification_size);
+	/* Store updates to be made to remote Pyxis directory */
+	std::vector<std::uintptr_t> sharer_bit_mask(classification_size);
+	/* Temporarily store remotely fetched cache data */
+	std::vector<char> temp_data(fetch_size*pagesize);
+
+	/* Write back existing cache entries if needed */
+	for(std::size_t idx = start_index, p = 0; idx < end_index; idx+=CACHELINE, p+=CACHELINE){
+		/* Address and pointer to the data being loaded */
+		const std::size_t temp_addr = aligned_access_offset + p*block_size;
+
+		/* Skip updating pages that are already present and valid in the cache */
+		if(cacheControl[idx].tag  == temp_addr && cacheControl[idx].state != INVALID){
+			pages_to_load[p] = false;
+			continue;
+		}else{
+			pages_to_load[p] = true;
 		}
 
+		/* If another page occupies the cache index, begin to evict it. */
+		if((cacheControl[idx].tag != temp_addr) && (cacheControl[idx].tag != GLOBAL_NULL)){
+			void* old_ptr = static_cast<char*>(startAddr) + cacheControl[idx].tag;
+			void* temp_ptr = static_cast<char*>(startAddr) + temp_addr;
+
+			/* If the page is dirty, write it back */
+			if(cacheControl[idx].dirty == DIRTY){
+				mprotect(old_ptr,block_size,PROT_READ);
+				for(std::size_t j=0; j < CACHELINE; j++){
+					storepageDIFF(idx+j,pagesize*j+(cacheControl[idx].tag));
+				}
+				argo_write_buffer->erase(idx);
+			}
+			/* Ensure the writeback has finished */
+			for(int i = 0; i < numtasks; i++){
+				if(barwindowsused[i] == 1){
+					MPI_Win_unlock(i, globalDataWindow[i]);
+					barwindowsused[i] = 0;
+				}
+			} // TODO: move this out to avoid unlocking for every page?
+
+			/* Clean up cache and protect memory */
+			cacheControl[idx].state = INVALID;
+			cacheControl[idx].tag = temp_addr;
+			cacheControl[idx].dirty = CLEAN;
+			vm::map_memory(temp_ptr, block_size, pagesize*idx, PROT_NONE);
+			mprotect(old_ptr,block_size,PROT_NONE);
+		}
 	}
 
-	MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-	MPI_Get(&cacheData[startidx*pagesize],
-					1,
-					cacheblock,
-					homenode,
-					offset, 1,cacheblock,globalDataWindow[homenode]);
-	MPI_Win_unlock(homenode, globalDataWindow[homenode]);
-
-	if(cacheControl[startidx].tag == GLOBAL_NULL){
-		vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
-		cacheControl[startidx].tag = lineAddr;
+	/* Initialize classification_index_array */
+	for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
+		const std::size_t temp_addr = aligned_access_offset + i*block_size;
+		classification_index_array[i] = get_classification_index(temp_addr);
 	}
-	else{
-		mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
-	}
-	touchedcache[startidx] = 1;
-	cacheControl[startidx].state = VALID;
 
-	cacheControl[startidx].dirty=CLEAN;
+	/* Increase stat counter as load will be performed */
+	stats.loads++;
+
+	/* Get globalSharers info from local node and add self to it */
+	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
+	for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
+		if(pages_to_load[i]){
+			/* Check local pyxis directory if we are sharer of the page */
+			local_sharers[i] = (globalSharers[classification_index_array[i]])&node_id_bit;
+			if(local_sharers[i] == 0){
+				sharer_bit_mask[i*2] = node_id_bit;
+				new_sharer = true; //At least one new sharer detected
+			}
+		}
+	}
+	MPI_Win_unlock(workrank, sharerWindow);
+
+	/* If this node is a new sharer of at least one of the pages */
+	if(new_sharer){
+		/* Register ourselves on all newly shared pages the loadnode directory */
+		MPI_Win_lock(MPI_LOCK_SHARED, load_node, 0, sharerWindow);
+		MPI_Get_accumulate(sharer_bit_mask.data(), classification_size, MPI_LONG,
+				remote_sharers.data(), classification_size, MPI_LONG,
+				load_node, classification_index_array[0], classification_size,
+				MPI_LONG, MPI_BOR, sharerWindow);
+		MPI_Win_unlock(load_node, sharerWindow);
+	}
+
+	/* Register the received remote globalSharers information locally */
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
+	for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
+		if(pages_to_load[i]){
+			globalSharers[classification_index_array[i]] |= remote_sharers[i*2];
+			globalSharers[classification_index_array[i]] |= node_id_bit; //Also add self
+			globalSharers[classification_index_array[i]+1] |= remote_sharers[(i*2)+1];
+		}
+	}
+	MPI_Win_unlock(workrank, sharerWindow);
+
+	/* If any owner of a page we loaded needs to downgrade from private
+	 * to shared, we need to notify it */
+	for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
+		/* Skip pages that are not loaded or already handled */
+		if(pages_to_load[i] && !handled_pages[i]){
+			std::fill(sharer_bit_mask.begin(), sharer_bit_mask.end(), 0);
+			const std::uintptr_t owner_id_bit =
+				remote_sharers[i*2]&node_id_inv_bit; // remove own bit
+
+			/* If there is exactly one other owner, and we are not sharer */
+			if(isPowerOf2(owner_id_bit) && owner_id_bit != 0 && local_sharers[i] == 0){
+				std::uintptr_t owner = invalid_node; // initialize to failsafe value
+				for(int n = 0; n < numtasks; n++) {
+					if(1ul<<n==owner_id_bit) {
+						owner = n; //just get rank...
+						break;
+					}
+				}
+				sharer_bit_mask[i*2] = node_id_bit;
+
+				/* Check if any of the remaining pages need downgrading on the same node */
+				for(std::size_t j = i+CACHELINE; j < fetch_size; j+=CACHELINE){
+					if(pages_to_load[j] && !handled_pages[j]){
+						if((remote_sharers[j*2]&node_id_inv_bit) == owner_id_bit &&
+								local_sharers[j] == 0){
+							sharer_bit_mask[j*2] = node_id_bit;
+							handled_pages[j] = true; //Ensure these are marked as completed
+						}
+					}
+				}
+
+				/* Downgrade all relevant pages on the owner node (P>S) */
+				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
+				MPI_Accumulate(sharer_bit_mask.data(), classification_size, MPI_LONG, owner,
+						classification_index_array[0], classification_size, MPI_LONG,
+						MPI_BOR, sharerWindow);
+				MPI_Win_unlock(owner, sharerWindow);
+			}
+		}
+	}
+
+	/* Finally, get the cache data and store it temporarily */
+	const std::size_t offset = getOffset(aligned_access_offset);
+	MPI_Win_lock(MPI_LOCK_SHARED, load_node , 0, globalDataWindow[load_node]);
+	MPI_Get(temp_data.data(), fetch_size, cacheblock,
+					load_node, offset, fetch_size, cacheblock, globalDataWindow[load_node]);
+	MPI_Win_unlock(load_node, globalDataWindow[load_node]);
+
+	/* Update the cache */
+	for(std::size_t idx = start_index, p = 0; idx < end_index; idx+=CACHELINE, p+=CACHELINE){
+		/* Update only the pages necessary */
+		if(pages_to_load[p]){
+			/* Insert the data in the node cache */
+			memcpy(&cacheData[idx*block_size], &temp_data[p*block_size], block_size);
+
+			const std::size_t temp_addr = aligned_access_offset + p*block_size;
+			void* temp_ptr = static_cast<char*>(startAddr) + temp_addr;
+
+			/* If this is the first time inserting in to this index, perform vm map */
+			if(cacheControl[idx].tag == GLOBAL_NULL){
+				vm::map_memory(temp_ptr, block_size, pagesize*idx, PROT_READ);
+				cacheControl[idx].tag = temp_addr;
+			}else{
+				/* Else, just mprotect the region */
+				mprotect(temp_ptr, block_size, PROT_READ);
+			}
+			touchedcache[idx] = 1;
+			cacheControl[idx].state = VALID;
+			cacheControl[idx].dirty=CLEAN;
+		}
+	}
+	/* Ensure to free space occupied by tempData */
 	sem_post(&ibsem);
 }
 
-void prefetch_cache_entry(unsigned long prefetchtag, unsigned long prefetchline) {
-	int i;
-	unsigned long homenode;
-	unsigned long id = 1 << getID();
-	unsigned long invid = ~id;
-	if(prefetchtag>=size_of_all){//Trying to access/prefetch out of memory
-		return;
-	}
-
-
-	homenode = getHomenode(prefetchtag);
-	unsigned long cacheIndex = prefetchline;
-	if(cacheIndex >= cachesize){
-		printf("idx > size   cacheIndex:%ld cachesize:%ld\n",cacheIndex,cachesize);
-		return;
-	}
-
-
-	sem_wait(&ibsem);
-	unsigned long pageAddr = prefetchtag;
-	unsigned long blocksize = pagesize*CACHELINE;
-	unsigned long lineAddr = pageAddr/blocksize;
-	lineAddr *= blocksize;
-	unsigned long startidx = cacheIndex/CACHELINE;
-	startidx*=CACHELINE;
-	unsigned long end = startidx+CACHELINE;
-
-	if(end>=cachesize){
-		end = cachesize;
-	}
-	argo_byte tmpstate = cacheControl[startidx].state;
-	unsigned long tmptag = cacheControl[startidx].tag;
-	if(tmptag == lineAddr && tmpstate != INVALID){ //trying to load already valid ..
-		sem_post(&ibsem);
-		return;
-	}
-
-
-	void * lineptr = (char*)startAddr + lineAddr;
-
-	if(cacheControl[startidx].tag  != lineAddr){
-		if(cacheControl[startidx].tag  != lineAddr){
-
-			void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
-			if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
-				argo_byte dirty = cacheControl[startidx].dirty;
-				if(dirty == DIRTY){
-					mprotect(tmpptr2,blocksize,PROT_READ);
-					int j;
-					for(j=0; j < CACHELINE; j++){
-						storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
-					}
-					argo_write_buffer->erase(startidx);
-				}
-
-				for(i = 0; i < numtasks; i++){
-					if(barwindowsused[i] == 1){
-						MPI_Win_unlock(i, globalDataWindow[i]);
-						barwindowsused[i] = 0;
-					}
-				}
-
-
-				cacheControl[startidx].state = INVALID;
-				cacheControl[startidx].tag = lineAddr;
-				cacheControl[startidx].dirty=CLEAN;
-
-				vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
-				mprotect(tmpptr2,blocksize,PROT_NONE);
-
-			}
-		}
-	}
-
-	stats.loads++;
-	unsigned long classidx = get_classification_index(lineAddr);
-	unsigned long tempsharer = 0;
-	unsigned long tempwriter = 0;
-	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-	unsigned long prevsharer = (globalSharers[classidx])&id;
-	MPI_Win_unlock(workrank, sharerWindow);
-	int n;
-	homenode = getHomenode(lineAddr);
-
-	if(prevsharer==0 ){ //if there is strictly less than two 'stable' sharers
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-		MPI_Get_accumulate(&id, 1, MPI_LONG, &tempsharer, 1, MPI_LONG,
-			homenode, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-		MPI_Get(&tempwriter, 1,MPI_LONG,homenode,classidx+1,1,MPI_LONG,sharerWindow);
-		MPI_Win_unlock(homenode, sharerWindow);
-	}
-
-	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-	globalSharers[classidx] |= tempsharer;
-	globalSharers[classidx+1] |= tempwriter;
-	MPI_Win_unlock(workrank, sharerWindow);
-
-	unsigned long offset = getOffset(lineAddr);
-	if(isPowerOf2((tempsharer)&invid) && prevsharer == 0){ //Other private. but may not have loaded page yet.
-		unsigned long ownid = tempsharer&invid; // remove own bit
-		unsigned long owner = invalid_node; // initialize to failsafe value
-		for(n=0; n<numtasks; n++) {
-			if(1ul<<n == ownid) {
-				owner = n; //just get rank...
-				break;
-			}
-		}
-		if(owner != invalid_node) {
-			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-			MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Win_unlock(owner, sharerWindow);
-		}
-
-	}
-
-	MPI_Win_lock(MPI_LOCK_SHARED, homenode , 0, globalDataWindow[homenode]);
-	MPI_Get(&cacheData[startidx*pagesize], 1, cacheblock, homenode,
-		offset, 1, cacheblock, globalDataWindow[homenode]);
-	MPI_Win_unlock(homenode, globalDataWindow[homenode]);
-
-
-	if(cacheControl[startidx].tag == GLOBAL_NULL){
-		vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_READ);
-		cacheControl[startidx].tag = lineAddr;
-	}
-	else{
-		mprotect(lineptr,pagesize*CACHELINE,PROT_READ);
-	}
-
-	touchedcache[startidx] = 1;
-	cacheControl[startidx].state = VALID;
-	cacheControl[startidx].dirty=CLEAN;
-	sem_post(&ibsem);
-}
 
 void initmpi(){
 	int ret,initialized,thread_status;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -796,7 +796,7 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	cachesize = std::max(cachesize, static_cast<unsigned long>(pagesize*CACHELINE*2));
 	cachesize /= pagesize;
 
-	classificationSize = 2*cachesize; // Could be smaller ?
+	classificationSize = 2*(argo_size/pagesize);
 	argo_write_buffer = new write_buffer<std::size_t>();
 
 	barwindowsused = (char *)malloc(numtasks*sizeof(char));

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -341,5 +341,14 @@ std::size_t peek_offset(std::size_t addr);
  * @return index for sharer vector for the page
  */
 unsigned long get_classification_index(uint64_t addr);
+/**
+ * @brief Check whether a page is either cached on the node or
+ * locally backed.
+ * @param addr Address in the global address space
+ * @return true if cached or locally backed, else false
+ * @warning This is strictly meant for testing prefetching
+ * @todo This should be moved in to a dedicated cache class
+ */
+bool _is_cached(std::size_t addr);
 #endif /* argo_swdsm_h */
 

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -57,8 +57,8 @@
 /** @brief Hack to avoid warnings when you have unused variables in a function */
 #define UNUSED_PARAM(x) (void)(x)
 
-/** @brief 1 for activating two memory requests in parallel, 0 for disabling*/
-#define DUAL_LOAD 1
+/** @brief The maximum number of ArgoDSM pages to fetch on each remote request */
+#define LOAD_PAGES 4
 
 /** @brief Wrapper for unsigned char - basically a byte */
 typedef unsigned char argo_byte;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include "argo.h"
+
 /** @brief Granularity of coherence unit / pagesize  */
 #define GRAN 4096L //page size.
 
@@ -225,13 +226,13 @@ void argo_reset_coherence(int n);
  * @deprecated Should use argo_get_nid() instead and eventually remove this
  * @see argo_get_nid()
  */
-unsigned int getID();
+argo::node_id_t getID();
 
 /**
  * @brief Gives the ArgoDSM node id for the local process
  * @return Returns the ArgoDSM node id for the local process
  */
-unsigned int argo_get_nid();
+argo::node_id_t argo_get_nid();
 
 /**
  * @brief Gives number of ArgoDSM nodes
@@ -309,17 +310,31 @@ unsigned long getCacheIndex(unsigned long addr);
 /**
  * @brief Gives homenode for a given address
  * @param addr Address in the global address space
- * @param cloc Used to identify the call location in the code
  * @return Process ID of the node backing the memory containing addr
  */
-unsigned long getHomenode(unsigned long addr, char cloc = 0);
+argo::node_id_t get_homenode(std::size_t addr);
+/**
+ * @brief Gives homenode for a given address
+ * @param addr Address in the global address space
+ * @return Process ID of the node backing the memory containing addr
+ * @note This version does not invoke a first-touch call and instead
+ * returns -1 if an address has not been first-touched
+ */
+argo::node_id_t peek_homenode(std::size_t addr);
 /**
  * @brief Gets the offset of an address on the local nodes part of the global memory
  * @param addr Address in the global address space
- * @param cloc Used to identify the call location in the code
  * @return addr-(start address of local process part of global memory)
  */
-unsigned long getOffset(unsigned long addr, char cloc = 0);
+std::size_t get_offset(std::size_t addr);
+/**
+ * @brief Gets the offset of an address on the local nodes part of the global memory
+ * @param addr Address in the global address space
+ * @return addr-(start address of local process part of global memory)
+ * @note This version does not invoke a first-touch call and instead
+ * returns SIZE_MAX if an address has not been first-touched
+ */
+std::size_t peek_offset(std::size_t addr);
 /**
  * @brief Gives an index to the sharer/writer vector depending on the address
  * @param addr Address in the global address space

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -316,9 +316,10 @@ argo::node_id_t get_homenode(std::size_t addr);
 /**
  * @brief Gives homenode for a given address
  * @param addr Address in the global address space
- * @return Process ID of the node backing the memory containing addr
- * @note This version does not invoke a first-touch call and instead
- * returns -1 if an address has not been first-touched
+ * @return Process ID of the node backing the memory containing addr,
+ * or argo::data_distribution::invalid_node_id if addr has not been first-touched
+ * @note This version does not invoke a first-touch call if an
+ * address has not been first-touched
  */
 argo::node_id_t peek_homenode(std::size_t addr);
 /**
@@ -330,9 +331,10 @@ std::size_t get_offset(std::size_t addr);
 /**
  * @brief Gets the offset of an address on the local nodes part of the global memory
  * @param addr Address in the global address space
- * @return addr-(start address of local process part of global memory)
- * @note This version does not invoke a first-touch call and instead
- * returns SIZE_MAX if an address has not been first-touched
+ * @return addr-(start address of local process part of global memory),
+ * or argo::data_distribution::invalid_offset if addr has not been first-touched yet
+ * @note This version does not invoke a first-touch call if an
+ * address has not been first-touched
  */
 std::size_t peek_offset(std::size_t addr);
 /**

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -57,9 +57,6 @@
 /** @brief Hack to avoid warnings when you have unused variables in a function */
 #define UNUSED_PARAM(x) (void)(x)
 
-/** @brief The maximum number of ArgoDSM pages to fetch on each remote request */
-#define LOAD_PAGES 4
-
 /** @brief Wrapper for unsigned char - basically a byte */
 typedef unsigned char argo_byte;
 

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -130,7 +130,7 @@ class write_buffer
 		void sort() {
 			std::sort(_buffer.begin(), _buffer.end(),
 					[](const T& l, const T& r) {
-				return getHomenode(cacheControl[l].tag) < getHomenode(cacheControl[r].tag);
+				return get_homenode(cacheControl[l].tag) < get_homenode(cacheControl[r].tag);
 			});
 		}
 
@@ -141,7 +141,7 @@ class write_buffer
 			assert(_buffer.size() >= _write_back_size);
 			std::sort(_buffer.begin(), _buffer.begin()+_write_back_size,
 					[](const T& l, const T& r) {
-				return getHomenode(cacheControl[l].tag) < getHomenode(cacheControl[r].tag);
+				return get_homenode(cacheControl[l].tag) < get_homenode(cacheControl[r].tag);
 			});
 		}
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -120,6 +120,11 @@ namespace argo {
 			return memory_size;
 		}
 
+		bool is_cached(void* addr) {
+			(void)addr;
+			return true;
+		}
+
 		void finalize() {
 		}
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -194,16 +194,20 @@ namespace argo {
 			}
 
 			void _store_public_owners_dir(const void* desired,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
+					const std::size_t size, const std::size_t count,
+					const std::size_t rank, const std::size_t disp) {
 				(void)desired;
 				(void)size;
+				(void)count;
 				(void)rank;
 				(void)disp;
 			}
 
 			void _store_local_owners_dir(const std::size_t* desired,
-					const std::size_t rank, const std::size_t disp) {
+					const std::size_t count, const std::size_t rank,
+					const std::size_t disp) {
 				(void)desired;
+				(void)count;
 				(void)rank;
 				(void)disp;
 			}
@@ -222,9 +226,11 @@ namespace argo {
 			}
 
 			void _load_public_owners_dir(void* output_buffer,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
+					const std::size_t size, const std::size_t count,
+					const std::size_t rank, const std::size_t disp) {
 				(void)output_buffer;
 				(void)size;
+				(void)count;
 				(void)rank;
 				(void)disp;
 			}
@@ -234,9 +240,12 @@ namespace argo {
 			 *       directory, since the values are hardcoded in the init call
 			 */
 			void _load_local_owners_dir(void* output_buffer,
-					const std::size_t rank, const std::size_t disp) {
+					const std::size_t count, const std::size_t rank,
+					const std::size_t disp) {
 				(void)rank;
-				*(static_cast<std::size_t*>(output_buffer)) = global_owners_dir[disp];
+				std::copy(&global_owners_dir[disp],
+						&global_owners_dir[disp+count],
+						static_cast<std::size_t*>(output_buffer));
 			}
 
 			void _load_local_offsets_tbl(void* output_buffer,

--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -15,6 +15,13 @@
 
 namespace argo {
 	namespace data_distribution {
+
+		/** @brief This constant is used to represent an invalid node id */
+		constexpr argo::node_id_t invalid_node_id = -1;
+
+		/** @brief This constant is used to represent an invalid offset */
+		constexpr std::size_t invalid_offset = SIZE_MAX;
+
 		/** @brief page size for the implementations */
 		static constexpr std::size_t granularity = 0x1000UL;
 
@@ -68,42 +75,46 @@ namespace argo {
 				 */
 				virtual node_id_t homenode (char* const ptr) {
 					(void)ptr;
-					return -1;
+					return invalid_node_id;
 				}
 
 				/**
 				 * @brief compute home node of an address
 				 * @param ptr address to find homenode of
+				 * @return the computed home node, or ::invalid_node_id if
+				 * ptr has not yet been first-touched
 				 * @note this version shall not perform first-touch on an
-				 * address that has not yet been first touched.
-				 * @return the computed home node
+				 * address that has not yet been first touched
 				 */
 				virtual node_id_t peek_homenode (char* const ptr) {
 					(void)ptr;
-					return -1;
+					return invalid_node_id;
 				}
 
 				/**
-				 * @brief compute offset into the home node's share of the memory
+				 * @brief compute the offset of ptr in the backing store
+				 * on ptr's homenode
 				 * @param ptr address to find offset of
-				 * @return the computed offset
+				 * @return the backing store offset
 				 */
 				virtual std::size_t local_offset (char* const ptr) {
 					(void)ptr;
-					return 0;
+					return invalid_offset;
 				}
 
 				/**
-				 * @brief compute offset into the home node's share of the memory
+				 * @brief compute the offset of ptr in the backing store
+				 * on ptr's homenode
 				 * @param ptr address to find offset of
 				 * does not have a valid offset
+				 * @return the backing store offset, or ::invalid_offset if
+				 * ptr has not yet been first-touched
 				 * @note this version shall not perform first-touch on an
-				 * address that has not yet been first touched.
-				 * @return the computed offset
+				 * address that has not yet been first touched
 				 */
 				virtual std::size_t peek_local_offset (char* const ptr) {
 					(void)ptr;
-					return 0;
+					return invalid_offset;
 				}
 
 				/**

--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -72,11 +72,36 @@ namespace argo {
 				}
 
 				/**
+				 * @brief compute home node of an address
+				 * @param ptr address to find homenode of
+				 * @note this version shall not perform first-touch on an
+				 * address that has not yet been first touched.
+				 * @return the computed home node
+				 */
+				virtual node_id_t peek_homenode (char* const ptr) {
+					(void)ptr;
+					return -1;
+				}
+
+				/**
 				 * @brief compute offset into the home node's share of the memory
 				 * @param ptr address to find offset of
 				 * @return the computed offset
 				 */
 				virtual std::size_t local_offset (char* const ptr) {
+					(void)ptr;
+					return 0;
+				}
+
+				/**
+				 * @brief compute offset into the home node's share of the memory
+				 * @param ptr address to find offset of
+				 * does not have a valid offset
+				 * @note this version shall not perform first-touch on an
+				 * address that has not yet been first touched.
+				 * @return the computed offset
+				 */
+				virtual std::size_t peek_local_offset (char* const ptr) {
 					(void)ptr;
 					return 0;
 				}

--- a/src/data_distribution/global_ptr.hpp
+++ b/src/data_distribution/global_ptr.hpp
@@ -35,21 +35,21 @@ namespace argo {
 
 			public:
 				/** @brief construct nullptr */
-				global_ptr() : homenode(-1), local_offset(0) {}
+				global_ptr() : homenode(-1), local_offset(SIZE_MAX) {}
 
 				/**
 				 * @brief construct from virtual address pointer
 				 * @param ptr pointer to construct from
-				 * @param sel select to invoke the homenode, the local_offset or both
+				 * @param compute_homenode If true, compute the homenode in constructor
+				 * @param compute_offset If true, compute local offset in constructor
 				 */
-				global_ptr(T* ptr, const std::string& sel = "")
-						: homenode(-1), local_offset(0), access_ptr(ptr) {
-					if (!sel.compare("getHomenode")) {
+				global_ptr(T* ptr, const bool compute_homenode = true,
+									const bool compute_offset = true)
+						: homenode(-1), local_offset(SIZE_MAX), access_ptr(ptr) {
+					if(compute_homenode){
 						homenode = policy()->homenode(reinterpret_cast<char*>(ptr));
-					} else if (!sel.compare("getOffset")) {
-						local_offset = policy()->local_offset(reinterpret_cast<char*>(ptr));
-					} else {
-						homenode = policy()->homenode(reinterpret_cast<char*>(ptr));
+					}
+					if(compute_offset){
 						local_offset = policy()->local_offset(reinterpret_cast<char*>(ptr));
 					}
 				}
@@ -89,6 +89,32 @@ namespace argo {
 				 * @return home node id
 				 */
 				node_id_t node() {
+					// If homenode is not yet calculated we need to find it
+					if(homenode == -1) {
+						homenode = policy()->homenode(
+								reinterpret_cast<char*>(access_ptr));
+					}
+					return homenode;
+				}
+
+				/**
+				 * @brief return the home node of the value pointed to, or a
+				 * default value if the page has not yet been first-touched
+				 * under first-touch allocation.
+				 * @return home node id
+				 */
+				node_id_t peek_node() {
+					// If homenode is not yet calculated we need to find it
+					if(homenode == -1) {
+						// Do not invoke first-touch
+						if(is_first_touch_policy()) {
+							homenode = policy()->peek_homenode(
+									reinterpret_cast<char*>(access_ptr));
+						} else {
+							homenode = policy()->homenode(
+									reinterpret_cast<char*>(access_ptr));
+						}
+					}
 					return homenode;
 				}
 
@@ -97,6 +123,31 @@ namespace argo {
 				 * @return local offset
 				 */
 				std::size_t offset() {
+					if(local_offset == SIZE_MAX) {
+						local_offset = policy()->local_offset(
+								reinterpret_cast<char*>(access_ptr));
+					}
+					return local_offset;
+				}
+
+				/**
+				 * @brief return the offset on the home node's local memory share
+				 * or a default value if the page has not yet been first-touched
+				 * under first-touch allocation.
+				 * @return local offset
+				 */
+				node_id_t peek_offset() {
+					// If homenode is not yet calculated we need to find it
+					if(local_offset == SIZE_MAX) {
+						// Do not invoke first-touch
+						if(is_first_touch_policy()) {
+							local_offset = policy()->peek_local_offset(
+									reinterpret_cast<char*>(access_ptr));
+						} else {
+							local_offset = policy()->local_offset(
+									reinterpret_cast<char*>(access_ptr));
+						}
+					}
 					return local_offset;
 				}
 

--- a/src/data_distribution/global_ptr.hpp
+++ b/src/data_distribution/global_ptr.hpp
@@ -35,7 +35,7 @@ namespace argo {
 
 			public:
 				/** @brief construct nullptr */
-				global_ptr() : homenode(-1), local_offset(SIZE_MAX) {}
+				global_ptr() : homenode(invalid_node_id), local_offset(invalid_offset) {}
 
 				/**
 				 * @brief construct from virtual address pointer
@@ -45,7 +45,7 @@ namespace argo {
 				 */
 				global_ptr(T* ptr, const bool compute_homenode = true,
 									const bool compute_offset = true)
-						: homenode(-1), local_offset(SIZE_MAX), access_ptr(ptr) {
+						: homenode(invalid_node_id), local_offset(invalid_offset), access_ptr(ptr) {
 					if(compute_homenode){
 						homenode = policy()->homenode(reinterpret_cast<char*>(ptr));
 					}
@@ -90,7 +90,7 @@ namespace argo {
 				 */
 				node_id_t node() {
 					// If homenode is not yet calculated we need to find it
-					if(homenode == -1) {
+					if(homenode == invalid_node_id) {
 						homenode = policy()->homenode(
 								reinterpret_cast<char*>(access_ptr));
 					}
@@ -105,7 +105,7 @@ namespace argo {
 				 */
 				node_id_t peek_node() {
 					// If homenode is not yet calculated we need to find it
-					if(homenode == -1) {
+					if(homenode == invalid_node_id) {
 						// Do not invoke first-touch
 						if(is_first_touch_policy()) {
 							homenode = policy()->peek_homenode(
@@ -123,7 +123,7 @@ namespace argo {
 				 * @return local offset
 				 */
 				std::size_t offset() {
-					if(local_offset == SIZE_MAX) {
+					if(local_offset == invalid_offset) {
 						local_offset = policy()->local_offset(
 								reinterpret_cast<char*>(access_ptr));
 					}
@@ -138,7 +138,7 @@ namespace argo {
 				 */
 				node_id_t peek_offset() {
 					// If homenode is not yet calculated we need to find it
-					if(local_offset == SIZE_MAX) {
+					if(local_offset == invalid_offset) {
 						// Do not invoke first-touch
 						if(is_first_touch_policy()) {
 							local_offset = policy()->peek_local_offset(

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -51,6 +51,12 @@ namespace {
 	const std::size_t default_allocation_block_size = 1ul<<4; // default: 16
 
 	/**
+	 * @brief default requested load size (if environment variable is unset)
+	 * @see @ref ARGO_LOAD_SIZE
+	 */
+	const std::size_t default_load_size = 8;
+
+	/**
 	 * @brief environment variable used for requesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
@@ -85,6 +91,12 @@ namespace {
 	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
 	 */
 	const std::string env_allocation_block_size = "ARGO_ALLOCATION_BLOCK_SIZE";
+
+	/**
+	 * @brief environment variable used for requesting load size
+	 * @see @ref ARGO_LOAD_SIZE
+	 */
+	const std::string env_load_size = "ARGO_LOAD_SIZE";
 
 	/** @brief error message string */
 	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
@@ -123,6 +135,11 @@ namespace {
 	 * @brief allocation block size requested through the environment variable @ref ARGO_ALLOCATION_BLOCK_SIZE
 	 */
 	std::size_t value_allocation_block_size;
+
+	/**
+	 * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
+	 */
+	std::size_t value_load_size;
 
 	/** @brief flag to allow checking that environment variables have been read before accessing their values */
 	bool is_initialized = false;
@@ -181,6 +198,7 @@ namespace argo {
 
 			value_allocation_policy = parse_env(env_allocation_policy, default_allocation_policy).second;
 			value_allocation_block_size = parse_env(env_allocation_block_size, default_allocation_block_size).second;
+			value_load_size = parse_env(env_load_size, default_load_size).second;
 
 			is_initialized = true;
 		}
@@ -215,5 +233,9 @@ namespace argo {
 			return value_allocation_block_size;
 		}
 
+		std::size_t load_size() {
+			assert_initialized();
+			return value_load_size;
+		}
 	} // namespace env
 } // namespace argo

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -40,6 +40,11 @@
  * @envvar{ARGO_ALLOCATION_BLOCK_SIZE} request a specific allocation block size in number of pages
  * @details This environment variable can be accessed through
  *          @ref argo::env::allocation_block_size() after argo::env::init() has been called.
+ *
+ * @envvar{ARGO_LOAD_SIZE} request a specific load size in number of pages
+ * @details This environment variable determines the maximum amount of DSM pages that
+ * 			are fetched on each remote load operation. It can be accessed through
+ *          @ref argo::env::load_size() after argo::env::init() has been called.
  */
 
 namespace argo {
@@ -97,6 +102,14 @@ namespace argo {
 		 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
 		 */
 		std::size_t allocation_block_size();
+
+		/**
+		 * @brief get the number of pages fetched remotely per load requested
+		 * by environment variable
+		 * @return the number of pages
+		 * @see @ref ARGO_LOAD_SIZE
+		 */
+		std::size_t load_size();
 	} // namespace env
 } // namespace argo
 

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -14,6 +14,7 @@
 #include "allocators/collective_allocator.hpp"
 #include "allocators/null_lock.hpp"
 #include "backend/backend.hpp"
+#include "env/env.hpp"
 #include "gtest/gtest.h"
 
 /** @brief ArgoDSM memory size */
@@ -21,13 +22,15 @@ constexpr std::size_t size = 1<<30;
 /** @brief ArgoDSM cache size */
 constexpr std::size_t cache_size = size/8;
 
+namespace env = argo::env;
+namespace dd = argo::data_distribution;
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
 
 /** @brief ArgoDSM page size */
-const unsigned int pagesize = 4096;
+const std::size_t page_size = 4096;
 
-/** @brief A random int constant */
+/** @brief A "random" char constant */
 constexpr char c_const = 'a';
 
 /**
@@ -49,11 +52,12 @@ class PrefetchTest : public testing::Test {
 
 
 /**
- * @brief Unittest that checks that there is no error when accessing the first byte of the allocation.
+ * @brief Unittest that checks that there is no error when accessing
+ * the first byte of the allocation.
  */
 TEST_F(PrefetchTest, FirstPage) {
-	std::size_t allocsize = default_global_mempool->available();
-	char *tmp = static_cast<char*>(collective_alloc(allocsize));
+	std::size_t alloc_size = default_global_mempool->available();
+	char *tmp = static_cast<char*>(collective_alloc(alloc_size));
 	if(argo::node_id()==0){
 		tmp[0] = c_const;
 	}
@@ -62,31 +66,101 @@ TEST_F(PrefetchTest, FirstPage) {
 }
 
 /**
- * @brief Unittest that checks that there is no error when accessing the last page in memory.
+ * @brief Unittest that checks that there is no error when accessing
+ * the last byte of the allocation.
  */
 TEST_F(PrefetchTest, OutOfBounds) {
-	std::size_t allocsize = default_global_mempool->available();
-	char *tmp = static_cast<char*>(collective_alloc(allocsize));
+	std::size_t alloc_size = default_global_mempool->available();
+	char *tmp = static_cast<char*>(collective_alloc(alloc_size));
 	if(argo::node_id()==0){
-		tmp[allocsize-1] = c_const;
+		tmp[alloc_size-1] = c_const;
 	}
 	argo::barrier();
-	ASSERT_EQ(c_const, tmp[allocsize-1]);
+	ASSERT_EQ(c_const, tmp[alloc_size-1]);
 }
 
 /**
- * @brief Unittest that checks that there is no error when accessing a page that may already be prefetched by a previous access.
+ * @brief Unittest that checks that there is no error when accessing
+ * bytes on either side of a page boundary.
  */
-TEST_F(PrefetchTest, AccessPrefetched) {
-	std::size_t allocsize = default_global_mempool->available();
-	char *tmp = static_cast<char*>(collective_alloc(allocsize));
+TEST_F(PrefetchTest, PageBoundaries) {
+	std::size_t alloc_size = default_global_mempool->available();
+	char *tmp = static_cast<char*>(collective_alloc(alloc_size));
+	std::size_t load_size = env::load_size();
 	if(argo::node_id()==0){
-		tmp[pagesize-1] = c_const;
-		tmp[pagesize] = c_const;
+		tmp[(page_size*load_size)-1] = c_const;
+		tmp[page_size*load_size] = c_const;
 	}
 	argo::barrier();
-	ASSERT_EQ(c_const, tmp[pagesize-1]);
-	ASSERT_EQ(c_const, tmp[pagesize]);
+	ASSERT_EQ(c_const, tmp[(page_size*load_size)-1]);
+	ASSERT_EQ(c_const, tmp[page_size*load_size]);
+}
+
+
+/**
+ * @brief Unittest that checks that pages are correctly prefetched.
+ */
+TEST_F(PrefetchTest, AccessPrefetched) {
+	std::size_t alloc_size = default_global_mempool->available();
+	char *tmp = static_cast<char*>(collective_alloc(alloc_size));
+	std::size_t num_nodes = argo::number_of_nodes();
+	std::size_t load_size = env::load_size();
+	std::size_t block_size = env::allocation_block_size();
+
+	std::size_t stride, start_page;
+	/* Figure out boundaries for both block_size and load_size */
+	if(dd::is_cyclic_policy()) {
+		/*
+		 * For blocked policies, at most one block is guaranteed
+		 * to be contiguious in both global memory and backing store
+		 */
+		stride = std::min(block_size, load_size);
+		start_page = block_size-1; //first block may already be fetched in init
+	} else {
+		/*
+		 * For the first touch policiy, at most
+		 * (alloc_size/4096)/num_nodes are guaranteed to be contiguious 
+		 * in both global memory and backing store.
+		 */
+		stride = (load_size < ((size/page_size)/num_nodes)) ?
+				load_size : (size/page_size)/num_nodes - 1;
+		start_page = stride-1; //First stride may already be fetched in init
+	}
+	std::size_t end_page = start_page+stride;
+
+	/* We can only test prefetching if stride is larger than 1 (page) */
+	if(stride > 1) {
+		/* On node 0, initialize one fetchable block of pages */
+		if(argo::node_id()==0){
+			for(std::size_t page_num = start_page;
+							page_num < end_page;
+							page_num++) {
+				for(std::size_t i = 0; i < page_size; i++) {
+					tmp[page_num*page_size+i] = c_const;
+				}
+			}
+		}
+		/* Wait for init to finish */
+		argo::barrier();
+
+		/* On all nodes, check that after accessing the first page,
+		 * all expected pages are either node local or cached. */
+		ASSERT_EQ(tmp[start_page*page_size], c_const); // Access first page
+		for(std::size_t page_num = start_page;
+						page_num < end_page;
+						page_num++) {
+			ASSERT_TRUE(argo::backend::is_cached(&tmp[page_num*page_size]));
+		}
+		/* On all nodes, check that after accessing the first page,
+		 * all data is correct. */
+		for(std::size_t page_num = start_page;
+						page_num < end_page;
+						page_num++) {
+			for(std::size_t i = 0; i < page_size; i++) {
+				ASSERT_EQ(tmp[page_num*page_size+i], c_const);
+			}
+		}
+	}
 }
 
 /**

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <iostream>
+#include <atomic>
 
 #include <limits.h>
 #include <unistd.h>
@@ -138,6 +139,15 @@ TEST_F(PrefetchTest, AccessPrefetched) {
 				for(std::size_t i = 0; i < page_size; i++) {
 					tmp[page_num*page_size+i] = c_const;
 				}
+				/**
+				 * This fence prevents both compiler and CPU reordering
+				 * of stores (and loads) on a page level to ensure that
+				 * tmp is contiguously mapped in the backing store. This
+				 * is necessary to ensure a deterministic behaviour for
+				 * the first-touch allocation policy.
+				 */
+				std::atomic_thread_fence(std::memory_order_seq_cst);
+
 			}
 		}
 		/* Wait for init to finish */

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -24,6 +24,12 @@ constexpr std::size_t cache_size = size/8;
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
 
+/** @brief ArgoDSM page size */
+const unsigned int pagesize = 4096;
+
+/** @brief A random int constant */
+constexpr char c_const = 'a';
+
 /**
  * @brief Class for the gtests fixture tests. Will reset the allocators to a clean state for every test
  */
@@ -42,18 +48,46 @@ class PrefetchTest : public testing::Test {
 
 
 
+/**
+ * @brief Unittest that checks that there is no error when accessing the first byte of the allocation.
+ */
+TEST_F(PrefetchTest, FirstPage) {
+	std::size_t allocsize = default_global_mempool->available();
+	char *tmp = static_cast<char*>(collective_alloc(allocsize));
+	if(argo::node_id()==0){
+		tmp[0] = c_const;
+	}
+	argo::barrier();
+	ASSERT_EQ(c_const, tmp[0]);
+}
 
 /**
- * @brief Unittest that checks that there is no error when accessing the last page in memory and tried to prefetch the page after.
+ * @brief Unittest that checks that there is no error when accessing the last page in memory.
  */
 TEST_F(PrefetchTest, OutOfBounds) {
 	std::size_t allocsize = default_global_mempool->available();
 	char *tmp = static_cast<char*>(collective_alloc(allocsize));
 	if(argo::node_id()==0){
-		tmp[allocsize-1]=42;
+		tmp[allocsize-1] = c_const;
 	}
+	argo::barrier();
+	ASSERT_EQ(c_const, tmp[allocsize-1]);
 }
 
+/**
+ * @brief Unittest that checks that there is no error when accessing a page that may already be prefetched by a previous access.
+ */
+TEST_F(PrefetchTest, AccessPrefetched) {
+	std::size_t allocsize = default_global_mempool->available();
+	char *tmp = static_cast<char*>(collective_alloc(allocsize));
+	if(argo::node_id()==0){
+		tmp[pagesize-1] = c_const;
+		tmp[pagesize] = c_const;
+	}
+	argo::barrier();
+	ASSERT_EQ(c_const, tmp[pagesize-1]);
+	ASSERT_EQ(c_const, tmp[pagesize]);
+}
 
 /**
  * @brief The main function that runs the tests


### PR DESCRIPTION
This pull request provides an updated and improved remote page loading functionality (`load_cache_entry`) that reduces the amount of remote operations per page loaded. It also enables prefetching of subsequent ArgoDSM pages located on the same remote node for a fraction of the cost compared to loading each page individually. This is achieved by performing both remote Pyxis operations and remote data loading **in bulk** when possible rather than individually for each page.

The total number of pages loaded on each remote load operation defaults to 8 (target page and up to 7 subsequent pages), and can be adjusted by setting the `ARGO_LOAD_SIZE` environment variable to the desired number.

As a side effect this PR deals with issues #28 (through commit f6b5306 specifically), #29, #30, and #32.