### PR TITLE
Exclude INSTANTIATE_TEST_CASE_P from doxygen output

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -795,7 +795,7 @@ EXCLUDE_PATTERNS       = */gtest-1.7.0/*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = argo_*_hpp argo_*_h
+EXCLUDE_SYMBOLS        = argo_*_hpp argo_*_h INSTANTIATE_TEST_CASE_P
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
This PR excludes INSTANTIATE_TEST_CASE_P from doxygen output
to suppress a missing parameter documentation warning when building with `ARGO_TESTS=ON` and `BUILD_DOCUMENTATION=ON` simultaneously.

As Doxygen macros are not defined by us, we can not provide their parameter documentation and should simply exclude symbols triggering this warning from Doxygen.