### PR TITLE
refactor global_tas_lock

### DIFF
--- a/docs/_includes/argo_example.cpp
+++ b/docs/_includes/argo_example.cpp
@@ -15,7 +15,7 @@ struct thread_args {
 int *data;
 int *max;
 
-bool *lock_flag;
+argo::globallock::global_tas_lock::internal_field_type *lock_field;
 argo::globallock::global_tas_lock *lock;
 
 void* parmax(void* argptr) {
@@ -55,8 +55,8 @@ int main(int argc, char* argv[]) {
 	local_num_threads = num_threads / argo::number_of_nodes();
 
 	// Initialize the lock
-	lock_flag = argo::conew_<bool>(false);
-	lock = new argo::globallock::global_tas_lock(lock_flag);
+	lock_field = argo::conew_<argo::globallock::global_tas_lock::internal_field_type>();
+	lock = new argo::globallock::global_tas_lock(lock_field);
 	// Allocate the array
 	data = argo::conew_array<int>(data_length);
 	max = argo::conew_<int>(std::numeric_limits<int>::min());
@@ -89,7 +89,7 @@ int main(int argc, char* argv[]) {
 
 	argo::codelete_array(data);
         delete lock;
-	argo::codelete_(lock_flag);
+	argo::codelete_(lock_field);
 	// Print the result
 	if (argo::node_id() == 0)
 		std::cout << "Max found to be " << *max << std::endl;

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -126,8 +126,8 @@ instead. The `global_tas_lock` requires as an argument a boolean variable to
 spin on, which of course has to be allocated on the global memory.
 
 ``` cpp
-lock_flag = argo::conew_<bool>(false);
-lock = new argo::globallock::global_tas_lock(lock_flag);
+lock_field = argo::conew_<argo::globallock::global_tas_lock::internal_field_type>();
+lock = new argo::globallock::global_tas_lock(lock_field);
 ```
 
 Finally, we need to take into consideration the fact that ArgoDSM runs multiple

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -55,8 +55,9 @@ namespace argo {
 					/**@todo this initialization should move to tools::init() land */
 					using namespace data_distribution;
 					naive_data_distribution<0>::set_memory_space(nodes, memory, max_size);
-					bool* flag = new (&memory[sizeof(std::size_t)]) bool;
-					global_tas_lock = new argo::globallock::global_tas_lock(flag);
+					using tas_lock = argo::globallock::global_tas_lock;
+					tas_lock::internal_field_type* field = new (&memory[sizeof(std::size_t)]) tas_lock::internal_field_type;
+					global_tas_lock = new tas_lock(field);
 
 					if(backend::node_id()==0){
 						/**@todo if needed - pad offset to be page or pagecache size and make sure offset and flag fits */

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -72,6 +72,13 @@ namespace argo {
 					while(!try_lock())
 						std::this_thread::yield();
 				}
+
+				/**
+				 * @brief internally used type for lock field
+				 * @note this type may change without warning,
+				 *       user code must use this type alias
+				 */
+				using internal_field_type = bool;
 		};
 	} // namespace globallock
 } // namespace argo

--- a/tests/lock.cpp
+++ b/tests/lock.cpp
@@ -44,23 +44,25 @@ protected:
 	argo::locallock::mcs_lock *mcs_lock;
 	/** @brief global cohort lock for testing */
 	argo::globallock::cohort_lock *cohort_lock;
+	/** @brief global tas lock type */
+	using tas_lock = argo::globallock::global_tas_lock;
 	/** @brief global tas lock for testing*/
-	argo::globallock::global_tas_lock *global_tas_lock;
-	/** @brief flag needed for the global tas lock*/
-	bool* flag;
+	tas_lock *global_tas_lock;
+	/** @brief field needed for the global tas lock*/
+	tas_lock::internal_field_type* field;
 	/** @brief global counter used in several tests */
 	int *counter;
 
 	LockTest() {
 		argo_reset();
 		argo::barrier();
-		flag = argo::conew_<bool>();
-		global_tas_lock = new argo::globallock::global_tas_lock(flag);
+		field = argo::conew_<tas_lock::internal_field_type>();
+		global_tas_lock = new tas_lock(field);
 		argo::barrier();
 	}
 
 	~LockTest() {
-		argo::codelete_(flag);
+		argo::codelete_(field);
 		delete global_tas_lock;
 		argo::barrier();
 	}


### PR DESCRIPTION
By introducing a typedef for the internal field type we will be able to
change the implementation of the lock without breaking the code that
uses the global_tas_lock.