### PR TITLE
Selective coherence and new write buffer

### DIFF
--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -118,6 +118,68 @@ namespace argo {
 		 */
 		void release();
 
+
+		/**
+		 * The following selective coherence functions are implemented individually
+		 * by each backend
+		 */
+
+		/**
+		 * @brief backend internal type erased function for selective acquire
+		 * @param addr pointer to the start of an ArgoDSM memory region
+		 * @param size size of the region pointed to by addr
+		 * @sa    selective_acquire
+		 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+		 */
+		void _selective_acquire(void* addr, std::size_t size);
+
+		/**
+		 * @brief backend internal type erased function for selective release
+		 * @param addr pointer to the start of an ArgoDSM memory region
+		 * @param size size of the region pointed to by addr
+		 * @sa    selective_release
+		 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+		 */
+		void _selective_release(void* addr, std::size_t size);
+
+		/**
+		 * The following selective coherence functions are generic interfaces to the
+		 * actual backend implementations
+		 */
+
+		/**
+		 * @brief causes a node to self-invalidate the specified pages from its cache,
+		 *        and thus getting any updated values on subsequent accesses
+		 * @param addr pointer to the start of the memory region to self-invalidate
+		 * @param size the size of the memory region pointed to by addr. A size equal
+		 *        to zero results in that no pages are selectively acquired.
+		 * @note  Selective coherence operations do not uphold the data consistency
+		 *        semantics of regular coherence operations and should be used with
+		 *        this in mind. Specifically, write ordering with respect to writes
+		 *        outside of the selective coherence region is not upheld.
+		 */
+		template<typename T>
+		void selective_acquire(T* addr, std::size_t size) {
+			_selective_acquire(static_cast<void*>(addr), size);
+		}
+
+		/**
+		 * @brief causes a node to self-downgrade specified pages from its cache,
+		 *        making all previous writes to be propagated to the homenode,
+		 *        visible for nodes calling acquire (or other synchronization primitives)
+		 * @param addr the start of the memory region to self-invalidate
+		 * @param size the size of the memory region pointed to by addr. A size equal
+		 *        to zero results in that no pages are selectively released.
+		 * @note  Selective coherence operations do not uphold the data consistency
+		 *        semantics of regular coherence operations and should be used with
+		 *        this in mind. Specifically, write ordering with respect to writes
+		 *        outside of the selective coherence region is not upheld.
+		 */
+		template<typename T>
+		void selective_release(T* addr, std::size_t size) {
+			_selective_release(static_cast<void*>(addr), size);
+		}
+
 		namespace atomic {
 			using namespace argo::atomic;
 

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
-add_library(argobackend-mpi SHARED mpi.cpp swdsm.cpp)
+add_library(argobackend-mpi SHARED mpi.cpp swdsm.cpp coherence.cpp)
 
 install(TARGETS argobackend-mpi
 	COMPONENT "Runtime"

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -1,0 +1,201 @@
+/**
+ * @file
+ * @brief This file implements selective coherence mechanisms for ArgoDSM
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include "../backend.hpp"
+#include "swdsm.h"
+#include "virtual_memory/virtual_memory.hpp"
+
+// EXTERNAL VARIABLES FROM BACKEND
+/**
+ * @brief This is needed to access page information from the cache
+ * @deprecated Should be replaced with a cache API
+ */
+extern control_data *cacheControl;
+/**
+ * @brief globalSharers is needed to access and modify the pyxis directory
+ * @deprecated Should eventually be handled by a cache module
+ */
+extern unsigned long *globalSharers;
+/**
+ * @brief A cache mutex protects all operations on cacheControl
+ * @deprecated Should eventually be handled by a cache module
+ */
+extern pthread_mutex_t cachemutex;
+/**
+ * @brief ibsem is used to serialize all Infiniband (MPI) operations
+ * @deprecated Should not be needed once the cache module is implemented
+ */
+extern sem_t ibsem;
+/**
+ * @brief barwindowsused is needed to know which globalDataWindows
+ * to close.
+ * @deprecated No longer needed once proper API functions are in place
+ */
+extern char * barwindowsused;
+/**
+ * @brief globalDataWindows need to be explicitly closed by the
+ * caller of storepageDIFF
+ * @deprecated Should eventually be handled through API functions
+ */
+extern MPI_Win *globalDataWindow;
+/**
+ * @brief sharerWindow protects the pyxis directory
+ * @deprecated Should not be needed once the pyxis directory is
+ * managed from elsewhere through a cache module.
+ */
+extern MPI_Win sharerWindow;
+/**
+ * @brief Needed to update argo statistics
+ * @deprecated Should be replaced by API calls to a stats module
+ */
+extern argo_statistics stats;
+/**
+ * @brief Needed to update information about cache pages touched
+ * @deprecated Should eventually be handled by a cache module
+ */
+extern argo_byte *touchedcache;
+/**
+ * @brief workcomm is needed to poke the MPI system during one sided RMA
+ */
+extern MPI_Comm workcomm;
+
+namespace argo {
+	namespace backend {
+		void _selective_acquire(void *addr, std::size_t size){
+			if(size == 0){
+				// Nothing to invalidate
+				return;
+			}
+
+			const std::size_t block_size = page_size*CACHELINE;
+			const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
+			const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
+			std::size_t argo_address =
+				((reinterpret_cast<std::size_t>(addr)-start_address)/block_size)*block_size;
+			const std::size_t node_id = argo::backend::node_id();
+			const std::size_t node_id_bit = 1 << node_id;
+
+			// Lock relevant mutexes. Start statistics timekeeping
+			double t1 = MPI_Wtime();
+			pthread_mutex_lock(&cachemutex);
+			pthread_mutex_lock(&wbmutex);
+			sem_wait(&ibsem);
+
+			// Iterate over all pages to selectively invalidate
+			for(std::size_t page_address = argo_address;
+					page_address < argo_address + page_misalignment + size;
+					page_address += block_size){
+				const std::size_t cache_index = getCacheIndex(page_address);
+				const std::size_t classification_index = get_classification_index(page_address);
+
+				// If the page is dirty, downgrade it
+				if(cacheControl[cache_index].dirty == DIRTY){
+					mprotect((char*)start_address + page_address, block_size, PROT_READ);
+					cacheControl[cache_index].dirty = CLEAN;
+					for(int i = 0; i <CACHELINE; i++){
+						storepageDIFF(cache_index+i,page_address+page_size*i);
+					}
+				}
+
+				// Optimization to keep pages in cache if they do not
+				// need to be invalidated.
+				MPI_Win_lock(MPI_LOCK_SHARED, node_id, 0, sharerWindow);
+				if(
+						// node is single writer
+						(globalSharers[classification_index+1] == node_id_bit)
+						||
+						// No writer and assert that the node is a sharer
+						((globalSharers[classification_index+1] == 0) &&
+						 ((globalSharers[classification_index] & node_id_bit) == node_id_bit))
+				  ){
+					MPI_Win_unlock(node_id, sharerWindow);
+					touchedcache[cache_index]=1;
+					//nothing - we keep the pages, SD is done in flushWB
+				}
+				else{ //multiple writer or SO, invalidate the page
+					MPI_Win_unlock(node_id, sharerWindow);
+					cacheControl[cache_index].dirty=CLEAN;
+					cacheControl[cache_index].state = INVALID;
+					touchedcache[cache_index]=0;
+					mprotect((char*)start_address + page_address, block_size, PROT_NONE);
+				}
+			}
+			// Make sure to sync writebacks
+			for(int i = 0; i < number_of_nodes(); i++){
+				if(barwindowsused[i] == 1){
+					MPI_Win_unlock(i, globalDataWindow[i]); //Sync write backs
+					barwindowsused[i] = 0;
+				}
+			}
+
+			double t2 = MPI_Wtime();
+			stats.ssitime += t2-t1;
+
+			// Poke the MPI system to force progress
+			int flag;
+			MPI_Iprobe(MPI_ANY_SOURCE,MPI_ANY_TAG,workcomm,&flag,MPI_STATUS_IGNORE);
+
+			// Release relevant mutexes
+			sem_post(&ibsem);
+			pthread_mutex_unlock(&wbmutex);
+			pthread_mutex_unlock(&cachemutex);
+		}
+
+		void _selective_release(void *addr, std::size_t size){
+			if(size == 0){
+				// Nothing to downgrade
+				return;
+			}
+
+			const std::size_t block_size = page_size*CACHELINE;
+			const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
+			const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
+			std::size_t argo_address =
+				((reinterpret_cast<std::size_t>(addr)-start_address)/block_size)*block_size;
+
+			// Lock relevant mutexes. Start statistics timekeeping
+			double t1 = MPI_Wtime();
+			pthread_mutex_lock(&cachemutex);
+			pthread_mutex_lock(&wbmutex);
+			sem_wait(&ibsem);
+
+			// Iterate over all pages to selectively downgrade
+			for(std::size_t page_address = argo_address;
+					page_address < argo_address + page_misalignment + size;
+					page_address += block_size){
+				const std::size_t cache_index = getCacheIndex(page_address);
+
+				// If the page is dirty, downgrade it
+				if(cacheControl[cache_index].dirty == DIRTY){
+					mprotect((char*)start_address + page_address, block_size, PROT_READ);
+					cacheControl[cache_index].dirty = CLEAN;
+					for(int i = 0; i <CACHELINE; i++){
+						storepageDIFF(cache_index+i,page_address+page_size*i);
+					}
+				}
+			}
+			// Make sure to sync writebacks
+			for(int i = 0; i < number_of_nodes(); i++){
+				if(barwindowsused[i] == 1){
+					MPI_Win_unlock(i, globalDataWindow[i]); //Sync write backs
+					barwindowsused[i] = 0;
+				}
+			}
+
+			double t2 = MPI_Wtime();
+			stats.ssdtime += t2-t1;
+
+			// Poke the MPI system to force progress
+			int flag;
+			MPI_Iprobe(MPI_ANY_SOURCE,MPI_ANY_TAG,workcomm,&flag,MPI_STATUS_IGNORE);
+
+			// Release relevant mutexes
+			sem_post(&ibsem);
+			pthread_mutex_unlock(&wbmutex);
+			pthread_mutex_unlock(&cachemutex);
+		}
+	} //namespace backend
+} //namespace argo

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -7,9 +7,12 @@
 
 #include "signal/signal.hpp"
 #include "virtual_memory/virtual_memory.hpp"
+#include "env/env.hpp"
 #include "swdsm.h"
+#include "write_buffer.hpp"
 
 namespace vm = argo::virtual_memory;
+namespace env = argo::env;
 namespace sig = argo::signal;
 
 /*Treads*/
@@ -50,18 +53,8 @@ char * pagecopy;
 pthread_mutex_t cachemutex = PTHREAD_MUTEX_INITIALIZER;
 
 /*Writebuffer*/
-/** @brief  Size of the writebuffer*/
-size_t writebuffersize;
-/** @brief  Writebuffer for storing indices to pages*/
-unsigned long  *writebuffer;
-/** @brief Most recent entry in the writebuffer*/
-unsigned long  writebufferstart;
-/** @brief Least recent entry in the writebuffer*/
-unsigned long  writebufferend;
-/** @brief writeback from writebuffer helper function */
-void write_back_writebuffer();
-/** @brief Lock for the writebuffer*/
-pthread_mutex_t wbmutex = PTHREAD_MUTEX_INITIALIZER;
+/** @brief A write buffer storing cache indices */
+write_buffer<std::size_t>* argo_write_buffer;
 
 /*MPI and Comm*/
 /** @brief  A copy of MPI_COMM_WORLD group to split up processes into smaller groups*/
@@ -149,74 +142,6 @@ unsigned long isPowerOf2(unsigned long x){
   unsigned long retval =  ((x & (x - 1)) == 0); //Checks if x is power of 2 (or zero)
   return retval;
 }
-
-void flushWriteBuffer(void){
-	unsigned long i,j;
-	double t1,t2;
-
-	t1 = MPI_Wtime();
-	pthread_mutex_lock(&wbmutex);
-
-  for(i = 0; i < cachesize; i+=CACHELINE){
-    unsigned long distrAddr = cacheControl[i].tag;
-    if(distrAddr != GLOBAL_NULL){
-
-      unsigned long distrAddr = cacheControl[i].tag;
-      unsigned long lineAddr = distrAddr/(CACHELINE*pagesize);
-      lineAddr*=(pagesize*CACHELINE);
-			void * lineptr = (char*)startAddr + lineAddr;
-
-      argo_byte dirty = cacheControl[i].dirty;
-			if(dirty == DIRTY){
-				mprotect(lineptr, pagesize*CACHELINE, PROT_READ);
-				cacheControl[i].dirty=CLEAN;
-				for(j=0; j < CACHELINE; j++){
-					storepageDIFF(i+j,pagesize*j+lineAddr);
-				}
-			}
-    }
-  }
-
-	for(i = 0; i < (unsigned long)numtasks; i++){
-		if(barwindowsused[i] == 1){
-			MPI_Win_unlock(i, globalDataWindow[i]);
-			barwindowsused[i] = 0;
-		}
-	}
-
-	writebufferstart = 0;
-	writebufferend = 0;
-
-	pthread_mutex_unlock(&wbmutex);
-	t2 = MPI_Wtime();
-	stats.flushtime += t2-t1;
-}
-
-void addToWriteBuffer(unsigned long cacheIndex){
-	pthread_mutex_lock(&wbmutex);
-	unsigned long line = cacheIndex/CACHELINE;
-	line *= CACHELINE;
-
-	if(writebuffer[writebufferend] == line ||
-		 writebuffer[writebufferstart] == line){
-		pthread_mutex_unlock(&wbmutex);
-		return;
-	}
-  unsigned long wbendplusone = ((writebufferend+1)%writebuffersize);
-	unsigned long wbendplustwo = ((writebufferend+2)%writebuffersize);
-	if(wbendplusone == writebufferstart ){ // Buffer is full wait for slot to be empty
-		double t1 = MPI_Wtime();
-		write_back_writebuffer();
-		double t4 = MPI_Wtime();
-		stats.writebacks+=CACHELINE;
-		stats.writebacktime+=(t4-t1);
-		writebufferstart = wbendplustwo;
-	}
-	writebuffer[writebufferend] = line;
-	writebufferend = wbendplusone;
-	pthread_mutex_unlock(&wbmutex);
-}
-
 
 int argo_get_local_tid(){
 	int i;
@@ -483,10 +408,10 @@ void handler(int sig, siginfo_t *si, void *unused){
 			}
 		}
 	}
-	sem_post(&ibsem);
 	unsigned char * copy = (unsigned char *)(pagecopy + line*pagesize);
 	memcpy(copy,aligned_access_ptr,CACHELINE*pagesize);
-	addToWriteBuffer(startIndex);
+	argo_write_buffer->add(startIndex);
+	sem_post(&ibsem);
 	mprotect(aligned_access_ptr, pagesize*CACHELINE,PROT_WRITE|PROT_READ);
 	pthread_mutex_unlock(&cachemutex);
 	double t2 = MPI_Wtime();
@@ -510,34 +435,6 @@ unsigned long getOffset(unsigned long addr){
 		exit(EXIT_FAILURE);
 	}
 	return offset;
-}
-
-void write_back_writebuffer() {
-	unsigned long i;
-	unsigned long oldstart;
-	unsigned long idx,tag;
-	sem_wait(&ibsem);
-
-	oldstart = writebufferstart;
-	i = oldstart;
-	idx = writebuffer[i];
-	tag = cacheControl[idx].tag;
-	writebuffer[i] = GLOBAL_NULL;
-	if(tag != GLOBAL_NULL && idx != GLOBAL_NULL && cacheControl[idx].dirty == DIRTY){
-		mprotect((char*)startAddr+tag,CACHELINE*pagesize,PROT_READ);
-		for(i = 0; i <CACHELINE; i++){
-			storepageDIFF(idx+i,tag+pagesize*i);
-			cacheControl[idx+i].dirty = CLEAN;
-		}
-	}
-	for(i = 0; i < (unsigned long)numtasks; i++){
-		if(barwindowsused[i] == 1){
-			MPI_Win_unlock(i, globalDataWindow[i]);
-			barwindowsused[i] = 0;
-		}
-	}
-	writebufferstart = (writebufferstart+1)%writebuffersize;
-	sem_post(&ibsem);
 }
 
 void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
@@ -584,11 +481,6 @@ void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
 
 	if(cacheControl[startidx].tag  != lineAddr){
 		if(cacheControl[startidx].tag  != lineAddr){
-			if(pthread_mutex_trylock(&wbmutex) != 0){
-				sem_post(&ibsem);
-				pthread_mutex_lock(&wbmutex);
-				sem_wait(&ibsem);
-			}
 
 			void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
 			if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
@@ -599,6 +491,7 @@ void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
 					for(j=0; j < CACHELINE; j++){
 						storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
 					}
+					argo_write_buffer->erase(startidx);
 				}
 
 				for(i = 0; i < numtasks; i++){
@@ -615,7 +508,6 @@ void load_cache_entry(unsigned long loadtag, unsigned long loadline) {
 				vm::map_memory(lineptr, blocksize, pagesize*startidx, PROT_NONE);
 				mprotect(tmpptr2,blocksize,PROT_NONE);
 			}
-			pthread_mutex_unlock(&wbmutex);
 		}
 	}
 
@@ -727,11 +619,6 @@ void prefetch_cache_entry(unsigned long prefetchtag, unsigned long prefetchline)
 
 	if(cacheControl[startidx].tag  != lineAddr){
 		if(cacheControl[startidx].tag  != lineAddr){
-			if(pthread_mutex_trylock(&wbmutex) != 0){
-				sem_post(&ibsem);
-				pthread_mutex_lock(&wbmutex);
-				sem_wait(&ibsem);
-			}
 
 			void * tmpptr2 = (char*)startAddr + cacheControl[startidx].tag;
 			if(cacheControl[startidx].tag != GLOBAL_NULL && cacheControl[startidx].tag  != lineAddr){
@@ -742,6 +629,7 @@ void prefetch_cache_entry(unsigned long prefetchtag, unsigned long prefetchline)
 					for(j=0; j < CACHELINE; j++){
 						storepageDIFF(startidx+j,pagesize*j+(cacheControl[startidx].tag));
 					}
+					argo_write_buffer->erase(startidx);
 				}
 
 				for(i = 0; i < numtasks; i++){
@@ -760,8 +648,6 @@ void prefetch_cache_entry(unsigned long prefetchtag, unsigned long prefetchline)
 				mprotect(tmpptr2,blocksize,PROT_NONE);
 
 			}
-			pthread_mutex_unlock(&wbmutex);
-
 		}
 	}
 
@@ -940,14 +826,7 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	cachesize /= pagesize;
 
 	classificationSize = 2*cachesize; // Could be smaller ?
-	writebuffersize = WRITE_BUFFER_PAGES/CACHELINE;
-	writebuffer = (unsigned long *) malloc(sizeof(unsigned long)*writebuffersize);
-	for(i = 0; i < (int)writebuffersize; i++){
-		writebuffer[i] = GLOBAL_NULL;
-	}
-
-	writebufferstart = 0;
-	writebufferend = 0;
+	argo_write_buffer = new write_buffer<std::size_t>();
 
 	barwindowsused = (char *)malloc(numtasks*sizeof(char));
 	for(i = 0; i < numtasks; i++){
@@ -1098,7 +977,7 @@ void self_invalidation(){
 			argo_byte dirty = cacheControl[i].dirty;
 
 			if(flushed == 0 && dirty == DIRTY){
-				flushWriteBuffer();
+				argo_write_buffer->flush();
 				flushed = 1;
 			}
 			MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
@@ -1142,7 +1021,7 @@ void swdsm_argo_barrier(int n){ //BARRIER
 		barrierlockholder = pthread_self();
 		pthread_mutex_lock(&cachemutex);
 		sem_wait(&ibsem);
-		flushWriteBuffer();
+		argo_write_buffer->flush();
 		MPI_Barrier(workcomm);
 		self_invalidation();
 		sem_post(&ibsem);
@@ -1192,7 +1071,7 @@ void argo_release(){
 	int flag;
 	pthread_mutex_lock(&cachemutex);
 	sem_wait(&ibsem);
-	flushWriteBuffer();
+	argo_write_buffer->flush();
 	MPI_Iprobe(MPI_ANY_SOURCE,MPI_ANY_TAG,workcomm,&flag,MPI_STATUS_IGNORE);
 	sem_post(&ibsem);
 	pthread_mutex_unlock(&cachemutex);
@@ -1266,7 +1145,8 @@ void storepageDIFF(unsigned long index, unsigned long addr){
 void printStatistics(){
 	printf("#####################STATISTICS#########################\n");
 	printf("# PROCESS ID %d \n",workrank);
-	printf("cachesize:%ld,CACHELINE:%ld wbsize:%ld\n",cachesize,CACHELINE,writebuffersize);
+	printf("cachesize:%ld,CACHELINE:%ld wbsize:%ld\n",cachesize,CACHELINE,
+			env::write_buffer_size()/CACHELINE);
 	printf("     writebacktime+=(t2-t1): %lf\n",stats.writebacktime);
 	printf("# Storetime : %lf , loadtime :%lf flushtime:%lf, writebacktime: %lf\n",
 		stats.storetime, stats.loadtime, stats.flushtime, stats.writebacktime);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1220,6 +1220,8 @@ void clearStatistics(){
 	stats.loads = 0;
 	stats.barriers = 0;
 	stats.locks = 0;
+	stats.ssitime = 0;
+	stats.ssdtime = 0;
 }
 
 void storepageDIFF(unsigned long index, unsigned long addr){
@@ -1268,6 +1270,7 @@ void printStatistics(){
 	printf("     writebacktime+=(t2-t1): %lf\n",stats.writebacktime);
 	printf("# Storetime : %lf , loadtime :%lf flushtime:%lf, writebacktime: %lf\n",
 		stats.storetime, stats.loadtime, stats.flushtime, stats.writebacktime);
+	printf("# SSDtime:%lf, SSItime:%lf\n", stats.ssdtime, stats.ssitime);
 	printf("# Barriertime : %lf, selfinvtime %lf\n",stats.barriertime, stats.selfinvtime);
 	printf("stores:%lu, loads:%lu, barriers:%lu\n",stats.stores,stats.loads,stats.barriers);
 	printf("Locks:%d\n",stats.locks);
@@ -1278,6 +1281,6 @@ void printStatistics(){
 void *argo_get_global_base(){return startAddr;}
 size_t argo_get_global_size(){return size_of_all;}
 
-inline unsigned long get_classification_index(uint64_t addr){
+unsigned long get_classification_index(uint64_t addr){
 	return (2*(addr/(pagesize*CACHELINE))) % classificationSize;
 }

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -46,10 +46,6 @@
 /**@bug this limits amount of local threads because of pthread barriers being initialized at startup*/
 #define NUM_THREADS 128
 #endif
-/** @brief Number of pages in writebuffer */
-#ifndef WRITE_BUFFER_PAGES
-#define WRITE_BUFFER_PAGES 512L
-#endif
 
 /** @brief Read a value and always get the latest - 'Read-Through' */
 #ifdef __cplusplus
@@ -195,18 +191,6 @@ void argo_release();
  *        according to Release Consistency)
  */
 void argo_acq_rel();
-
-/*Reading and Writing pages*/
-/**
- * @brief Writes back the whole writebuffer (All dirty data on the node)
- */
-void flushWriteBuffer(void);
-
-/**
- * @brief Adds an entry to the writebuffer - if buffer is full writeback the least recent entry
- * @param cacheIndex index of cache that should be entered in the writebuffer
- */
-void addToWriteBuffer(unsigned long cacheIndex);
 
 /**
  * @brief stores a page remotely - only writing back what has been written locally since last synchronization point

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -105,6 +105,10 @@ typedef struct argo_statisticsStruct
 		unsigned long writebacks; 
 		/** @brief Number of locks */
 		int locks;
+		/** @brief Time spent performing selective acquire */
+		double ssitime;
+		/** @brief Time spent performing selective release */
+		double ssdtime;
 } argo_statistics;
 
 /*constants for control values*/
@@ -120,6 +124,13 @@ static const argo_byte DIRTY=3;
 static const argo_byte WRITER=4;
 /** @brief Constant for reader states */
 static const argo_byte READER=5;
+
+/**
+ * @brief The size of a hardware memory page
+ * @note  This should be better centralized for all
+ *        modules and backend implementations
+ */
+constexpr std::size_t page_size = 4096;
 
 /*Handler*/
 /**
@@ -331,6 +342,6 @@ unsigned long getOffset(unsigned long addr);
  * @param addr Address in the global address space
  * @return index for sharer vector for the page
  */
-inline unsigned long get_classification_index(uint64_t addr);
+unsigned long get_classification_index(uint64_t addr);
 #endif /* argo_swdsm_h */
 

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -1,0 +1,305 @@
+/**
+ * @file
+ * @brief This file provides an interface for the ArgoDSM write buffer.
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef argo_write_buffer_hpp
+#define argo_write_buffer_hpp argo_write_buffer_hpp
+
+#include <deque>
+#include <iterator>
+#include <algorithm>
+#include <mutex>
+#include <mpi.h>
+
+#include "backend/backend.hpp"
+#include "env/env.hpp"
+#include "virtual_memory/virtual_memory.hpp"
+#include "swdsm.h"
+
+/**
+ * @brief		Argo statistics struct
+ * @deprecated 	This should be replaced with an API call
+ */
+extern argo_statistics stats;
+
+/**
+ * @brief		Argo cache data structure
+ * @deprecated 	prototype implementation, should be replaced with API calls
+ */
+extern control_data* cacheControl;
+
+/**
+ * @brief		MPI Window for the global ArgoDSM memory space
+ * @deprecated 	Prototype implementation, this should not be accessed directly
+ */
+extern MPI_Win* globalDataWindow;
+
+/**
+ * @brief		Tracking of which MPI RDMA windows are open
+ * @deprecated 	Prototype implementation, this should not be accessed directly
+ */
+extern char* barwindowsused;
+
+/** @brief Block size based on backend definition */
+const std::size_t block_size = page_size*CACHELINE;
+
+/**
+ * @brief	A write buffer in FIFO style with the capability to erase any
+ * element from the buffer while preserving ordering.
+ * @tparam	T the type of the write buffer
+ */
+template<typename T>
+class write_buffer
+{
+	private:
+		/** @brief This container holds cache indexes that should be written back */
+		std::deque<T> _buffer;
+
+		/** @brief The maximum size of the write buffer */
+		std::size_t _max_size;
+
+		/**
+		 * @brief The number of elements to write back once attempting to
+		 * add an element to an already full write buffer.
+		 */
+		std::size_t _write_back_size;
+
+		/** @brief	Mutex to protect the write buffer from simultaneous accesses */
+		mutable std::mutex _buffer_mutex;
+
+		/**
+		 * @brief	Check if the write buffer is empty
+		 * @return	True if empty, else False
+		 */
+		bool empty() {
+			return _buffer.empty();
+		}
+
+		/**
+		 * @brief	Get the size of the buffer
+		 * @return	The size of the buffer
+		 */
+		size_t size() {
+			return _buffer.size();
+		}
+
+		/**
+		 * @brief	Get the buffer element at index i
+		 * @param	i The requested buffer index
+		 * @return	The element at index i of type T
+		 */
+		T at(std::size_t i){
+			return _buffer.at(i);
+		}
+
+		/**
+		 * @brief	Check if val exists in the buffer
+		 * @param	val The value to check for
+		 * @return	True if val exists in the buffer, else False
+		 */
+		bool has(T val) {
+			typename std::deque<T>::iterator it = std::find(_buffer.begin(),
+					_buffer.end(), val);
+			return (it != _buffer.end());
+		}
+
+		/**
+		 * @brief	Constructs a new element and emplaces it at the back of the buffer
+		 * @param	args Properties of the new element to emplace back
+		 */
+		template<typename... Args>
+			void emplace_back( Args&&... args) {
+				_buffer.emplace_back(std::forward<Args>(args)...);
+			}
+
+		/**
+		 * @brief	Removes the front element from the buffer and returns it
+		 * @return	The element that was popped from the buffer
+		 */
+		T pop() {
+			auto elem = std::move(_buffer.front());
+			_buffer.pop_front();
+			return elem;
+		}
+
+		/**
+		 * @brief	Sorts all elements in ascending order
+		 */
+		void sort() {
+			std::sort(_buffer.begin(), _buffer.end());
+		}
+
+		/**
+		 * @brief	Sorts the first _write_back_size elements in ascending order
+		 */
+		void sort_first() {
+			assert(_buffer.size() >= _write_back_size);
+			std::sort(_buffer.begin(), _buffer.begin()+_write_back_size);
+		}
+
+		/**
+		 * @brief	Flushes first _write_back_size elements of the  ArgoDSM 
+		 * 			write buffer to memory
+		 * @pre		Require ibsem to be taken until parallel MPI
+		 * @pre		Require write_buffer_mutex to be held
+		 */
+		void flush_partial() {
+			// Sort the first _write_back_size elements
+			sort_first();
+
+			// For each element, handle the corresponding ArgoDSM page
+			for(std::size_t i = 0; i < _write_back_size; i++) {
+				// The code below should be replaced with a cache API
+				// call to write back a cached page
+				std::size_t cache_index = pop();
+				std::uintptr_t page_address = cacheControl[cache_index].tag;
+				void* page_ptr = static_cast<char*>(
+						argo::virtual_memory::start_address()) + page_address;
+
+				// Write back the page
+				mprotect(page_ptr, block_size, PROT_READ);
+				cacheControl[cache_index].dirty=CLEAN;
+				for(int i=0; i < CACHELINE; i++){
+					storepageDIFF(cache_index+i,page_size*i+page_address);
+				}
+			}
+
+			// Close any windows used to write back data
+			// This should be replaced with an API call
+			for(int i = 0; i < argo::backend::number_of_nodes(); i++){
+				if(barwindowsused[i] == 1){
+					MPI_Win_unlock(i, globalDataWindow[i]);
+					barwindowsused[i] = 0;
+				}
+			}
+		}
+
+	public:
+		/**
+		 * @brief	Constructor
+		 */
+		write_buffer()	:
+			_max_size(argo::env::write_buffer_size()/CACHELINE),
+			_write_back_size(argo::env::write_buffer_write_back_size()/CACHELINE) { }
+
+		/**
+		 * @brief	Copy constructor
+		 * @param	other The write_buffer object to copy from
+		 */
+		write_buffer(const write_buffer & other) {
+			// Ensure protection of data
+			std::lock_guard<std::mutex> lock_other(other._buffer_mutex);
+			// Copy data
+			_buffer = other._buffer;
+			_max_size = other._max_size;
+			_write_back_size = other._write_back_size;
+		}
+
+		/**
+		 * @brief	Copy assignment operator
+		 * @param	other the write_buffer object to copy assign from
+		 * @return	reference to the created copy
+		 */
+		write_buffer& operator=(const write_buffer & other) {
+			if(&other != this) {
+				// Ensure protection of data
+				std::unique_lock<std::mutex> lock_this(_buffer_mutex, std::defer_lock);
+				std::unique_lock<std::mutex> lock_other(other._buffer_mutex, std::defer_lock);
+				std::lock(lock_this, lock_other);
+				// Copy data
+				_buffer = other._buffer;
+				_max_size = other._max_size;
+				_write_back_size = other._write_back_size;
+			}
+			return *this;
+		}
+
+		/**
+		 * @brief	If val exists in buffer, delete it. Else, do nothing.
+		 * @param	val The value of type T to erase
+		 */
+		void erase(T val) {
+			std::lock_guard<std::mutex> lock(_buffer_mutex);
+
+			typename std::deque<T>::iterator it = std::find(_buffer.begin(),
+					_buffer.end(), val);
+			if(it != _buffer.end()){
+				_buffer.erase(it);
+			}
+		}
+
+		/**
+		 * @brief	Flushes the ArgoDSM write buffer to memory
+		 * @pre		Require ibsem to be taken until parallel MPI
+		 */
+		void flush() {
+			double t_start = MPI_Wtime();
+			std::lock_guard<std::mutex> lock(_buffer_mutex);
+
+			// Sort the write buffer if needed
+			if(!empty()) {
+				sort();
+			}
+
+			// For each element, handle the corresponding ArgoDSM page
+			while(!empty()) {
+				// The code below should be replaced with a cache API
+				// call to write back a cached page
+				std::size_t cache_index = pop();
+				std::uintptr_t page_address = cacheControl[cache_index].tag;
+				void* page_ptr = static_cast<char*>(
+						argo::virtual_memory::start_address()) + page_address;
+
+				// Write back the page
+				mprotect(page_ptr, block_size, PROT_READ);
+				cacheControl[cache_index].dirty=CLEAN;
+				for(int i=0; i < CACHELINE; i++){
+					storepageDIFF(cache_index+i,page_size*i+page_address);
+				}
+			}
+
+			// Close any windows used to write back data
+			// This should be replaced with an API call
+			for(int i = 0; i < argo::backend::number_of_nodes(); i++){
+				if(barwindowsused[i] == 1){
+					MPI_Win_unlock(i, globalDataWindow[i]);
+					barwindowsused[i] = 0;
+				}
+			}
+
+			// Update timer statistics
+			double t_stop = MPI_Wtime();
+			stats.flushtime = t_stop-t_start;
+		}
+
+		/**
+		 * @brief	Adds a new element to the write buffer
+		 * @param	val The value of type T to add to the buffer
+		 * @pre		Require ibsem to be taken until parallel MPI
+		 */
+		void add(T val) {
+			std::lock_guard<std::mutex> lock(_buffer_mutex);
+
+			// If already present in the buffer, do nothing
+			if(has(val)){
+				return;
+			}
+
+			// If the buffer is full, write back _write_back_size indices
+			if(size() >= _max_size){
+				double t_start = MPI_Wtime();
+				flush_partial();
+				double t_end = MPI_Wtime();
+				stats.writebacks+=CACHELINE;
+				stats.writebacktime+=t_end-t_start;
+			}
+
+			// Add val to the back of the buffer
+			emplace_back(val);
+		}
+
+}; //class
+
+#endif /* argo_write_buffer_hpp */

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -149,6 +149,16 @@ namespace argo {
 		void release() {
 			std::atomic_thread_fence(std::memory_order_release);
 		}
+		void _selective_acquire(void* addr, std::size_t size) {
+			(void)addr;
+			(void)size;
+			acquire();	// Selective acquire not actually possible here
+		}
+		void _selective_release(void* addr, std::size_t size) {
+			(void)addr;
+			(void)size;
+			release();	// Selective release not actually possible here
+		}
 
 		namespace atomic {
 			void _exchange(global_ptr<void> obj, void* desired,

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -27,6 +27,18 @@ namespace {
 	const std::size_t default_cache_size = 1ul<<30; // default: 1GB
 
 	/**
+	 * @brief default requested write buffer size (if environment variable is unset)
+	 * @see @ref ARGO_WRITE_BUFFER_SIZE
+	 */
+	const std::size_t default_write_buffer_size = 512; // default: 512 cache blocks
+
+	/**
+	 * @brief default requested write buffer write back size (if environment variable is unset)
+	 * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+	 */
+	const std::size_t default_write_buffer_write_back_size = 32; // default: 32 pages
+
+	/**
 	 * @brief environment variable used for requesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
@@ -37,6 +49,18 @@ namespace {
 	 * @see @ref ARGO_CACHE_SIZE
 	 */
 	const std::string env_cache_size = "ARGO_CACHE_SIZE";
+
+	/**
+	 * @brief environment variable used for requesting write buffer size
+	 * @see @ref ARGO_WRITE_BUFFER_SIZE
+	 */
+	const std::string env_write_buffer_size = "ARGO_WRITE_BUFFER_SIZE";
+
+	/**
+	 * @brief environment variable used for requesting write buffer write back size
+	 * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+	 */
+	const std::string env_write_buffer_write_back_size = "ARGO_WRITE_BUFFER_WRITE_BACK_SIZE";
 
 	/** @brief error message string */
 	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
@@ -55,6 +79,16 @@ namespace {
 	 * @brief cache size requested through the environment variable @ref ARGO_CACHE_SIZE
 	 */
 	std::size_t value_cache_size;
+
+	/**
+	 * @brief write buffer size requested through the environment variable @ref ARGO_WRITE_BUFFER_SIZE
+	 */
+	std::size_t value_write_buffer_size;
+
+	/**
+	 * @brief write buffer write back size requested through the environment variable @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+	 */
+	std::size_t value_write_buffer_write_back_size;
 
 	/** @brief flag to allow checking that environment variables have been read before accessing their values */
 	bool is_initialized = false;
@@ -100,6 +134,16 @@ namespace argo {
 		void init() {
 			value_memory_size = parse_env(env_memory_size, default_memory_size).second;
 			value_cache_size = parse_env(env_cache_size, default_cache_size).second;
+			value_write_buffer_size = parse_env(
+					env_write_buffer_size,
+					default_write_buffer_size).second;
+			value_write_buffer_write_back_size = parse_env(
+					env_write_buffer_write_back_size,
+					default_write_buffer_write_back_size).second;
+			// Limit the write buffer write back size to the write buffer size
+			if(value_write_buffer_write_back_size > value_write_buffer_size){
+				value_write_buffer_write_back_size = value_write_buffer_size;
+			}
 
 			is_initialized = true;
 		}
@@ -112,6 +156,16 @@ namespace argo {
 		std::size_t cache_size() {
 			assert_initialized();
 			return value_cache_size;
+		}
+
+		std::size_t write_buffer_size() {
+			assert_initialized();
+			return value_write_buffer_size;
+		}
+
+		std::size_t write_buffer_write_back_size() {
+			assert_initialized();
+			return value_write_buffer_write_back_size;
 		}
 
 	} // namespace env

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -21,6 +21,17 @@
  * @details This environment variable is only used if argo::init() is called with no
  *          cache_size parameter (or it has value 0). It can be accessed through
  *          @ref argo::env::cache_size() after argo::env::init() has been called.
+ *
+ * @envvar{ARGO_WRITE_BUFFER_SIZE} request a specific write buffer size in cache blocks
+ * @details This environment variable defaults to 512 cache blocks if not specified.
+ *          It can be accessed through @ref argo::env::write_buffer_size() after
+ *          argo::env::init() has been called.
+ *
+ * @envvar{ARGO_WRITE_BUFFER_WRITE_BACK_SIZE} request a specific write buffer write
+ * back size in cache blocks.
+ * @details This environment variable defaults to 32 cache blocks if not specified.
+ *          It can be accessed through @ref argo::env::write_buffer_write_back_size()
+ *          after argo::env::init() has been called.
  */
 
 namespace argo {
@@ -50,6 +61,20 @@ namespace argo {
 		 * @see @ref ARGO_CACHE_SIZE
 		 */
 		std::size_t cache_size();
+
+		/**
+		 * @brief get the write buffer size requested by environment variable
+		 * @return the requested write buffer size in cache blocks
+		 * @see @ref ARGO_WRITE_BUFFER_SIZE
+		 */
+		std::size_t write_buffer_size();
+
+		/**
+		 * @brief get the write buffer write back size requested by environment variable
+		 * @return the requested write buffer write back size in cache blocks
+		 * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+		 */
+		std::size_t write_buffer_write_back_size();
 	} // namespace env
 } // namespace argo
 


### PR DESCRIPTION
This PR aims to add selective coherence functionality to ArgoDSM through `argo::backend::selective_acquire(void* addr, std::size_t size)` and `argo::backend::selective_release(void* addr, std::size_t size)`. Selective coherence performs invalidation and downgrade just like their regular counterparts but limited to a region confined by `[addr, addr+size)`, without performing self-invalidation or self-downgrade on the remainder of the cache. Used in the correct situations, so long as the data race free property of the code is maintained, this can provide significant performance gains by reducing the amount of remote reads and writes.

This PR also includes a dedicated write buffer storing cache indexes to be written back to their remote homenodes, implemented with the goal of providing a FIFO-style buffer with the option to delete any given element from the buffer. This is required in order to delete a cache index that may exist anywhere in the buffer when performing selective coherence on the corresponding cached page. The size of the write buffer can be set through the environment variable `ARGO_WRITE_BUFFER_SIZE` and defaults to 512 pages if not set. The number of least recently added pages written back once attempting to add a new page to a full write buffer can be set through the environment variable `ARGO_WRITE_BUFFER_WRITE_BACK_SIZE` and defaults to 32 pages.