### PR TITLE
Add option to initialize ArgoDSM with multi-threaded MPI support

### DIFF
--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -7,3 +7,11 @@ install(TARGETS argobackend-mpi
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib)
+
+option(ARGO_ENABLE_MT
+	"Enable support for multi-threaded MPI in ArgoDSM (MPI_THREAD_MULTIPLE)" OFF)
+if(ARGO_ENABLE_MT)
+	target_compile_definitions(argobackend-mpi PRIVATE ARGO_ENABLE_MT=1)
+else()
+	target_compile_definitions(argobackend-mpi PRIVATE ARGO_ENABLE_MT=0)
+endif()

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -695,7 +695,7 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 
 void initmpi(){
 	int ret,initialized,thread_status;
-	int thread_level = MPI_THREAD_SERIALIZED;
+	int thread_level = (ARGO_ENABLE_MT == 1) ? MPI_THREAD_MULTIPLE : MPI_THREAD_SERIALIZED;
 	MPI_Initialized(&initialized);
 	if (!initialized){
 		ret = MPI_Init_thread(NULL,NULL,thread_level,&thread_status);


### PR DESCRIPTION
This PR adds the CMake option `ARGO_ENABLE_MT` that ensures ArgoDSM is initalized with thread level `MPI_THREAD_MULTIPLE`. The default value of this option is `OFF`, as ArgoDSM itself does not yet make use of multithreaded MPI communication. Setting this to `ON` is necessary in order to support use of the ArgoDSM library in applications that already rely on multi-threaded MPI operations.

I believe that a CMake option is a better choice than an environment variable, even if this requires rebuilding ArgoDSM to change the state, as this ensures that the feature remains in the same state (ON or OFF) even if there are changes to the environment.