### PR TITLE
Avoid first-touching pages by default in C++ alloc

### DIFF
--- a/src/allocators/collective_allocator.hpp
+++ b/src/allocators/collective_allocator.hpp
@@ -106,7 +106,7 @@ namespace argo {
 
 		void* ptr = collective_alloc(sizeof(T));
 		using namespace data_distribution;
-		global_ptr<void> gptr(ptr);
+		global_ptr<void> gptr(ptr, false, false);
 		// The home node of ptr handles initialization
 		if (initialize && argo::backend::node_id() == gptr.node()) {
 			new (ptr) T(std::forward<Ps>(ps)...);
@@ -164,7 +164,7 @@ namespace argo {
 		}
 
 		using namespace data_distribution;
-		global_ptr<T> gptr(ptr);
+		global_ptr<T> gptr(ptr, false, false);
 		// The home node of ptr handles deinitialization
 		if (deinitialize && argo::backend::node_id() == gptr.node()) {
 			ptr->~T();
@@ -217,7 +217,7 @@ namespace argo {
 
 		void* ptr = collective_alloc(sizeof(T) * size);
 		using namespace data_distribution;
-		global_ptr<void> gptr(ptr);
+		global_ptr<void> gptr(ptr, false, false);
 		// The home node of ptr handles initialization
 		if (initialize && argo::backend::node_id() == gptr.node()) {
 			new (ptr) T[size]();
@@ -268,7 +268,7 @@ namespace argo {
 		}
 
 		using namespace data_distribution;
-		global_ptr<T> gptr(ptr);
+		global_ptr<T> gptr(ptr, false, false);
 		// The home node of ptr handles deinitialization
 		if (deinitialize && argo::backend::node_id() == gptr.node()) {
 			auto elements =


### PR DESCRIPTION
This PR fixes #58 by ensuring that the C++ (de)allocators and do not erroneously first-touch pages that are not set to be (de)initialized under the first-touch allocation policy. The cause of this error was that the default `global_ptr` constructor calculates the homenode and node local offset of the given address, which for _first-touch_ corresponds to first-touching the page.

https://github.com/etascale/argodsm/blob/70e7392a6e5bb6fc7076f93f7e52f6471de83867/src/data_distribution/global_ptr.hpp#L40-L55

By passing `false` to both `compute_homenode` and `compute_offset`, _first-touch_ of the page is delayed until after evaluation of the `initialize` parameter, and is only performed if this evaluates to true.

Jenkins testing run 408 and 409 show unchanged performance as expected, since this error only concerns the first page of each allocation.

