### PR TITLE
Improve first-touch data distribution

### DIFF
--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -250,13 +250,6 @@ unsigned int argo_get_nodes();
 unsigned int getThreadCount();
 
 /**
- * @brief Gives the backing memory offset of the ArgoDSM node for the local process
- * @return Returns the reference to the current offset for the local process
- * @note Implementation-specific function for the first-touch data distribution
- */
-std::size_t& get_local_data_offset();
-
-/**
  * @brief Gives a pointer to the global address space
  * @return Start address of the global address space
  */

--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -8,6 +8,8 @@
 #define argo_base_distribution_hpp argo_base_distribution_hpp
 
 #include <cstdlib>
+#include <iostream>
+#include <system_error>
 
 #include "../types/types.hpp"
 
@@ -15,6 +17,11 @@ namespace argo {
 	namespace data_distribution {
 		/** @brief page size for the implementations */
 		static constexpr std::size_t granularity = 0x1000UL;
+
+		/** @brief error message string for the implementations */
+		static const std::string msg_fetch_homenode_fail = "ArgoDSM failed to fetch a valid backing node. Please report a bug.";
+		/** @brief error message string for the implementations */
+		static const std::string msg_fetch_offset_fail = "ArgoDSM failed to fetch a valid backing offset. Please report a bug.";
 		
 		/**
 		 * @brief the base data distribution class

--- a/src/data_distribution/cyclic_distribution.hpp
+++ b/src/data_distribution/cyclic_distribution.hpp
@@ -25,6 +25,8 @@ namespace argo {
 					const node_id_t homenode = pagenum % base_distribution<instance>::nodes;
 
 					if(homenode >= base_distribution<instance>::nodes) {
+						std::cerr << msg_fetch_homenode_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
 						exit(EXIT_FAILURE);
 					}
 					return homenode;
@@ -38,6 +40,8 @@ namespace argo {
 					const std::size_t offset = pagenum / base_distribution<instance>::nodes * pageblock + addr % pageblock + drift;
 					
 					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+						std::cerr << msg_fetch_offset_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
 						exit(EXIT_FAILURE);
 					}
 					return offset;

--- a/src/data_distribution/first_touch_distribution.hpp
+++ b/src/data_distribution/first_touch_distribution.hpp
@@ -8,7 +8,6 @@
 #define argo_first_touch_distribution_hpp argo_first_touch_distribution_hpp
 
 #include <mutex>
-#include <iostream>
 
 #include "base_distribution.hpp"
 
@@ -21,26 +20,43 @@ namespace argo {
 	/* forward argo::backend function declarations */
 	namespace backend {
 		node_id_t node_id();
-		std::size_t& backing_offset();
 		/* forward argo::backend::atomic function declarations */
 		namespace atomic {
-			void _store_public_dir(const void* desired,
+			void _store_public_owners_dir(const void* desired,
 				const std::size_t size, const std::size_t rank, const std::size_t disp);
-			void _store_local_dir(const std::size_t desired,
+			void _store_local_owners_dir(const std::size_t* desired,
 				const std::size_t rank, const std::size_t disp);
-			void _load_local_dir(void* output_buffer,
+			void _store_local_offsets_tbl(const std::size_t desired,
 				const std::size_t rank, const std::size_t disp);
-			void _compare_exchange_dir(const void* desired, const void* expected, void* output_buffer,
+			void _load_public_owners_dir(void* output_buffer,
+				const std::size_t size, const std::size_t rank, const std::size_t disp);
+			void _load_local_owners_dir(void* output_buffer,
+				const std::size_t rank, const std::size_t disp);
+			void _load_local_offsets_tbl(void* output_buffer,
+				const std::size_t rank, const std::size_t disp);
+			void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
+				const std::size_t size, const std::size_t rank, const std::size_t disp);
+			void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
 				const std::size_t size, const std::size_t rank, const std::size_t disp);
 		} // namespace atomic
 	} // namespace backend
 } // namespace argo
+
+/** @brief tiny macro to find if all the values of `page_info` are equal to a specific value */
+#define is_all_equal_to(arr, val) (((arr[0] == val) && (arr[1] == val) && (arr[2] == val)) ? 1 : 0)
+/** @brief tiny macro to find if any of the values of `page_info` is equal to a specific value */
+#define is_one_equal_to(arr, val) (((arr[0] == val) || (arr[1] == val) || (arr[2] == val)) ? 1 : 0)
+
+/** @brief error message string */
+static const std::string msg_first_touch_fail = "ArgoDSM failed to find a backing node. Please report a bug.";
 
 namespace argo {
 	namespace data_distribution {
 		/**
 		 * @brief the first-touch data distribution
 		 * @details gives ownership of a page to the node that first touched it.
+		 * @note if a node's backing store size is not sufficient, it passes the
+		 *       ownership of the page to a node that can host it.
 		 */
 		template<int instance>
 		class first_touch_distribution : public base_distribution<instance> {
@@ -48,32 +64,37 @@ namespace argo {
 				/**
 				 * @brief try and claim ownership of a page
 				 * @param addr address in the global address space
-				 * @return the homenode of addr
 				 */
-				static std::size_t first_touch (const std::size_t& addr);
-				/** @brief protects the owner directory */
-				std::mutex owner_mutex;
+				static void first_touch (const std::size_t& addr);
+				/**
+				 * @brief perform the necessary directory actions
+				 * @param addr address in the global address space
+				 */
+				static void update_dirs (const std::size_t& addr);
+				/** @brief protects the owners directory */
+				std::mutex owners_mutex;
 
 			public:
 				virtual node_id_t homenode (char* const ptr) {
-					std::size_t homenode_bit_id;
+					std::size_t homenode;
+					static const std::size_t rank = argo::backend::node_id();
+					static const std::size_t global_null = base_distribution<instance>::total_size + 1;
 					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t owner_window_index = 2 * (addr / granularity);
+					const std::size_t owners_dir_window_index = 3 * (addr / granularity);
 
-					std::unique_lock<std::mutex> def_lock(owner_mutex, std::defer_lock);
+					std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
 					def_lock.lock();
-					argo::backend::atomic::_load_local_dir(&homenode_bit_id, argo::backend::node_id(), owner_window_index);
-					if (!homenode_bit_id) { homenode_bit_id = first_touch(addr); }
+					/* handle all the necessary directory actions for the global address */
+					update_dirs(addr);
+					/* spin in case the values other than `ownership` have not been reflected to the local window */
+					do {
+						argo::backend::atomic::_load_local_owners_dir(&homenode, rank, owners_dir_window_index);
+					} while (homenode == global_null);
 					def_lock.unlock();
 
-					node_id_t n, homenode;
-					for(n = 0; n < base_distribution<instance>::nodes; n++) {
-						if((1UL << n) == homenode_bit_id) {
-							homenode = n;
-						}
-					}
-
-					if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
+					if(homenode >= static_cast<std::size_t>(base_distribution<instance>::nodes)) {
+						std::cerr << msg_fetch_homenode_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
 						exit(EXIT_FAILURE);
 					}
 					return homenode;
@@ -81,26 +102,26 @@ namespace argo {
 
 				virtual std::size_t local_offset (char* const ptr) {
 					std::size_t offset;
+					static const std::size_t rank = argo::backend::node_id();
 					static const std::size_t global_null = base_distribution<instance>::total_size + 1;
 					const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
 					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t owner_window_index = 2 * (addr / granularity);
+					const std::size_t owners_dir_window_index = 3 * (addr / granularity);
 
-					std::unique_lock<std::mutex> def_lock(owner_mutex, std::defer_lock);
+					std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
 					def_lock.lock();
-					/* spin till an update from a remote node has been reflected in the local window */
+					/* handle all the necessary directory actions for the global address */
+					update_dirs(addr);
+					/* spin in case the values other than `ownership` have not been reflected to the local window */
 					do {
-						argo::backend::atomic::_load_local_dir(&offset, argo::backend::node_id(), owner_window_index+1);
-					} while(offset == global_null);
+						argo::backend::atomic::_load_local_owners_dir(&offset, rank, owners_dir_window_index+1);
+					} while (offset == global_null);
 					def_lock.unlock();
 					offset += drift;
 
-					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
-						std::cerr << "Maximum backing store size exceeded on node "
-								<< argo::backend::node_id() << "\n"
-								<< "\t- allocate more distributed memory or\n"
-								<< "\t- ensure better distribution of data"
-								<< std::endl;
+					if(offset >= base_distribution<instance>::size_per_node) {
+						std::cerr << msg_fetch_offset_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
 						exit(EXIT_FAILURE);
 					}
 					return offset;
@@ -108,40 +129,101 @@ namespace argo {
 		};
 
 		template<int instance>
-		std::size_t first_touch_distribution<instance>::first_touch (const std::size_t& addr) {
-			/* variables for CAS */
-			std::size_t homenode_bit_id, result;
-			constexpr std::size_t compare = 0;
-			const std::size_t id = 1UL << argo::backend::node_id();
-			const std::size_t owner_window_index = 2 * (addr / granularity);
-	    
-			/* check/try to acquire ownership of the page with CAS to process' 0 index */
-			argo::backend::atomic::_compare_exchange_dir(&id, &compare, &result, sizeof(std::size_t), 0, owner_window_index);
+		void first_touch_distribution<instance>::update_dirs (const std::size_t& addr) {
+			std::size_t ownership;
+			static const std::size_t rank = argo::backend::node_id();
+			static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+			const std::size_t owners_dir_window_index = 3 * (addr / granularity);
+			const std::size_t cas_node = (addr / granularity) % base_distribution<instance>::nodes;
 
-			/* this process was the first one to deposit the id */
-			if (result == 0) {
-				homenode_bit_id = id;
-
-				/* mark the page in the local window */
-				argo::backend::atomic::_store_local_dir(id, argo::backend::node_id(), owner_window_index);
-				argo::backend::atomic::_store_local_dir(argo::backend::backing_offset(), argo::backend::node_id(), owner_window_index+1);
-
-				/* mark the page in the public windows */
-				node_id_t n;
-				for(n = 0; n < base_distribution<instance>::nodes; n++) {
-					if (n != argo::backend::node_id()) {
-						argo::backend::atomic::_store_public_dir(&id, sizeof(std::size_t), n, owner_window_index);
-						argo::backend::atomic::_store_public_dir(&argo::backend::backing_offset(), sizeof(std::size_t), n, owner_window_index+1);
+			/* fetch the ownership value for the page from the local window */
+			argo::backend::atomic::_load_local_owners_dir(&ownership, rank, owners_dir_window_index+2);
+			/* check if no info is found locally regarding the page */
+			if (ownership == global_null) {
+				/* load page info from the public cas_node window */
+				std::size_t page_info[3];
+				argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), cas_node, owners_dir_window_index);
+				/* check if any page info is found on the cas_node window */
+				if (!is_all_equal_to(page_info, global_null)) {
+					/* make sure that all the remote values are read correctly */
+					if (rank != cas_node) {
+						while (is_one_equal_to(page_info, global_null)) {
+							argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), cas_node, owners_dir_window_index);
+						}
+						/* store page info in the local window */
+						argo::backend::atomic::_store_local_owners_dir(page_info, rank, owners_dir_window_index);
 					}
+				} else {
+					/* try to claim ownership of that page */
+					first_touch(addr);
 				}
-		
-				/* since a new page was acquired increase the homenode offset */
-				argo::backend::backing_offset() += granularity;
-			} else {
-				homenode_bit_id = result;
 			}
-			
-			return homenode_bit_id;
+		}
+
+		template<int instance>
+		void first_touch_distribution<instance>::first_touch (const std::size_t& addr) {
+			/* variables for CAS */
+			std::size_t offset, homenode, result;
+			static const std::size_t rank = argo::backend::node_id();
+			static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+			const std::size_t owners_dir_window_index = 3 * (addr / granularity);
+			/* decentralize CAS */
+			const std::size_t cas_node = (addr / granularity) % base_distribution<instance>::nodes;
+	    
+			/* check/try to acquire ownership of the page with CAS to process' cas_node index */
+			argo::backend::atomic::_compare_exchange_owners_dir(&rank, &global_null, &result, sizeof(std::size_t), cas_node, owners_dir_window_index+2);
+
+			/* this process was the first one to deposit its rank */
+			if (result == global_null) {
+				/* iterate through the nodes to find a valid offset for the page, starting from the currently running one */
+				bool succeeded = false;
+				std::size_t n, searched;
+				for(n = rank, searched = 0; searched < static_cast<std::size_t>(base_distribution<instance>::nodes);
+						n = (n + 1) % base_distribution<instance>::nodes, searched++) {
+					/* load backing offset for the node from the offsets table */
+					argo::backend::atomic::_load_local_offsets_tbl(&offset, rank, n);
+					/* check if the backing store size of this node is sufficient */
+					while (offset < base_distribution<instance>::size_per_node) {
+						/* try to claim a valid offset */
+						const std::size_t incr_offset = offset + granularity;
+						argo::backend::atomic::_compare_exchange_offsets_tbl(&incr_offset, &offset, &result, sizeof(std::size_t), n, n);
+						if (result == offset) { succeeded = true; homenode = n; break; }
+						offset = result;
+					}
+					/* cache the offset returned from a remote CAS operation */
+					if (n != rank) {
+						argo::backend::atomic::_store_local_offsets_tbl(offset, rank, n);
+					}
+					/* succeeded, leave */
+					if (succeeded) break;
+				}
+
+				/* this should never happen */
+				if (!succeeded) {
+					std::cerr << msg_first_touch_fail << std::endl;
+					throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_first_touch_fail);
+					exit(EXIT_FAILURE);
+				}
+
+				/* store page info in the local window */
+				std::size_t page_info[3] = {homenode, offset, rank};
+				argo::backend::atomic::_store_local_owners_dir(page_info, rank, owners_dir_window_index);
+
+				/* store page info in the remote public cas_node window */
+				if (rank != cas_node) {
+					argo::backend::atomic::_store_public_owners_dir(page_info, sizeof(std::size_t), cas_node, owners_dir_window_index);
+				}
+			} else {
+				/* load page info from the remote public cas_node window */
+				if (rank != cas_node) {
+					std::size_t page_info[3];
+					do {
+						argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), cas_node, owners_dir_window_index);
+					} while (is_one_equal_to(page_info, global_null));
+					/* store page info in the local window */
+					argo::backend::atomic::_store_local_owners_dir(page_info, rank, owners_dir_window_index);
+				}
+			}
 		}
 	} // namespace data_distribution
 } // namespace argo

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -25,6 +25,8 @@ namespace argo {
 					node_id_t homenode = addr / base_distribution<instance>::size_per_node;
 
 					if(homenode >= base_distribution<instance>::nodes) {
+						std::cerr << msg_fetch_homenode_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
 						exit(EXIT_FAILURE);
 					}
 					return homenode;
@@ -35,6 +37,8 @@ namespace argo {
 					std::size_t offset = addr - (homenode(ptr)) * base_distribution<instance>::size_per_node;
                     
 					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+						std::cerr << msg_fetch_offset_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
 						exit(EXIT_FAILURE);
 					}
 					return offset;

--- a/src/data_distribution/prime_mapp_distribution.hpp
+++ b/src/data_distribution/prime_mapp_distribution.hpp
@@ -28,6 +28,8 @@ namespace argo {
 					: pagenum % prime;
 
 					if(homenode >= base_distribution<instance>::nodes) {
+						std::cerr << msg_fetch_homenode_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
 						exit(EXIT_FAILURE);
 					}
 					return homenode;
@@ -59,6 +61,8 @@ namespace argo {
 					}
 
 					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+						std::cerr << msg_fetch_offset_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
 						exit(EXIT_FAILURE);
 					}
 					return offset;

--- a/src/data_distribution/skew_mapp_distribution.hpp
+++ b/src/data_distribution/skew_mapp_distribution.hpp
@@ -26,6 +26,8 @@ namespace argo {
 					const node_id_t homenode = (pagenum + pagenum / base_distribution<instance>::nodes + 1) % base_distribution<instance>::nodes;
 
 					if(homenode >= base_distribution<instance>::nodes) {
+						std::cerr << msg_fetch_homenode_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
 						exit(EXIT_FAILURE);
 					}
 					return homenode;
@@ -39,6 +41,8 @@ namespace argo {
 					const std::size_t offset = pagenum / base_distribution<instance>::nodes * pageblock + addr % pageblock + drift;
 
 					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+						std::cerr << msg_fetch_offset_fail << std::endl;
+						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
 						exit(EXIT_FAILURE);
 					}
 					return offset;

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -12,16 +12,6 @@
 
 #include "gtest/gtest.h"
 
-/**
- * @brief Team process initialize the array worked in tests:
- *        - selectiveArray
- *        - selectiveUnaligned
- *        - writeBufferLoad
- * @param 1 To enable team process initialization
- * @param 0 To disable team process initialization
- */
-#define TEAM_INIT 1
-
 /** @brief Global pointer to char */
 using global_char = typename argo::data_distribution::global_ptr<char>;
 /** @brief Global pointer to double */
@@ -34,7 +24,7 @@ using global_uint = typename argo::data_distribution::global_ptr<unsigned>;
 using global_intptr = typename argo::data_distribution::global_ptr<int*>;
 
 /** @brief ArgoDSM memory size */
-constexpr std::size_t size = 1<<25; // 32MB
+constexpr std::size_t size = 1<<24; // 16MB
 /** @brief ArgoDSM cache size */
 constexpr std::size_t cache_size = size;
 
@@ -64,32 +54,6 @@ class backendTest : public testing::Test, public ::testing::WithParamInterface<i
 			argo::barrier();
 		}
 };
-
-/**
- * @brief Function to distribute the workload among nodes
- * @param beg Points to the beginning of the chunk to be worked on
- * @param end Points to the end of the chunk to be worked on
- * @param loop_size Workload to distribute
- * @param beg_offset Offset at which the distribution loop begins
- * @param less_equal Set to `0` if the loop condition uses `<`
- *                   Set to `1` if the loop condition uses `<=`
- */
-static inline void distribute
-	(
-		std::size_t& beg,
-		std::size_t& end,
-		const std::size_t& loop_size,
-		const std::size_t& beg_offset = 0,
-    		const std::size_t& less_equal = 0
-	) {
-	std::size_t chunk = loop_size / argo::number_of_nodes();
-	beg = argo::node_id() * chunk + ((argo::node_id() == 0)
-		? beg_offset 
-		: less_equal);
-	end = (argo::node_id() != argo::number_of_nodes() - 1)
-		? argo::node_id() * chunk + chunk
-		: loop_size;
-}
 
 /**
  * @brief Test if atomic exchange writes the correct values
@@ -449,33 +413,11 @@ TEST_F(backendTest, selectiveArray) {
 		std::chrono::system_clock::now() + deadlock_threshold;
 
 	// Initialize
-	/**
-	 * @note Team process initialize for the pages
-	 *       to be distributed among nodes.
-	 * @warning If only one process handles initia-
-	 *          lization, under the first-touch me-
-	 *          mory policy, it is possible that
-	 *          this test fails since the backing
-	 *          store of that node is exceeded.
-	 * @todo This should not be the case in an
-	 *       improved version of first-touch or
-	 *       when the system is patched to be able
-	 *       to increase the size_per_node limit
-	 *       when that is not sufficient enough.
-	 */
-#if TEAM_INIT == 1
-	std::size_t beg, end;
-	distribute(beg, end, array_size);
-	for(std::size_t i=beg; i<end; i++){
-		array[i] = 0;
-	}
-#else
 	if(argo::node_id() == 0){
 		for(std::size_t i=0; i<array_size; i++){
 			array[i] = 0;
 		}
 	}
-#endif
 	argo::barrier();
 
 	// Set each array element on node 0, then set flag
@@ -528,33 +470,11 @@ TEST_F(backendTest, selectiveUnaligned) {
 		std::chrono::system_clock::now() + deadlock_threshold;
 
 	// Initialize
-	/**
-	 * @note Team process initialize for the pages
-	 *       to be distributed among nodes.
-	 * @warning If only one process handles initia-
-	 *          lization, under the first-touch me-
-	 *          mory policy, it is possible that
-	 *          this test fails since the backing
-	 *          store of that node is exceeded.
-	 * @todo This should not be the case in an
-	 *       improved version of first-touch or
-	 *       when the system is patched to be able
-	 *       to increase the size_per_node limit
-	 *       when that is not sufficient enough.
-	 */
-#if TEAM_INIT == 1
-	std::size_t beg, end;
-	distribute(beg, end, array_size);
-	for(std::size_t i=beg; i<end; i++){
-		array[i] = 0;
-	}
-#else
 	if(argo::node_id() == 0){
 		for(std::size_t i=0; i<array_size; i++){
 			array[i] = 0;
 		}
 	}
-#endif
 	argo::barrier();
 
 	// Set array elements on node 0, then set flag
@@ -615,33 +535,11 @@ TEST_F(backendTest, writeBufferLoad) {
 	std::uniform_int_distribution<int> dist(0,array_size-1);
 
 	// Initialize write buffer
-	/**
-	 * @note Team process initialize for the pages
-	 *       to be distributed among nodes.
-	 * @warning If only one process handles initia-
-	 *          lization, under the first-touch me-
-	 *          mory policy, it is possible that
-	 *          this test fails since the backing
-	 *          store of that node is exceeded.
-	 * @todo This should not be the case in an
-	 *       improved version of first-touch or
-	 *       when the system is patched to be able
-	 *       to increase the size_per_node limit
-	 *       when that is not sufficient enough.
-	 */
-#if TEAM_INIT == 1
-	std::size_t beg, end;
-	distribute(beg, end, array_size);
-	for(std::size_t i=beg; i<end; i++){
-		array[i] = 0;
-	}
-#else
 	if(argo::node_id() == 0){
 		for(std::size_t i=0; i<array_size; i++){
 			array[i] = 0;
 		}
 	}
-#endif
 	argo::barrier();
 
 	// One node at a time, increment random elements num_writes times

--- a/tests/uninitialized.cpp
+++ b/tests/uninitialized.cpp
@@ -14,7 +14,6 @@ constexpr std::size_t size = 1<<28;
 constexpr std::size_t cache_size = size/2;
 
 namespace mem = argo::mempools;
-namespace dd = argo::data_distribution;
 extern mem::global_memory_pool<>* default_global_mempool;
 
 /**
@@ -40,19 +39,6 @@ class UninitializedAccessTest : public testing::Test {
 TEST_F(UninitializedAccessTest, ReadUninitializedSinglenode) {
 	std::size_t allocsize = default_global_mempool->available();
 	char *tmp = static_cast<char*>(collective_alloc(allocsize));
-
-	/**
-	 * @note When running under first-touch, narrow down the size
-	 *       for the pages fit in the backing store of node_0.
-	 * @todo This should be removed in an improved version of
-	 *       first-touch or when the system is patched to be able
-	 *       to increase the size_per_node limit when that is not
-	 *       sufficient enough.
-	 */
-	if(dd::is_first_touch_policy()) {
-		allocsize = (allocsize / argo::number_of_nodes()) / 4096UL * 4096UL;
-	}
-
 	if(argo::node_id() == 0) {
 		for(std::size_t i = 0; i < allocsize; i++) {
 			ASSERT_NO_THROW(asm volatile ("" : "=m" (tmp[i]) : "r" (tmp[i])));


### PR DESCRIPTION
This PR improves the _first-touch_ data distribution so that it passes ownership of a page to a remote node, when its backing store is not of sufficient size to host more pages. Briefly, the node first checks if it has sufficient backing store size, and if not, then right-wise checks for availability in the rest of the nodes.

This PR also:
* Enables back pre-fetching for the _first-touch_ data distribution.
* Decentralizes the ownership CAS operation done in `first_touch()`.
* Performs the MPI RMA operations to the public windows in bulk.
* Limits these operations to a specific node, rather than broadcasting.
* Detaches the directory actions from `homenode()` and moves them to `dir_actions()`.
* Reverts the tests in `backend.cpp` and `uninitialized.cpp`, which were changed due to _first-touch_ in #44.

Note: The function `dir_actions()` is invoked both in the `homenode()` and `local_offset()` functions, which eliminates the pre-condition of the `getHomenode()` function to have to be invoked before `getOffset()` for a specific address.