### PR TITLE
Catch exceptions by const reference

### DIFF
--- a/src/allocators/generic_allocator.hpp
+++ b/src/allocators/generic_allocator.hpp
@@ -218,7 +218,7 @@ namespace argo {
 					T* allocation;
 					try {
 						allocation = static_cast<T*>(mempool->reserve(n*sizeof(T)));
-					} catch (typename MemoryPool::bad_alloc) {
+					} catch (const typename MemoryPool::bad_alloc&) {
 						auto avail = mempool->available();
 						if(avail > 0) {
 							allocation = static_cast<T*>(mempool->reserve(avail));
@@ -227,7 +227,7 @@ namespace argo {
 						}
 						try {
 							mempool->grow(n*sizeof(T));
-						}catch(std::bad_alloc){
+						}catch(const std::bad_alloc&){
 							lock->unlock();
 							throw;
 						}

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -155,7 +155,7 @@ namespace argo {
 						if(do_grow<growth_mode>()) {
 							memory = allocator->allocate(alloc_size);
 						}
-					}catch(std::bad_alloc){
+					}catch(const std::bad_alloc&){
 						memory = nullptr;
 					}
 					synchronize<growth_mode>(&memory);


### PR DESCRIPTION
This small patch ensures that exceptions that were previously caught by value are now caught by `const` reference. This fixes the issues mentioned in #33 when building ArgoDSM in debug mode (`-DARGO_DEBUG=ON`) using newer version of gcc.