### PR TITLE
Fix compilation with -DARGO_DEBUG=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(ARGO_VERSION_MAJOR 0)
 set(ARGO_VERSION_MINOR 1)
 
 set(DEFAULT_C_FLAGS "-std=c11 -pthread")
-set(DEFAULT_CXX_FLAGS "-std=c++11 -pthread")
+set(DEFAULT_CXX_FLAGS "-std=c++11 -pthread -DOMPI_SKIP_MPICXX=1")
 set(DEFAULT_LINK_FLAGS "")
 
 option(ARGO_DEBUG

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief MPI backend implemenation
+ * @brief MPI backend implementation
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
@@ -9,7 +9,6 @@
 #include <atomic>
 #include <type_traits>
 
-#include "mpi.h"
 #include "swdsm.h"
 
 /**

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <type_traits>
+#include <mpi.h>
 
 #include "swdsm.h"
 


### PR DESCRIPTION
Pass a CXX compiler option for bypassing a known issue
(https://github.com/open-mpi/ompi/issues/5157) in the C++
bindings for OpenMPI, which are deprecated anyway.

While at it, fix two small things I've noticed.