### PR TITLE
Parallel backend

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -387,7 +387,7 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # If one adds a struct or class to a group and this option is enabled, then also
 # any nested class or struct is added to the same group. By default this option

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -227,15 +227,5 @@ export ARGO_WRITE_BUFFER_WRITE_BACK_SIZE=64
 
 ## Multi-threaded MPI Support
 
-If the ArgoDSM library is used inside a project that already utilizes MPI,
-it is important to remember that MPI may only be initialized once. We
-advise that ArgoDSM is left to initialize MPI, as deferring initialization
-is not supported. ArgoDSM currently does not exploit multi-threaded MPI,
-and therefore by default initializes MPI with thread level
-`MPI_THREAD_SERIALIZED`. It is possible to force ArgoDSM to initialize MPI
-with support for multi-threaded MPI (`MPI_THREAD_MULTIPLE`); should this be
-requested by setting the CMake option `-DARGO_ENABLE_MT=ON` before building
-ArgoDSM. Note that support for, and the stability of, RMA over
-multi-threaded MPI depends on the MPI implementation, and therefore it is
-recommended to use this option only with the latest stable release of any
-MPI implementation.
+ArgoDSM now requires and utilizes multi-threaded MPI. Please ensure that
+your MPI installation supports `MPI_THREAD_MULTIPLE`.

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -106,12 +106,12 @@ namespace argo {
 		backend::barrier();
 	}
 
-	int node_id() {
-		return static_cast<int>(argo::backend::node_id());
+	argo::node_id_t node_id() {
+		return argo::backend::node_id();
 	}
 
-	int number_of_nodes() {
-		return static_cast<int>(argo::backend::number_of_nodes());
+	argo::num_nodes_t number_of_nodes() {
+		return argo::backend::number_of_nodes();
 	}
 
 	std::size_t get_block_size() {
@@ -144,7 +144,7 @@ extern "C" {
 		return argo::is_argo_address(addr);
 	}
 
-	int argo_get_homenode(void* addr) {
+	argo::node_id_t argo_get_homenode(void* addr) {
 		return argo::get_homenode(addr);
 	}
 

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -60,8 +60,8 @@ namespace argo {
 				"Invalid load size (must be a number bigger than 0)");
 		}
 
-		std::size_t requested_argo_mpi_windows = env::mpi_windows();
-		if(requested_argo_mpi_windows == 0) {
+		std::size_t requested_argo_mpi_windows_per_node = env::mpi_windows_per_node();
+		if(requested_argo_mpi_windows_per_node == 0) {
 			throw std::invalid_argument(
 				"Invalid number of MPI windows (must be a number bigger than 0)");
 		}

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -60,10 +60,10 @@ namespace argo {
 				"Invalid load size (must be a number bigger than 0)");
 		}
 
-		std::size_t requested_argo_mpi_win_granularity = env::mpi_win_granularity();
-		if(requested_argo_mpi_win_granularity == 0) {
+		std::size_t requested_argo_mpi_windows = env::mpi_windows();
+		if(requested_argo_mpi_windows == 0) {
 			throw std::invalid_argument(
-				"Invalid cache block size (must be a number bigger than 0)");
+				"Invalid number of MPI windows (must be a number bigger than 0)");
 		}
 
 		std::size_t requested_argo_print_level = env::print_statistics();

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -55,7 +55,7 @@ namespace argo {
 		}
 
 		std::size_t requested_argo_load_size = env::load_size();
-		if(requested_argo_block_size == 0) {
+		if(requested_argo_load_size == 0) {
 			throw std::invalid_argument(
 				"Invalid load size (must be a number bigger than 0)");
 		}

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -54,6 +54,18 @@ namespace argo {
 				"Invalid page block size (must be a number bigger than 0)");
 		}
 
+		std::size_t requested_argo_load_size = env::load_size();
+		if(requested_argo_block_size == 0) {
+			throw std::invalid_argument(
+				"Invalid load size (must be a number bigger than 0)");
+		}
+
+		std::size_t requested_argo_mpi_win_granularity = env::mpi_win_granularity();
+		if(requested_argo_mpi_win_granularity == 0) {
+			throw std::invalid_argument(
+				"Invalid cache block size (must be a number bigger than 0)");
+		}
+
 		/* note: the backend must currently initialize before the mempool can be set */
 		backend::init(requested_argo_size, requested_cache_size);
 		default_global_mempool = new mp();

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -66,6 +66,12 @@ namespace argo {
 				"Invalid cache block size (must be a number bigger than 0)");
 		}
 
+		std::size_t requested_argo_print_level = env::print_statistics();
+		if(requested_argo_print_level > 3) {
+			throw std::invalid_argument(
+				"Invalid statistics level (must be a number between 0 and 3)");
+		}
+
 		/* note: the backend must currently initialize before the mempool can be set */
 		backend::init(requested_argo_size, requested_cache_size);
 		default_global_mempool = new mp();

--- a/src/argo.h
+++ b/src/argo.h
@@ -64,7 +64,7 @@ bool argo_is_argo_address(void* addr);
  * been first-touched under the first-touch allocation policy
  * @pre addr must be an address in ArgoDSM memory
  */
-int argo_get_homenode(void* addr);
+argo::node_id_t argo_get_homenode(void* addr);
 
 /**
  * @brief Get the block size of the current allocation policy

--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -69,12 +69,12 @@ namespace argo {
 	 * @brief A unique ArgoDSM node identifier. Counting starts from 0.
 	 * @return The node ID
 	 */
-	int node_id();
+	argo::node_id_t node_id();
 	/**
 	 * @brief Number of ArgoDSM nodes being run
 	 * @return The total number of ArgoDSM nodes
 	 */
-	int number_of_nodes();
+	argo::num_nodes_t number_of_nodes();
 
 	/**
 	 * @brief Check if addr belongs in the ArgoDSM memory space
@@ -100,7 +100,7 @@ namespace argo {
 	 * @pre addr must be an address in ArgoDSM memory
 	 */
 	template<typename T>
-	int get_homenode(T* addr) {
+	argo::node_id_t get_homenode(T* addr) {
 		data_distribution::global_ptr<T> gptr(addr, false, false);
 		return gptr.peek_node();
 	}

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -100,6 +100,11 @@ namespace argo {
 		bool is_cached(void* addr);
 
 		/**
+		 * @brief Resets statistics for the ArgoDSM backend in use
+		 */
+		void reset_stats();
+
+		/**
 		 * @brief global memory space address
 		 * @deprecated prototype implementation detail
 		 */

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
-add_library(argobackend-mpi SHARED mpi.cpp swdsm.cpp coherence.cpp)
+add_library(argobackend-mpi SHARED mpi.cpp swdsm.cpp coherence.cpp mpi_lock.cpp)
 target_link_libraries(argobackend-mpi qd)
 
 install(TARGETS argobackend-mpi

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -8,11 +8,3 @@ install(TARGETS argobackend-mpi
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib)
-
-option(ARGO_ENABLE_MT
-	"Enable support for multi-threaded MPI in ArgoDSM (MPI_THREAD_MULTIPLE)" OFF)
-if(ARGO_ENABLE_MT)
-	target_compile_definitions(argobackend-mpi PRIVATE ARGO_ENABLE_MT=1)
-else()
-	target_compile_definitions(argobackend-mpi PRIVATE ARGO_ENABLE_MT=0)
-endif()

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -4,12 +4,13 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
-#include "../backend.hpp"
-#include "swdsm.h"
-#include "write_buffer.hpp"
-#include "mpi_lock.hpp"
-#include "virtual_memory/virtual_memory.hpp"
 #include <vector>
+
+#include "../backend.hpp"
+#include "mpi_lock.hpp"
+#include "swdsm.h"
+#include "virtual_memory/virtual_memory.hpp"
+#include "write_buffer.hpp"
 
 // EXTERNAL VARIABLES FROM BACKEND
 /**

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -144,7 +144,9 @@ namespace argo {
 			}
 
 			double t2 = MPI_Wtime();
-			stats.ssitime += t2-t1;
+			auto current = stats.ssi_time.load();
+			while (!stats.ssi_time.compare_exchange_weak(current, current+t2-t1))
+				;
 
 			// Poke the MPI system to force progress
 			int flag;
@@ -200,7 +202,9 @@ namespace argo {
 			}
 
 			double t2 = MPI_Wtime();
-			stats.ssdtime += t2-t1;
+			auto current = stats.ssd_time.load();
+			while (!stats.ssd_time.compare_exchange_weak(current, current+t2-t1))
+				;
 
 			// Poke the MPI system to force progress
 			int flag;

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -66,8 +66,8 @@ extern write_buffer<std::size_t>* argo_write_buffer;
 namespace argo {
 	namespace backend {
 		void _selective_acquire(void *addr, std::size_t size){
+			// Skip selective acquire if the size of the region is 0
 			if(size == 0){
-				// Nothing to invalidate
 				return;
 			}
 
@@ -151,8 +151,8 @@ namespace argo {
 		}
 
 		void _selective_release(void *addr, std::size_t size){
+			// Skip selective release if the size of the region is 0
 			if(size == 0){
-				// Nothing to downgrade
 				return;
 			}
 
@@ -180,6 +180,7 @@ namespace argo {
 					homenode_id == argo::data_distribution::invalid_node_id) {
 					continue;
 				}
+
 				const std::size_t cache_index = getCacheIndex(page_address);
 				cache_locks[cache_index].lock();
 

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -136,11 +136,7 @@ namespace argo {
 				}
 				cache_locks[cache_index].unlock();
 			}
-
 			double t2 = MPI_Wtime();
-			auto current = stats.ssi_time.load();
-			while (!stats.ssi_time.compare_exchange_weak(current, current+t2-t1))
-				;
 
 			// Poke the MPI system to force progress
 			int flag;
@@ -148,6 +144,9 @@ namespace argo {
 
 			// Release relevant mutexes
 			pthread_rwlock_unlock(&sync_lock);
+
+			std::lock_guard<std::mutex> ssi_time_lock(stats.ssi_time_mutex);
+			stats.ssi_time += t2-t1;
 		}
 
 		void _selective_release(void *addr, std::size_t size){
@@ -195,11 +194,7 @@ namespace argo {
 				}
 				cache_locks[cache_index].unlock();
 			}
-
 			double t2 = MPI_Wtime();
-			auto current = stats.ssd_time.load();
-			while (!stats.ssd_time.compare_exchange_weak(current, current+t2-t1))
-				;
 
 			// Poke the MPI system to force progress
 			int flag;
@@ -207,6 +202,9 @@ namespace argo {
 
 			// Release relevant mutexes
 			pthread_rwlock_unlock(&sync_lock);
+
+			std::lock_guard<std::mutex> ssd_time_lock(stats.ssd_time_mutex);
+			stats.ssd_time += t2-t1;
 		}
 	} //namespace backend
 } //namespace argo

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -22,11 +22,6 @@ extern control_data *cacheControl;
  * @deprecated Should eventually be handled by a cache module
  */
 extern std::uint64_t *globalSharers;
-///**
-// * @brief A cache mutex protects all operations on cacheControl
-// * @deprecated Should eventually be handled by a cache module
-// */
-//extern pthread_mutex_t cachemutex;
 /**
  * @brief A vector containing cache locks
  * @deprecated Should eventually be handled by a cache module
@@ -86,7 +81,6 @@ namespace argo {
 
 			// Lock relevant mutexes. Start statistics timekeeping
 			double t1 = MPI_Wtime();
-			//pthread_mutex_lock(&cachemutex);
 			pthread_rwlock_rdlock(&sync_lock);
 
 			// Iterate over all pages to selectively invalidate

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -197,7 +197,6 @@ namespace argo {
 					cacheControl[cache_index].dirty = CLEAN;
 				}
 				cache_locks[cache_index].unlock();
-				//TODO: Does this have to be outside?
 			}
 
 			double t2 = MPI_Wtime();

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -54,14 +54,6 @@ extern std::uintptr_t *global_owners_dir;
 extern std::uintptr_t *global_offsets_tbl;
 
 /**
- * @todo should be changed to qd-locking (but need to be replaced in the other files as well)
- *       or removed when infiniband/the mpi implementations allows for multithreaded accesses to the interconnect
- * @deprecated prototype implementation detail
- */
-#include <semaphore.h>
-extern sem_t ibsem;
-
-/**
  * @brief Returns an MPI integer type that exactly matches in size the argument given
  *
  * @param size The size of the datatype to be returned
@@ -201,9 +193,7 @@ namespace argo {
 
 		template<typename T>
 		void broadcast(node_id_t source, T* ptr) {
-			sem_wait(&ibsem);
 			MPI_Bcast(static_cast<void*>(ptr), sizeof(T), MPI_BYTE, source, workcomm);
-			sem_post(&ibsem);
 		}
 
 		void acquire() {
@@ -220,25 +210,21 @@ namespace argo {
 		namespace atomic {
 			void _exchange(global_ptr<void> obj, void* desired,
 					std::size_t size, void* output_buffer) {
-				sem_wait(&ibsem);
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the exchange operation
 				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, obj.node(), 0, globalDataWindow[0]);
 				MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), obj.offset(), MPI_REPLACE, globalDataWindow[0]);
 				MPI_Win_unlock(obj.node(), globalDataWindow[0]);
 				// Cleanup
-				sem_post(&ibsem);
 			}
 
 			void _store(global_ptr<void> obj, void* desired, std::size_t size) {
-				sem_wait(&ibsem);
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, obj.node(), 0, globalDataWindow[0]);
 				MPI_Put(desired, 1, t_type, obj.node(), obj.offset(), 1, t_type, globalDataWindow[0]);
 				MPI_Win_unlock(obj.node(), globalDataWindow[0]);
 				// Cleanup
-				sem_post(&ibsem);
 			}
 
 			void _store_public_owners_dir(const void* desired,
@@ -269,14 +255,12 @@ namespace argo {
 
 			void _load(global_ptr<void> obj, std::size_t size,
 					void* output_buffer) {
-				sem_wait(&ibsem);
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				MPI_Win_lock(MPI_LOCK_SHARED, obj.node(), 0, globalDataWindow[0]);
 				MPI_Get(output_buffer, 1, t_type, obj.node(), obj.offset(), 1, t_type, globalDataWindow[0]);
 				MPI_Win_unlock(obj.node(), globalDataWindow[0]);
 				// Cleanup
-				sem_post(&ibsem);
 			}
 
 			void _load_public_owners_dir(void* output_buffer,
@@ -309,14 +293,12 @@ namespace argo {
 
 			void _compare_exchange(global_ptr<void> obj, void* desired,
 					std::size_t size, void* expected, void* output_buffer) {
-				sem_wait(&ibsem);
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, obj.node(), 0, globalDataWindow[0]);
 				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), obj.offset(), globalDataWindow[0]);
 				MPI_Win_unlock(obj.node(), globalDataWindow[0]);
 				// Cleanup
-				sem_post(&ibsem);
 			}
 
 			void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
@@ -352,13 +334,11 @@ namespace argo {
 			 */
 			void _fetch_add(global_ptr<void> obj, void* value,
 					MPI_Datatype t_type, void* output_buffer) {
-				sem_wait(&ibsem);
 				// Perform the exchange operation
 				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, obj.node(), 0, globalDataWindow[0]);
 				MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), obj.offset(), MPI_SUM, globalDataWindow[0]);
 				MPI_Win_unlock(obj.node(), globalDataWindow[0]);
 				// Cleanup
-				sem_post(&ibsem);
 			}
 
 			void _fetch_add_int(global_ptr<void> obj, void* value,

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -221,9 +221,10 @@ namespace argo {
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the exchange operation
 				std::size_t win_index = get_data_win_index(obj.offset());
+				std::size_t win_offset = get_data_win_offset(obj.offset());
 				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), obj.offset(), MPI_REPLACE, data_windows[win_index][obj.node()]);
+				MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
 				// Cleanup
 			}
@@ -232,9 +233,9 @@ namespace argo {
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				std::size_t win_index = get_data_win_index(obj.offset());
-				// TODO: Does this have to be to node 0 like in prev implementation?
+				std::size_t win_offset = get_data_win_offset(obj.offset());
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Put(desired, 1, t_type, obj.node(), obj.offset(), 1, t_type, data_windows[win_index][obj.node()]);
+				MPI_Put(desired, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
 				// Cleanup
 			}
@@ -270,9 +271,10 @@ namespace argo {
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				std::size_t win_index = get_data_win_index(obj.offset());
+				std::size_t win_offset = get_data_win_offset(obj.offset());
 				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Get(output_buffer, 1, t_type, obj.node(), obj.offset(), 1, t_type, data_windows[win_index][obj.node()]);
+				MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
 				// Cleanup
 			}
@@ -310,9 +312,10 @@ namespace argo {
 				MPI_Datatype t_type = fitting_mpi_int(size);
 				// Perform the store operation
 				std::size_t win_index = get_data_win_index(obj.offset());
+				std::size_t win_offset = get_data_win_offset(obj.offset());
 				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), obj.offset(), data_windows[win_index][obj.node()]);
+				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
 				// Cleanup
 			}
@@ -352,9 +355,10 @@ namespace argo {
 					MPI_Datatype t_type, void* output_buffer) {
 				// Perform the exchange operation
 				std::size_t win_index = get_data_win_index(obj.offset());
+				std::size_t win_offset = get_data_win_offset(obj.offset());
 				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), obj.offset(), MPI_SUM, data_windows[win_index][obj.node()]);
+				MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
 				// Cleanup
 			}

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -187,6 +187,10 @@ namespace argo {
 			return _is_cached(reinterpret_cast<std::size_t>(addr));
 		}
 
+		void reset_stats(){
+			argo_reset_stats();
+		}
+
 		void finalize() {
 			argo_finalize();
 		}

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <atomic>
 #include <type_traits>
-#include <vector>
 
 #include "swdsm.h"
 #include "../backend.hpp"

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -226,7 +226,6 @@ namespace argo {
 				// Perform the exchange operation
 				std::size_t win_index = get_data_win_index(obj.offset());
 				std::size_t win_offset = get_data_win_offset(obj.offset());
-				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
@@ -274,7 +273,6 @@ namespace argo {
 				// Perform the store operation
 				std::size_t win_index = get_data_win_index(obj.offset());
 				std::size_t win_offset = get_data_win_offset(obj.offset());
-				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
@@ -314,7 +312,6 @@ namespace argo {
 				// Perform the store operation
 				std::size_t win_index = get_data_win_index(obj.offset());
 				std::size_t win_offset = get_data_win_offset(obj.offset());
-				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
@@ -356,7 +353,6 @@ namespace argo {
 				// Perform the exchange operation
 				std::size_t win_index = get_data_win_index(obj.offset());
 				std::size_t win_offset = get_data_win_offset(obj.offset());
-				// TODO: Does this have to be to node 0 like in prev implementation?
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -230,7 +230,6 @@ namespace argo {
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-				// Cleanup
 			}
 
 			void _store(global_ptr<void> obj, void* desired, std::size_t size) {
@@ -241,7 +240,6 @@ namespace argo {
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Put(desired, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-				// Cleanup
 			}
 
 			void _store_public_owners_dir(const void* desired,
@@ -280,7 +278,6 @@ namespace argo {
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-				// Cleanup
 			}
 
 			void _load_public_owners_dir(void* output_buffer,
@@ -321,7 +318,6 @@ namespace argo {
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-				// Cleanup
 			}
 
 			void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
@@ -364,7 +360,6 @@ namespace argo {
 				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
 				MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
 				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-				// Cleanup
 			}
 
 			void _fetch_add_int(global_ptr<void> obj, void* value,

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief       This file provices an implementation of a specialized MPI lock allowing
+ * @brief       This file provides an implementation of a specialized MPI lock allowing
  *              multiple threads to access an MPI Window concurrently.
  * @copyright   Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -7,87 +7,72 @@
 
 #include "mpi_lock.hpp"
 
-mpi_lock::mpi_lock()
-	: num_locks(0),
-	/* spin lock statistics */
-	spin_lock_time(0),
-	max_spin_lock_time(0),
-	spin_hold_time(0),
-	max_spin_hold_time(0),
-	/* MPI lock statistics */
-	mpi_lock_time(0),
-	max_mpi_lock_time(0),
-	mpi_unlock_time(0),
-	max_mpi_unlock_time(0),
-	mpi_hold_time(0),
-	max_mpi_hold_time(0)
-{
-	pthread_spin_init(&spin_lock, PTHREAD_PROCESS_PRIVATE);
+mpi_lock::mpi_lock() {
+	pthread_spin_init(&_local_lock, PTHREAD_PROCESS_PRIVATE);
 };
 
 
 void mpi_lock::lock(int lock_type, int target, MPI_Win window){
 
-	// Take global spinlock
-	double spin_start = MPI_Wtime();
-	pthread_spin_lock(&spin_lock);
-	double spin_end = MPI_Wtime();
-	spin_acquire_time = spin_end;
+	// Take the local lock
+	double local_start = MPI_Wtime();
+	pthread_spin_lock(&_local_lock);
+	double local_end = MPI_Wtime();
+	_local_acquire_time = local_end;
 
-	// Lock MPI
+	// Take the MPI lock
 	double mpi_start = MPI_Wtime();
 	MPI_Win_lock(lock_type, target, 0, window);
 	double mpi_end = MPI_Wtime();
-	mpi_acquire_time = mpi_end;
+	_mpi_acquire_time = mpi_end;
 
-	num_locks++;
-	/* Update max lock times */
-	if((spin_end-spin_start) > max_spin_lock_time){
-		max_spin_lock_time = spin_end-spin_start;
+	_num_locks++;
+	// Update max lock times
+	if((local_end - local_start) > _max_local_lock_time){
+		_max_local_lock_time = local_end - local_start;
 	}
-	if((mpi_end-mpi_start) > max_mpi_lock_time){
-		max_mpi_lock_time = mpi_end - mpi_start;
+	if((mpi_end - mpi_start) > _max_mpi_lock_time){
+		_max_mpi_lock_time = mpi_end - mpi_start;
 	}
-	/* Update time spent in lock */
-	mpi_lock_time += mpi_end-mpi_start;
-	spin_lock_time += spin_end-spin_start;
+	// Update time spent in lock
+	_mpi_lock_time += mpi_end - mpi_start;
+	_local_lock_time += local_end - local_start;
 }
 
 void mpi_lock::unlock(int target, MPI_Win window){
-
-	/* Unlock MPI */
+	// Unlock MPI
 	double mpi_start = MPI_Wtime();
 	MPI_Win_unlock(target, window);
 	double mpi_end = MPI_Wtime();
-	mpi_release_time = mpi_end;
+	_mpi_release_time = mpi_end;
 
-	/* Update time spent in MPI lock */
-	mpi_unlock_time += mpi_end-mpi_start;
-	mpi_hold_time += mpi_release_time-mpi_acquire_time;
-	/* Update max time holding an MPI lock if new record*/
-	if((mpi_release_time-mpi_acquire_time) > max_mpi_hold_time){
-		max_mpi_hold_time = mpi_release_time-mpi_acquire_time;
+	// Update time spent in MPI lock
+	_mpi_unlock_time += mpi_end - mpi_start;
+	_mpi_hold_time += _mpi_release_time - _mpi_acquire_time;
+	// Update max time holding an MPI lock if new record
+	if((_mpi_release_time - _mpi_acquire_time) > _max_mpi_hold_time){
+		_max_mpi_hold_time = _mpi_release_time - _mpi_acquire_time;
 	}
 
-	/* Update the time spent in spin lock */
-	spin_release_time = MPI_Wtime();
-	spin_hold_time += spin_release_time-spin_acquire_time;
-	/* Update max time holding a spin lock if new record*/
-	if((spin_release_time-spin_acquire_time) > max_spin_hold_time){
-		max_spin_hold_time = spin_release_time-spin_acquire_time;
+	// Update the time spent in local lock
+	_local_release_time = MPI_Wtime();
+	_local_hold_time += _local_release_time - _local_acquire_time;
+	// Update max time holding a local lock if new record
+	if((_local_release_time - _local_acquire_time) > _max_local_hold_time){
+		_max_local_hold_time = _local_release_time - _local_acquire_time;
 	}
 
-	/* Release the spinlock */
-	pthread_spin_unlock(&spin_lock);
+	// Release the local lock
+	pthread_spin_unlock(&_local_lock);
 }
 
 bool mpi_lock::trylock(int lock_type, int target, MPI_Win window){
-	// Try to take global spinlock
-	if(!pthread_spin_trylock(&spin_lock)){
-		spin_acquire_time = MPI_Wtime();
+	// Try to take local lock
+	if(!pthread_spin_trylock(&_local_lock)){
+		_local_acquire_time = MPI_Wtime();
 		// Lock MPI
 		MPI_Win_lock(lock_type, target, 0, window);
-		mpi_acquire_time = MPI_Wtime();
+		_mpi_acquire_time = MPI_Wtime();
 		return true;
 	}
 	return false;
@@ -95,23 +80,23 @@ bool mpi_lock::trylock(int lock_type, int target, MPI_Win window){
 
 
 /*********************************************************
- * SPIN LOCK STATISTICS
+ * LOCAL LOCK STATISTICS
  * ******************************************************/
 
-double mpi_lock::get_spin_lock_time(){
-	return spin_lock_time;
+double mpi_lock::get_local_lock_time(){
+	return _local_lock_time;
 }
 
-double mpi_lock::get_max_spin_lock_time(){
-	return max_spin_lock_time;
+double mpi_lock::get_max_local_lock_time(){
+	return _max_local_lock_time;
 }
 
-double mpi_lock::get_spin_hold_time(){
-	return spin_hold_time;
+double mpi_lock::get_local_hold_time(){
+	return _local_hold_time;
 }
 
-double mpi_lock::get_max_spin_hold_time(){
-	return max_spin_hold_time;
+double mpi_lock::get_max_local_hold_time(){
+	return _max_local_hold_time;
 }
 
 /*********************************************************
@@ -119,27 +104,27 @@ double mpi_lock::get_max_spin_hold_time(){
  * ******************************************************/
 
 double mpi_lock::get_mpi_lock_time(){
-	return mpi_lock_time;
+	return _mpi_lock_time;
 }
 
 double mpi_lock::get_max_mpi_lock_time(){
-	return max_mpi_lock_time;
+	return _max_mpi_lock_time;
 }
 
 double mpi_lock::get_mpi_unlock_time(){
-	return mpi_unlock_time;
+	return _mpi_unlock_time;
 }
 
 double mpi_lock::get_max_mpi_unlock_time(){
-	return max_mpi_unlock_time;
+	return _max_mpi_unlock_time;
 }
 
 double mpi_lock::get_mpi_hold_time(){
-	return mpi_hold_time;
+	return _mpi_hold_time;
 }
 
 double mpi_lock::get_max_mpi_hold_time(){
-	return max_mpi_hold_time;
+	return _max_mpi_hold_time;
 }
 
 
@@ -149,21 +134,23 @@ double mpi_lock::get_max_mpi_hold_time(){
  * ******************************************************/
 
 int mpi_lock::get_num_locks(){
-	return num_locks;
+	return _num_locks;
 }
 
 void mpi_lock::reset_stats(){
-	num_locks = 0;
-	/* spin lock statistics */
-	spin_lock_time = 0;
-	max_spin_lock_time = 0;
-	spin_hold_time = 0;
-	max_spin_hold_time = 0;
-	/* MPI lock statistics */
-	mpi_lock_time = 0;
-	max_mpi_lock_time = 0;
-	mpi_unlock_time = 0;
-	max_mpi_unlock_time = 0;
-	mpi_hold_time = 0;
-	max_mpi_hold_time = 0;
+	_num_locks = 0;
+	
+	// reset local lock statistics
+	_local_lock_time = 0;
+	_max_local_lock_time = 0;
+	_local_hold_time = 0;
+	_max_local_hold_time = 0;
+	
+	// reset MPI lock statistics
+	_mpi_lock_time = 0;
+	_max_mpi_lock_time = 0;
+	_mpi_unlock_time = 0;
+	_max_mpi_unlock_time = 0;
+	_mpi_hold_time = 0;
+	_max_mpi_hold_time = 0;
 }

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -14,17 +14,13 @@ mpi_lock::mpi_lock()
 	max_spin_lock_time(0),
 	spin_hold_time(0),
 	max_spin_hold_time(0),
-	spin_acquire_time(0),
-	spin_release_time(0),
 	/* MPI lock statistics */
 	mpi_lock_time(0),
 	max_mpi_lock_time(0),
 	mpi_unlock_time(0),
 	max_mpi_unlock_time(0),
 	mpi_hold_time(0),
-	max_mpi_hold_time(0),
-	mpi_acquire_time(0),
-	mpi_release_time(0)
+	max_mpi_hold_time(0)
 {
 	pthread_spin_init(&spin_lock, PTHREAD_PROCESS_PRIVATE);
 };

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -37,19 +37,17 @@ mpi_lock::mpi_lock()
  * @param window    MPI window to lock
  */
 void mpi_lock::lock(int lock_type, int target, MPI_Win window){
-	double mpi_start, mpi_end, lock_start, lock_end;
-
-	lock_start = MPI_Wtime();
+	double lock_start = MPI_Wtime();
 
 	// Take global spinlock and stat lock
 	pthread_spin_lock(&spin_lock);
 
 	// Lock MPI
-	mpi_start = MPI_Wtime();
+	double mpi_start = MPI_Wtime();
 	acquiretime = mpi_start;
 	MPI_Win_lock(lock_type, target, 0, window);
-	mpi_end = MPI_Wtime();
-	lock_end = MPI_Wtime();
+	double mpi_end = MPI_Wtime();
+	double lock_end = MPI_Wtime();
 
 	numlocksremote++;
 	/* Update max lock time */
@@ -67,17 +65,15 @@ void mpi_lock::lock(int lock_type, int target, MPI_Win window){
  * @param window    MPI window to lock
  */
 void mpi_lock::unlock(int target, MPI_Win window){
-	double g, unlock_start, unlock_end, mpi_start, mpi_end;
-
-	unlock_start = MPI_Wtime();
+	double unlock_start = MPI_Wtime();
 
 	/* Unlock MPI */
-	mpi_start = MPI_Wtime();
+	double mpi_start = MPI_Wtime();
 	MPI_Win_unlock(target, window);
-	mpi_end = MPI_Wtime();
+	double mpi_end = MPI_Wtime();
 	releasetime = mpi_end;
 
-	unlock_end = MPI_Wtime();
+	double unlock_end = MPI_Wtime();
 	/* Update max time spent in unlock */
 	if((unlock_end-unlock_start) > maxunlocktime){
 		maxunlocktime = unlock_end-unlock_start;

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -1,0 +1,252 @@
+/**
+ * @file
+ * @brief       This file provices an implementation of a specialized MPI lock allowing
+ *              multiple threads to access an MPI Window concurrently.
+ * @copyright   Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#include "mpi_lock.hpp"
+
+/**
+ * @brief mpi_lock constructor 
+ */
+mpi_lock::mpi_lock()
+	/* Initialize lock timekeeping */
+	: locktime(0),
+	maxlocktime(0),
+	mpilocktime(0),
+	numlocksremote(0),
+	/* Initialize unlock timekeeping */
+	unlocktime(0),
+	maxunlocktime(0),
+	mpiunlocktime(0),
+	/* Initialize general statkeeping */
+	holdtime(0),
+	maxholdtime(0),
+	acquiretime(0),
+	releasetime(0)
+{ 
+	pthread_spin_init(&spin_lock, PTHREAD_PROCESS_PRIVATE);
+};
+
+
+/**
+ * @brief acquire mpi_lock
+ * @param lock_type MPI_LOCK_SHARED or MPI_LOCK_EXCLUSIVE
+ * @param target    target node of the lock
+ * @param window    MPI window to lock
+ */
+void mpi_lock::lock(int lock_type, int target, MPI_Win window){
+	double mpi_start, mpi_end, lock_start, lock_end;
+
+	lock_start = MPI_Wtime();
+
+	// Take global spinlock
+	pthread_spin_lock(&spin_lock);
+	// Lock MPI
+	mpi_start = MPI_Wtime();
+	acquiretime = mpi_start;
+	MPI_Win_lock(lock_type, target, 0, window);
+	mpi_end = MPI_Wtime();
+	mpilocktime += (mpi_end-mpi_start);
+	numlocksremote++;
+
+	lock_end = MPI_Wtime();
+	/* Update max time spent in lock (NOT THREAD SAFE)*/
+	if((lock_end-lock_start) > maxlocktime){
+		maxlocktime = lock_end-lock_start;
+	}
+	/* Update time spent in lock atomically */
+	for (double g = locktime.load(std::memory_order_acquire); !locktime.compare_exchange_strong(g, (g+lock_end-lock_start)););
+}
+
+/** 
+ * @brief release mpi_lock
+ * @param target    target node of the lock
+ * @param window    MPI window to lock
+ */
+void mpi_lock::unlock(int target, MPI_Win window){
+	double g, unlock_start, unlock_end, mpi_start, mpi_end;
+
+	unlock_start = MPI_Wtime();
+
+	mpi_start = MPI_Wtime();
+	MPI_Win_unlock(target, window);
+	mpi_end = MPI_Wtime();
+	mpiunlocktime += mpi_end-mpi_start;
+	releasetime = mpi_end;
+	holdtime += (releasetime-acquiretime);
+	if((releasetime-acquiretime) > maxholdtime){
+		maxholdtime = releasetime-acquiretime;
+	}
+	pthread_spin_unlock(&spin_lock);
+
+	unlock_end = MPI_Wtime();
+	/* Update max time spent in unlock (NOT THREAD SAFE)*/
+	if((unlock_end-unlock_start) > maxunlocktime){
+		maxunlocktime = unlock_end-unlock_start;
+	}
+	/* Update time spent in lock atomically */
+	for (g = unlocktime.load(std::memory_order_acquire); !unlocktime.compare_exchange_strong(g, (g+unlock_end-unlock_start)););
+}
+
+
+/** 
+ * @brief try to acquire lock
+ * @param lock_type MPI_LOCK_SHARED or MPI_LOCK_EXCLUSIVE
+ * @param target    target node of the lock
+ * @param window    MPI window to lock
+ * @return          true if successful, false otherwise
+ */
+bool mpi_lock::trylock(int lock_type, int target, MPI_Win window){
+	/* TODO: Not really fully tested and no stat tracking */
+	// Try to take global spinlock
+	if(!pthread_spin_trylock(&spin_lock)){
+		// Lock MPI
+		MPI_Win_lock(lock_type, target, 0, window);
+		return true;
+	}
+	return false;
+}
+
+
+
+/*********************************************************
+ * LOCK STATISTICS
+ * ******************************************************/
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the total time spent for all threads in the mpi_lock
+ */
+double mpi_lock::get_locktime(){
+	return locktime.load();
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the average time spent per lock
+ */
+double mpi_lock::get_avglocktime(){
+	double numlocks = static_cast<double>(numlocksremote);
+	if(numlocks>0){
+		return locktime.load()/numlocks;
+	}else{
+		return 0.0;
+	}
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the average time spent per lock
+ */
+double mpi_lock::get_maxlocktime(){
+	return maxlocktime;
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the total time spent for all threads waiting for MPI_Win_lock
+ */
+double mpi_lock::get_mpilocktime(){
+	return mpilocktime;
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the total number of locks taken
+ */
+int mpi_lock::get_numlocks(){
+	return numlocksremote;
+}
+
+/*********************************************************
+ * UNLOCK STATISTICS
+ * ******************************************************/
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the total time spent for all threads in the mpi_unlock
+ */
+double mpi_lock::get_unlocktime(){
+	return unlocktime.load();
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the average time spent per unlock
+ */
+double mpi_lock::get_avgunlocktime(){
+	double numlocks = static_cast<double>(numlocksremote);
+	if(numlocks>0){
+		return unlocktime.load()/numlocks;
+	}else{
+		return 0.0;
+	}
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the maximum time spent in mpi_unlock
+ */
+double mpi_lock::get_maxunlocktime(){
+	return maxunlocktime;
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the total time spent for all threads waiting for mpi_win_lock
+ */
+double mpi_lock::get_mpiunlocktime(){
+	return mpiunlocktime;
+}
+
+/*********************************************************
+ * GENERAL STATISTICS
+ * ******************************************************/
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the total time spent holding an mpi_lock
+ */
+double mpi_lock::get_holdtime(){
+	return holdtime;
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the average time spent holding an mpi_lock
+ */
+double mpi_lock::get_avgholdtime(){
+	if(numlocksremote>0){
+		return holdtime/(double)numlocksremote;
+	}else{
+		return 0;
+	}
+}
+
+/** 
+ * @brief  get timekeeping statistics
+ * @return the maximum time spent holding an mpi_lock
+ */
+double mpi_lock::get_maxholdtime(){
+	return maxholdtime;
+}
+
+/**
+ * @brief reset the timekeeping statistics
+ */
+void mpi_lock::reset_stats(){
+	/* Lock stuff */
+	locktime.store(0);
+	maxlocktime = 0;
+	mpilocktime = 0;
+	numlocksremote = 0;
+	/* Unlock stuff */
+	unlocktime.store(0);
+	maxunlocktime = 0;
+	mpiunlocktime = 0;
+	/* Other stuff */
+	holdtime = 0;
+	maxholdtime = 0;
+}

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -86,11 +86,12 @@ void mpi_lock::unlock(int target, MPI_Win window){
 }
 
 bool mpi_lock::trylock(int lock_type, int target, MPI_Win window){
-	/* TODO: Not really fully tested and no stat tracking */
 	// Try to take global spinlock
 	if(!pthread_spin_trylock(&spin_lock)){
+		spin_acquire_time = MPI_Wtime();
 		// Lock MPI
 		MPI_Win_lock(lock_type, target, 0, window);
+		mpi_acquire_time = MPI_Wtime();
 		return true;
 	}
 	return false;
@@ -105,30 +106,12 @@ double mpi_lock::get_spin_lock_time(){
 	return spin_lock_time;
 }
 
-double mpi_lock::get_avg_spin_lock_time(){
-	double locks = static_cast<double>(num_locks);
-	if(num_locks>0){
-		return spin_lock_time/locks;
-	}else{
-		return 0.0;
-	}
-}
-
 double mpi_lock::get_max_spin_lock_time(){
 	return max_spin_lock_time;
 }
 
 double mpi_lock::get_spin_hold_time(){
 	return spin_hold_time;
-}
-
-double mpi_lock::get_avg_spin_hold_time(){
-	double locks = static_cast<double>(num_locks);
-	if(num_locks>0){
-		return spin_hold_time/locks;
-	}else{
-		return 0.0;
-	}
 }
 
 double mpi_lock::get_max_spin_hold_time(){
@@ -143,15 +126,6 @@ double mpi_lock::get_mpi_lock_time(){
 	return mpi_lock_time;
 }
 
-double mpi_lock::get_avg_mpi_lock_time(){
-	double locks = static_cast<double>(num_locks);
-	if(num_locks>0){
-		return mpi_lock_time/locks;
-	}else{
-		return 0.0;
-	}
-}
-
 double mpi_lock::get_max_mpi_lock_time(){
 	return max_mpi_lock_time;
 }
@@ -160,30 +134,12 @@ double mpi_lock::get_mpi_unlock_time(){
 	return mpi_unlock_time;
 }
 
-double mpi_lock::get_avg_mpi_unlock_time(){
-	double locks = static_cast<double>(num_locks);
-	if(num_locks>0){
-		return mpi_unlock_time/locks;
-	}else{
-		return 0.0;
-	}
-}
-
 double mpi_lock::get_max_mpi_unlock_time(){
 	return max_mpi_unlock_time;
 }
 
 double mpi_lock::get_mpi_hold_time(){
 	return mpi_hold_time;
-}
-
-double mpi_lock::get_avg_mpi_hold_time(){
-	double locks = static_cast<double>(num_locks);
-	if(num_locks>0){
-		return mpi_hold_time/locks;
-	}else{
-		return 0.0;
-	}
 }
 
 double mpi_lock::get_max_mpi_hold_time(){

--- a/src/backend/mpi/mpi_lock.cpp
+++ b/src/backend/mpi/mpi_lock.cpp
@@ -9,11 +9,9 @@
 
 mpi_lock::mpi_lock() {
 	pthread_spin_init(&_local_lock, PTHREAD_PROCESS_PRIVATE);
-};
-
+}
 
 void mpi_lock::lock(int lock_type, int target, MPI_Win window){
-
 	// Take the local lock
 	double local_start = MPI_Wtime();
 	pthread_spin_lock(&_local_lock);
@@ -139,13 +137,11 @@ int mpi_lock::get_num_locks(){
 
 void mpi_lock::reset_stats(){
 	_num_locks = 0;
-	
 	// reset local lock statistics
 	_local_lock_time = 0;
 	_max_local_lock_time = 0;
 	_local_hold_time = 0;
 	_max_local_hold_time = 0;
-	
 	// reset MPI lock statistics
 	_mpi_lock_time = 0;
 	_max_mpi_lock_time = 0;

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -13,27 +13,29 @@
 /** @brief Provides MPI RMA epoch locking */
 class mpi_lock {
 	private:
-		/** @brief spinlock protecting the MPI lock */
-		pthread_spinlock_t spin_lock;
+		/** @brief local lock protecting the MPI lock from multi-threaded access */
+		pthread_spinlock_t _local_lock;
 
 		/** @brief General statistics */
-		int num_locks;
+		int _num_locks{0};
 
 		/**@{*/
 		/**
-		 * @brief Variables used to track spin lock statistics
+		 * @brief Variables used to track local lock statistics
 		 */
-		double spin_lock_time, max_spin_lock_time;
-		double spin_hold_time, max_spin_hold_time, spin_acquire_time, spin_release_time;
+		double _local_lock_time{0}, _max_local_lock_time{0};
+		double _local_hold_time{0}, _max_local_hold_time{0};
+		double _local_acquire_time{0}, _local_release_time{0};
 		/**@}*/
 
 		/**@{*/
 		/**
 		 * @brief Variables used to track MPI lock statistics
 		 */
-		double mpi_lock_time, max_mpi_lock_time;
-		double mpi_unlock_time, max_mpi_unlock_time;
-		double mpi_hold_time, max_mpi_hold_time, mpi_acquire_time, mpi_release_time;
+		double _mpi_lock_time{0}, _max_mpi_lock_time{0};
+		double _mpi_unlock_time{0}, _max_mpi_unlock_time{0};
+		double _mpi_hold_time{0}, _max_mpi_hold_time{0};
+		double _mpi_acquire_time{0}, _mpi_release_time{0};
 		/**@}*/
 
 	public:
@@ -72,32 +74,32 @@ class mpi_lock {
 
 
 		/*********************************************************
-		 * SPIN LOCK STATISTICS
+		 * LOCAL LOCK STATISTICS
 		 * ******************************************************/
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the total time spent locking a spin lock
+		 * @return the total time spent locking a local lock
 		 */
-		double get_spin_lock_time();
+		double get_local_lock_time();
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the maximum time spent locking a spin lock
+		 * @return the maximum time spent locking a local lock
 		 */
-		double get_max_spin_lock_time();
+		double get_max_local_lock_time();
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the total time spent holding a spin lock
+		 * @return the total time spent holding a local lock
 		 */
-		double get_spin_hold_time();
+		double get_local_hold_time();
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the maximum time spent holding a spin lock
+		 * @return the maximum time spent holding a local lock
 		 */
-		double get_max_spin_hold_time();
+		double get_max_local_hold_time();
 
 		/*********************************************************
 		 * MPI LOCK STATISTICS

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -4,11 +4,11 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
-#ifndef argo_mpi_lock_hpp
-#define argo_mpi_lock_hpp argo_mpi_lock_hpp
+#ifndef ARGODSM_SRC_BACKEND_MPI_MPI_LOCK_HPP_
+#define ARGODSM_SRC_BACKEND_MPI_MPI_LOCK_HPP_
 
-#include <pthread.h>
 #include <mpi.h>
+#include <pthread.h>
 
 /** @brief Provides MPI RMA epoch locking */
 class mpi_lock {
@@ -61,7 +61,7 @@ class mpi_lock {
 		 * @param target    target node of the lock
 		 * @param window    MPI window to lock
 		 */
-		void unlock(int target, MPI_Win window); 
+		void unlock(int target, MPI_Win window);
 
 		/** 
 		 * @brief try to acquire lock
@@ -158,4 +158,4 @@ class mpi_lock {
 		void reset_stats();
 };
 
-#endif /* argo_mpi_lock_hpp */
+#endif  // ARGODSM_SRC_BACKEND_MPI_MPI_LOCK_HPP_

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -16,15 +16,17 @@ class mpi_lock {
 		/* @brief spinlock protecting the MPI lock */
 		pthread_spinlock_t spin_lock;
 
-		/** @brief Timekeeping for lock */
-		double locktime, maxlocktime, mpilocktime;
-		int numlocksremote;
-
-		/** @brief Timekeeping for unlock */
-		double unlocktime, maxunlocktime, mpiunlocktime;
-
 		/** @brief General statistics */
-		double holdtime, maxholdtime, flagtime, acquiretime, releasetime;
+		int num_locks;
+
+		/** @brief Statistics for spin lock */
+		double spin_lock_time, max_spin_lock_time;
+		double spin_hold_time, max_spin_hold_time, spin_acquire_time, spin_release_time;
+
+		/** @brief Statistics for mpi lock */
+		double mpi_lock_time, max_mpi_lock_time;
+		double mpi_unlock_time, max_mpi_unlock_time;
+		double mpi_hold_time, max_mpi_hold_time, mpi_acquire_time, mpi_release_time;
 
 	public:
 		/**
@@ -61,90 +63,114 @@ class mpi_lock {
 		bool trylock(int lock_type, int target, MPI_Win window);
 
 
-
 		/*********************************************************
-		 * LOCK STATISTICS
+		 * SPIN LOCK STATISTICS
 		 * ******************************************************/
 
-		/** 
+		/**
 		 * @brief  get timekeeping statistics
-		 * @return the total time spent for all threads in the mpi_lock
+		 * @return the total time spent locking a spin lock
 		 */
-		double get_locktime();
+		double get_spin_lock_time();
 
-		/** 
+		/**
 		 * @brief  get timekeeping statistics
-		 * @return the maximum time spent locking a window
+		 * @return the average time spent locking a spin lock
 		 */
-		double get_avglocktime();
+		double get_avg_spin_lock_time();
 
-		/** 
+		/**
 		 * @brief  get timekeeping statistics
-		 * @return the maximum time spent locking a window
+		 * @return the maximum time spent locking a spin lock
 		 */
-		double get_maxlocktime();
+		double get_max_spin_lock_time();
 
-		/** 
+		/**
 		 * @brief  get timekeeping statistics
-		 * @return the total time spent for all threads waiting for MPI_Win_lock
+		 * @return the total time spent holding a spin lock
 		 */
-		double get_mpilocktime();
+		double get_spin_hold_time();
 
-		/** 
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the average time spent holding a spin lock
+		 */
+		double get_avg_spin_hold_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent holding a spin lock
+		 */
+		double get_max_spin_hold_time();
+
+		/*********************************************************
+		 * MPI LOCK STATISTICS
+		 * ******************************************************/
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent locking an mpi_lock
+		 */
+		double get_mpi_lock_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the average time spent locking an mpi_lock
+		 */
+		double get_avg_mpi_lock_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent locking an mpi_lock
+		 */
+		double get_max_mpi_lock_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent unlocking an mpi_lock
+		 */
+		double get_mpi_unlock_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the average time spent unlocking an mpi_lock
+		 */
+		double get_avg_mpi_unlock_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent unlocking an mpi_lock
+		 */
+		double get_max_mpi_unlock_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent holding an mpi_lock
+		 */
+		double get_mpi_hold_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the average time spent holding an mpi_lock
+		 */
+		double get_avg_mpi_hold_time();
+
+		/**
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent holding an mpi_lock
+		 */
+		double get_max_mpi_hold_time();
+
+
+		/*********************************************************
+		 * GENERAL
+		 * ******************************************************/
+
+		/**
 		 * @brief  get timekeeping statistics
 		 * @return the total number of locks taken
 		 */
-		int get_numlocks();
-
-		/*********************************************************
-		 * UNLOCK STATISTICS
-		 * ******************************************************/
-
-		/** 
-		 * @brief  get timekeeping statistics
-		 * @return the total time spent unlocking the lock
-		 */
-		double get_unlocktime();
-
-		/** 
-		 * @brief  get timekeeping statistics
-		 * @return the average time spent unlocking the lock
-		 */
-		double get_avgunlocktime();
-
-		/** 
-		 * @brief  get timekeeping statistics
-		 * @return the maximum time spent unlocking a window
-		 */
-		double get_maxunlocktime();
-
-		/** 
-		 * @brief  get timekeeping statistics
-		 * @return the total time spent unlocking the MPI Windows
-		 */
-		double get_mpiunlocktime();
-
-		/*********************************************************
-		 * GENERAL STATISTICS
-		 * ******************************************************/
-
-		/** 
-		 * @brief  get lock statistics
-		 * @return the total amount of time holding an mpi_lock
-		 */
-		double get_holdtime();
-
-		/** 
-		 * @brief  get lock statistics
-		 * @return the total amount of time holding an mpi_lock
-		 */
-		double get_avgholdtime();
-
-		/** 
-		 * @brief  get lock statistics
-		 * @return the total amount of time holding an mpi_lock
-		 */
-		double get_maxholdtime();
+		int get_num_locks();
 
 		/**
 		 * @brief reset the timekeeping statistics

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -4,8 +4,8 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
-#ifndef mpi_lock_h
-#define mpi_lock_h mpi_lock_h
+#ifndef argo_mpi_lock_hpp
+#define argo_mpi_lock_hpp argo_mpi_lock_hpp
 
 #include <pthread.h>
 #include <mpi.h>
@@ -13,20 +13,28 @@
 /** @brief Provides MPI RMA epoch locking */
 class mpi_lock {
 	private:
-		/* @brief spinlock protecting the MPI lock */
+		/** @brief spinlock protecting the MPI lock */
 		pthread_spinlock_t spin_lock;
 
 		/** @brief General statistics */
 		int num_locks;
 
-		/** @brief Statistics for spin lock */
+		/**@{*/
+		/**
+		 * @brief Variables used to track spin lock statistics
+		 */
 		double spin_lock_time, max_spin_lock_time;
 		double spin_hold_time, max_spin_hold_time, spin_acquire_time, spin_release_time;
+		/**@}*/
 
-		/** @brief Statistics for mpi lock */
+		/**@{*/
+		/**
+		 * @brief Variables used to track MPI lock statistics
+		 */
 		double mpi_lock_time, max_mpi_lock_time;
 		double mpi_unlock_time, max_mpi_unlock_time;
 		double mpi_hold_time, max_mpi_hold_time, mpi_acquire_time, mpi_release_time;
+		/**@}*/
 
 	public:
 		/**
@@ -148,4 +156,4 @@ class mpi_lock {
 		void reset_stats();
 };
 
-#endif /* mpi_lock_h */
+#endif /* argo_mpi_lock_hpp */

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -7,24 +7,21 @@
 #ifndef mpi_lock_h
 #define mpi_lock_h mpi_lock_h
 
-#include <atomic>
 #include <pthread.h>
 #include <mpi.h>
 
 /** @brief Provides MPI RMA epoch locking */
 class mpi_lock {
 	private:
-		/* @brief atomic spinlock */
+		/* @brief spinlock protecting the MPI lock */
 		pthread_spinlock_t spin_lock;
 
 		/** @brief Timekeeping for lock */
-		std::atomic<double> locktime;
-		double maxlocktime, mpilocktime;
+		double locktime, maxlocktime, mpilocktime;
 		int numlocksremote;
 
 		/** @brief Timekeeping for unlock */
-		std::atomic<double> unlocktime;
-		double maxunlocktime, mpiunlocktime;
+		double unlocktime, maxunlocktime, mpiunlocktime;
 
 		/** @brief General statistics */
 		double holdtime, maxholdtime, flagtime, acquiretime, releasetime;

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -1,0 +1,158 @@
+/**
+ * @file
+ * @brief Declaration of MPI lock
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef mpi_lock_h
+#define mpi_lock_h mpi_lock_h
+
+#include <atomic>
+#include <pthread.h>
+#include <mpi.h>
+
+/** @brief Provides MPI RMA epoch locking */
+class mpi_lock {
+	private:
+		/* @brief atomic spinlock */
+		pthread_spinlock_t spin_lock;
+
+		/** @brief Timekeeping for lock */
+		std::atomic<double> locktime;
+		double maxlocktime, mpilocktime;
+		int numlocksremote;
+
+		/** @brief Timekeeping for unlock */
+		std::atomic<double> unlocktime;
+		double maxunlocktime, mpiunlocktime;
+
+		/** @brief General statistics */
+		double holdtime, maxholdtime, flagtime, acquiretime, releasetime;
+
+	public:
+		/**
+		 * @brief mpi_lock constructor 
+		 */
+		mpi_lock();
+
+		/*********************************************************
+		 * LOCK ACQUISITION AND RELEASE
+		 * ******************************************************/
+
+		/** 
+		 * @brief acquire mpi_lock
+		 * @param lock_type MPI_LOCK_SHARED or MPI_LOCK_EXCLUSIVE
+		 * @param target    target node of the lock
+		 * @param window    MPI window to lock
+		 */
+		void lock(int lock_type, int target, MPI_Win window);
+
+		/** 
+		 * @brief release mpi_lock
+		 * @param target    target node of the lock
+		 * @param window    MPI window to lock
+		 */
+		void unlock(int target, MPI_Win window); 
+
+		/** 
+		 * @brief try to acquire lock
+		 * @param lock_type MPI_LOCK_SHARED or MPI_LOCK_EXCLUSIVE
+		 * @param target    target node of the lock
+		 * @param window    MPI window to lock
+		 * @return          true if successful, false otherwise
+		 */
+		bool trylock(int lock_type, int target, MPI_Win window);
+
+
+
+		/*********************************************************
+		 * LOCK STATISTICS
+		 * ******************************************************/
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent for all threads in the mpi_lock
+		 */
+		double get_locktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent locking a window
+		 */
+		double get_avglocktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent locking a window
+		 */
+		double get_maxlocktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent for all threads waiting for MPI_Win_lock
+		 */
+		double get_mpilocktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the total number of locks taken
+		 */
+		int get_numlocks();
+
+		/*********************************************************
+		 * UNLOCK STATISTICS
+		 * ******************************************************/
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent unlocking the lock
+		 */
+		double get_unlocktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the average time spent unlocking the lock
+		 */
+		double get_avgunlocktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the maximum time spent unlocking a window
+		 */
+		double get_maxunlocktime();
+
+		/** 
+		 * @brief  get timekeeping statistics
+		 * @return the total time spent unlocking the MPI Windows
+		 */
+		double get_mpiunlocktime();
+
+		/*********************************************************
+		 * GENERAL STATISTICS
+		 * ******************************************************/
+
+		/** 
+		 * @brief  get lock statistics
+		 * @return the total amount of time holding an mpi_lock
+		 */
+		double get_holdtime();
+
+		/** 
+		 * @brief  get lock statistics
+		 * @return the total amount of time holding an mpi_lock
+		 */
+		double get_avgholdtime();
+
+		/** 
+		 * @brief  get lock statistics
+		 * @return the total amount of time holding an mpi_lock
+		 */
+		double get_maxholdtime();
+
+		/**
+		 * @brief reset the timekeeping statistics
+		 */
+		void reset_stats();
+};
+
+#endif /* mpi_lock_h */

--- a/src/backend/mpi/mpi_lock.hpp
+++ b/src/backend/mpi/mpi_lock.hpp
@@ -75,12 +75,6 @@ class mpi_lock {
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the average time spent locking a spin lock
-		 */
-		double get_avg_spin_lock_time();
-
-		/**
-		 * @brief  get timekeeping statistics
 		 * @return the maximum time spent locking a spin lock
 		 */
 		double get_max_spin_lock_time();
@@ -90,12 +84,6 @@ class mpi_lock {
 		 * @return the total time spent holding a spin lock
 		 */
 		double get_spin_hold_time();
-
-		/**
-		 * @brief  get timekeeping statistics
-		 * @return the average time spent holding a spin lock
-		 */
-		double get_avg_spin_hold_time();
 
 		/**
 		 * @brief  get timekeeping statistics
@@ -115,12 +103,6 @@ class mpi_lock {
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the average time spent locking an mpi_lock
-		 */
-		double get_avg_mpi_lock_time();
-
-		/**
-		 * @brief  get timekeeping statistics
 		 * @return the maximum time spent locking an mpi_lock
 		 */
 		double get_max_mpi_lock_time();
@@ -133,12 +115,6 @@ class mpi_lock {
 
 		/**
 		 * @brief  get timekeeping statistics
-		 * @return the average time spent unlocking an mpi_lock
-		 */
-		double get_avg_mpi_unlock_time();
-
-		/**
-		 * @brief  get timekeeping statistics
 		 * @return the maximum time spent unlocking an mpi_lock
 		 */
 		double get_max_mpi_unlock_time();
@@ -148,12 +124,6 @@ class mpi_lock {
 		 * @return the total time spent holding an mpi_lock
 		 */
 		double get_mpi_hold_time();
-
-		/**
-		 * @brief  get timekeeping statistics
-		 * @return the average time spent holding an mpi_lock
-		 */
-		double get_avg_mpi_hold_time();
 
 		/**
 		 * @brief  get timekeeping statistics

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -49,8 +49,14 @@ argo_byte * touchedcache;
 char* cacheData;
 /** @brief Copy of the local cache to keep twinpages for later being able to DIFF stores */
 char * pagecopy;
+/** @brief Pointer to locks protecting the page cache */
+std::vector<cache_lock> cache_locks;
+/** @brief Mutex ensuring that only one thread can perform sync */
+//std::shared_mutex sync_mutex;
+pthread_rwlock_t sync_lock = PTHREAD_RWLOCK_INITIALIZER;
+
 /** @brief Protects the pagecache */
-pthread_mutex_t cachemutex = PTHREAD_MUTEX_INITIALIZER;
+//pthread_mutex_t cachemutex = PTHREAD_MUTEX_INITIALIZER;
 
 /*Writebuffer*/
 /** @brief A write buffer storing cache indices */
@@ -80,8 +86,6 @@ int rank;
 /** @brief rank/process ID in the MPI/ArgoDSM runtime*/
 argo::node_id_t workrank;
 /** @brief Semaphore protecting infiniband accesses*/
-/** @todo replace with a (qd?)lock */
-sem_t ibsem;
 
 /*Common*/
 /** @brief  Points to start of global address space*/
@@ -146,14 +150,12 @@ int argo_get_global_tid(){
 
 void argo_register_thread(){
 	int i;
-	sem_wait(&ibsem);
 	for(i = 0; i < NUM_THREADS; i++){
 		if(tid[i] == 0){
 			tid[i] = pthread_self();
 			break;
 		}
 	}
-	sem_post(&ibsem);
 	pthread_barrier_wait(&threadbarrier[NUM_THREADS]);
 }
 
@@ -163,7 +165,6 @@ void argo_pin_threads(){
   cpu_set_t cpuset;
   int s;
   argo_register_thread();
-  sem_wait(&ibsem);
   CPU_ZERO(&cpuset);
   int pinto = argo_get_local_tid();
   CPU_SET(pinto, &cpuset);
@@ -173,7 +174,6 @@ void argo_pin_threads(){
     printf("PINNING ERROR\n");
     argo_finalize();
   }
-  sem_post(&ibsem);
 }
 
 
@@ -246,6 +246,8 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 
 	/* If it's not an ArgoDSM address, do not handle it */
 	if(aligned_access_offset >= size_of_all){
+		//TODO: Must probably unlock here?
+		printf("WARNING: UNSAFE CASE!!!\n");
 		return;
 	}
 
@@ -264,12 +266,11 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 	const argo::node_id_t load_node = get_homenode(aligned_access_offset);
 	const std::size_t load_offset = get_offset(aligned_access_offset);
 
-	sem_wait(&ibsem);
 
 	/* Return if requested cache entry is already up to date. */
 	if(cacheControl[start_index].tag == aligned_access_offset &&
 			cacheControl[start_index].state != INVALID){
-		sem_post(&ibsem);
+		cache_locks[start_index].unlock();
 		return;
 	}
 
@@ -318,12 +319,18 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 		/* Address and pointer to the data being loaded */
 		const std::size_t temp_addr = aligned_access_offset + p*block_size;
 
-		/* Skip updating pages that are already present and valid in the cache */
-		if(cacheControl[idx].tag == temp_addr && cacheControl[idx].state != INVALID){
+		if(cache_locks[idx].try_lock() || idx == start_index){
+			/* Skip updating pages that are already present and valid in the cache */
+			if(cacheControl[idx].tag == temp_addr && cacheControl[idx].state != INVALID){
+				pages_to_load[p] = false;
+				cache_locks[idx].unlock();
+				continue;
+			}else{
+				pages_to_load[p] = true;
+			}
+		}else{
 			pages_to_load[p] = false;
 			continue;
-		}else{
-			pages_to_load[p] = true;
 		}
 
 		/* If another page occupies the cache index, begin to evict it. */
@@ -465,11 +472,10 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 			touchedcache[idx] = 1;
 			cacheControl[idx].state = VALID;
 			cacheControl[idx].dirty = CLEAN;
+			cache_locks[idx].unlock();
 		}
 	}
-	sem_post(&ibsem);
 }
-
 
 void handler(int sig, siginfo_t *si, void *context){
 	UNUSED_PARAM(sig);
@@ -511,10 +517,8 @@ void handler(int sig, siginfo_t *si, void *context){
 	std::size_t offset;
 	if(dd::is_first_touch_policy()){
 		std::lock_guard<std::mutex> lock(spin_mutex);
-		sem_wait(&ibsem);
 		homenode = get_homenode(aligned_access_offset);
 		offset = get_offset(aligned_access_offset);
-		sem_post(&ibsem);
 	}else{
 		homenode = get_homenode(aligned_access_offset);
 		offset = get_offset(aligned_access_offset);
@@ -523,11 +527,15 @@ void handler(int sig, siginfo_t *si, void *context){
 	std::uint64_t id = static_cast<std::uint64_t>(1) << getID();
 	std::uint64_t invid = ~id;
 
-	pthread_mutex_lock(&cachemutex);
+	//pthread_mutex_lock(&cachemutex);
+	/* Acquire shared sync lock and first cache index lock */
+	//sync_mutex.shared_lock();
+	pthread_rwlock_rdlock(&sync_lock);
+	cache_locks[startIndex].lock();
+
 
 	/* page is local */
 	if(homenode == (getID())){
-		sem_wait(&ibsem);
 		std::uint64_t sharers;
 		MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
 		std::uint64_t prevsharer = (globalSharers[classidx])&id;
@@ -602,8 +610,11 @@ void handler(int sig, siginfo_t *si, void *context){
 			/* set page to permit read/write and map it to the page cache */
 			vm::map_memory(aligned_access_ptr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ|PROT_WRITE);
 		}
-		sem_post(&ibsem);
-		pthread_mutex_unlock(&cachemutex);
+		//pthread_mutex_unlock(&cachemutex);
+		/* Unlock shared sync lock and cache index lock */
+		cache_locks[startIndex].unlock();
+		//sync_mutex.unlock_shared();
+		pthread_rwlock_unlock(&sync_lock);
 		return;
 	}
 
@@ -624,7 +635,9 @@ void handler(int sig, siginfo_t *si, void *context){
 		(miss_type == sig::access_type::undefined && performed_load)) {
 		assert(cacheControl[startIndex].state == VALID);
 		assert(cacheControl[startIndex].tag == aligned_access_offset);
-		pthread_mutex_unlock(&cachemutex);
+		//pthread_mutex_unlock(&cachemutex);
+		//sync_mutex.unlock_shared();
+		pthread_rwlock_unlock(&sync_lock);
 		double t2 = MPI_Wtime();
 		stats.loadtime += t2-t1;
 		return;
@@ -634,14 +647,16 @@ void handler(int sig, siginfo_t *si, void *context){
 	line *= CACHELINE;
 
 	if(cacheControl[line].dirty == DIRTY){
-		pthread_mutex_unlock(&cachemutex);
+		//pthread_mutex_unlock(&cachemutex);
+		cache_locks[startIndex].unlock();
+		//sync_mutex.unlock_shared();
+		pthread_rwlock_unlock(&sync_lock);
 		return;
 	}
 
 	touchedcache[line] = 1;
 	cacheControl[line].dirty = DIRTY;
 
-	sem_wait(&ibsem);
 	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
 	std::uint64_t writers = globalSharers[classidx+1];
 	std::uint64_t sharers = globalSharers[classidx];
@@ -691,9 +706,11 @@ void handler(int sig, siginfo_t *si, void *context){
 	unsigned char* copy = reinterpret_cast<unsigned char*>(pagecopy + line*pagesize);
 	memcpy(copy, aligned_access_ptr, CACHELINE*pagesize);
 	argo_write_buffer->add(startIndex);
-	sem_post(&ibsem);
 	mprotect(aligned_access_ptr, pagesize*CACHELINE, PROT_WRITE|PROT_READ);
-	pthread_mutex_unlock(&cachemutex);
+	//pthread_mutex_unlock(&cachemutex);
+	cache_locks[startIndex].unlock();
+	//sync_mutex.unlock_shared();
+	pthread_rwlock_unlock(&sync_lock);
 	double t2 = MPI_Wtime();
 	stats.storetime += t2-t1;
 	return;
@@ -773,6 +790,9 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	/** At least two pages are required to prevent endless eviction loops */
 	cachesize = std::max(cachesize, static_cast<std::size_t>(pagesize*CACHELINE*2));
 	cachesize /= pagesize;
+
+	/* Create the cache locks */
+	cache_locks.resize(cachesize);
 
 	classificationSize = 2*(argo_size/pagesize);
 	argo_write_buffer = new write_buffer<std::size_t>();
@@ -862,8 +882,6 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		tmpcache = global_offsets_tbl;
 		vm::map_memory(tmpcache, offsets_tbl_size_bytes, current_offset, PROT_READ|PROT_WRITE);
 	}
-
-	sem_init(&ibsem, 0, 1);
 
 	globalDataWindow = static_cast<MPI_Win*>(malloc(numtasks*sizeof(MPI_Win)));
 
@@ -1019,8 +1037,9 @@ void swdsm_argo_barrier(int n, upgrade_type upgrade){
 	// Let one thread per node perform MPI operations
 	if(pthread_mutex_trylock(&barriermutex) == 0){
 		barrierlockholder = pthread_self();
-		pthread_mutex_lock(&cachemutex);
-		sem_wait(&ibsem);
+		//pthread_mutex_lock(&cachemutex);
+		//sync_mutex.lock();
+		pthread_rwlock_wrlock(&sync_lock);
 
 		// Perform SD followed by SI
 		argo_write_buffer->flush();
@@ -1033,8 +1052,9 @@ void swdsm_argo_barrier(int n, upgrade_type upgrade){
 			MPI_Barrier(workcomm);
 		}
 
-		sem_post(&ibsem);
-		pthread_mutex_unlock(&cachemutex);
+		//pthread_mutex_unlock(&cachemutex);
+		//sync_mutex.unlock()
+		pthread_rwlock_unlock(&sync_lock);
 	}
 
 	// Wait for n threads to arrive
@@ -1057,7 +1077,6 @@ void argo_reset_coherence(){
 		cacheControl[i].dirty = CLEAN;
 	}
 
-	sem_wait(&ibsem);
 	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
 	for(std::size_t i = 0; i < classificationSize; i++){
 		globalSharers[i] = 0;
@@ -1082,7 +1101,6 @@ void argo_reset_coherence(){
 		MPI_Win_unlock(workrank, offsets_tbl_window);
 	}
 
-	sem_post(&ibsem);
 	swdsm_argo_barrier(1);
 	mprotect(startAddr, size_of_all, PROT_NONE);
 	swdsm_argo_barrier(1);
@@ -1091,23 +1109,27 @@ void argo_reset_coherence(){
 
 void argo_acquire() {
 	int flag;
-	pthread_mutex_lock(&cachemutex);
-	sem_wait(&ibsem);
+	//pthread_mutex_lock(&cachemutex);
+	//sync_mutex.lock();
+	pthread_rwlock_wrlock(&sync_lock);
 	self_invalidation();
 	MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
-	sem_post(&ibsem);
-	pthread_mutex_unlock(&cachemutex);
+	//pthread_mutex_unlock(&cachemutex);
+	//sync_mutex.unlock();
+	pthread_rwlock_unlock(&sync_lock);
 }
 
 
 void argo_release() {
 	int flag;
-	pthread_mutex_lock(&cachemutex);
-	sem_wait(&ibsem);
+	//pthread_mutex_lock(&cachemutex);
+	//sync_mutex.lock();
+	pthread_rwlock_wrlock(&sync_lock);
 	argo_write_buffer->flush();
 	MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
-	sem_post(&ibsem);
-	pthread_mutex_unlock(&cachemutex);
+	//pthread_mutex_unlock(&cachemutex);
+	//sync_mutex.unlock();
+	pthread_rwlock_unlock(&sync_lock);
 }
 
 void argo_acq_rel() {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -54,11 +54,7 @@ std::size_t win_granularity;
 /** @brief Pointer to locks protecting the page cache */
 std::vector<cache_lock> cache_locks;
 /** @brief Mutex ensuring that only one thread can perform sync */
-//std::shared_mutex sync_mutex;
 pthread_rwlock_t sync_lock = PTHREAD_RWLOCK_INITIALIZER;
-
-/** @brief Protects the pagecache */
-//pthread_mutex_t cachemutex = PTHREAD_MUTEX_INITIALIZER;
 
 /*Writebuffer*/
 /** @brief A write buffer storing cache indices */
@@ -74,7 +70,7 @@ MPI_Group workgroup;
 /** @brief Communicator can be replaced with MPI_COMM_WORLD*/
 MPI_Comm workcomm;
 /** @brief MPI window for communicating pyxis directory*/
-MPI_Win sharerWindow;
+std::vector<MPI_Win> sharer_windows;
 /** @brief MPI windows for reading and writing data in global address space */
 MPI_Win *globalDataWindow;
 /** @brief MPI data structure for sending cache control data*/
@@ -87,7 +83,11 @@ int numtasks;
 int rank;
 /** @brief rank/process ID in the MPI/ArgoDSM runtime*/
 argo::node_id_t workrank;
-/** @brief Semaphore protecting infiniband accesses*/
+
+//void sharer_op(int lock_type, int rank, int offset,
+//		std::function<void(const std::size_t win_index)> op);
+//
+//std::size_t get_window_index(int offset);
 
 /*Common*/
 /** @brief  Points to start of global address space*/
@@ -213,7 +213,6 @@ inline std::size_t align_backwards(std::size_t offset, std::size_t size) {
 	return (offset / size) * size;
 }
 
-
 argo::node_id_t get_homenode(std::uintptr_t addr){
 	dd::global_ptr<char> gptr(reinterpret_cast<char*>(
 			addr + reinterpret_cast<std::uintptr_t>(startAddr)), true, false);
@@ -267,6 +266,8 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 	std::size_t end_index = start_index+CACHELINE;
 	const argo::node_id_t load_node = get_homenode(aligned_access_offset);
 	const std::size_t load_offset = get_offset(aligned_access_offset);
+	const std::size_t load_win_index = get_window_index(
+			get_classification_index(aligned_access_offset));
 
 
 	/* Return if requested cache entry is already up to date. */
@@ -285,7 +286,11 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 		if(temp_addr < size_of_all && i < cachesize){
 			const argo::node_id_t temp_node = peek_homenode(temp_addr);
 			const std::size_t temp_offset = peek_offset(temp_addr);
-			if(temp_node == load_node && temp_offset == (load_offset + p*block_size)){
+			const std::size_t temp_win_index = get_window_index(
+					get_classification_index(temp_addr));
+			if(temp_node == load_node &&
+					temp_offset == (load_offset + p*block_size) &&
+					temp_win_index == load_win_index){
 				end_index+=CACHELINE;
 			}else{
 				break;
@@ -368,43 +373,48 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 	stats.loads++;
 
 	/* Get globalSharers info from local node and add self to it */
-	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-	for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
-		if(pages_to_load[i]){
-			/* Check local pyxis directory if we are sharer of the page */
-			local_sharers[i] = (globalSharers[classification_index_array[i]])&node_id_bit;
-			if(local_sharers[i] == 0){
-				sharer_bit_mask[i*2] = node_id_bit;
-				new_sharer = true; //At least one new sharer detected
+	sharer_op(MPI_LOCK_SHARED, workrank, classification_index_array[0],
+			[&](std::size_t win_index){
+		for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
+			if(pages_to_load[i]){
+				/* Check local pyxis directory if we are sharer of the page */
+				local_sharers[i] = (globalSharers[classification_index_array[i]])&node_id_bit;
+				if(local_sharers[i] == 0){
+					sharer_bit_mask[i*2] = node_id_bit;
+					new_sharer = true; //At least one new sharer detected
+				}
 			}
 		}
-	}
-	MPI_Win_unlock(workrank, sharerWindow);
+	});
 
+	std::size_t win_offset = get_window_offset(classification_index_array[0]);
 	/* If this node is a new sharer of at least one of the pages */
 	if(new_sharer){
 		/* Register this node as sharer of all newly shared pages in the load_node's
 		 * globalSharers directory using one MPI call. When this call returns,
 		 * remote_sharers contains remote globalSharers directory values prior to
 		 * this call. */
-		MPI_Win_lock(MPI_LOCK_SHARED, load_node, 0, sharerWindow);
-		MPI_Get_accumulate(sharer_bit_mask.data(), classification_size, MPI_LONG,
-				remote_sharers.data(), classification_size, MPI_LONG,
-				load_node, classification_index_array[0], classification_size,
-				MPI_LONG, MPI_BOR, sharerWindow);
-		MPI_Win_unlock(load_node, sharerWindow);
+		sharer_op(MPI_LOCK_SHARED, load_node, classification_index_array[0],
+				[&](std::size_t win_index){
+				MPI_Get_accumulate(sharer_bit_mask.data(), classification_size, MPI_LONG,
+						remote_sharers.data(), classification_size, MPI_LONG,
+						load_node, win_offset, classification_size,
+						MPI_LONG, MPI_BOR, sharer_windows[win_index]);
+				});
+		//TODO: Offsets need to be relative to window start/end
 	}
 
 	/* Register the received remote globalSharers information locally */
-	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-	for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
-		if(pages_to_load[i]){
-			globalSharers[classification_index_array[i]] |= remote_sharers[i*2];
-			globalSharers[classification_index_array[i]] |= node_id_bit; //Also add self
-			globalSharers[classification_index_array[i]+1] |= remote_sharers[(i*2)+1];
+	sharer_op(MPI_LOCK_EXCLUSIVE, workrank, classification_index_array[0],
+			[&](std::size_t win_index){
+		for(std::size_t i = 0; i < fetch_size; i+=CACHELINE){
+			if(pages_to_load[i]){
+						globalSharers[classification_index_array[i]] |= remote_sharers[i*2];
+						globalSharers[classification_index_array[i]] |= node_id_bit; //Also add self
+						globalSharers[classification_index_array[i]+1] |= remote_sharers[(i*2)+1];
+			}
 		}
-	}
-	MPI_Win_unlock(workrank, sharerWindow);
+	});
 
 	/* If any owner of a page we loaded needs to downgrade from private
 	 * to shared, we need to notify it */
@@ -438,11 +448,13 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 				}
 
 				/* Downgrade all relevant pages on the owner node from private to shared */
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-				MPI_Accumulate(sharer_bit_mask.data(), classification_size, MPI_LONG, owner,
-						classification_index_array[0], classification_size, MPI_LONG,
-						MPI_BOR, sharerWindow);
-				MPI_Win_unlock(owner, sharerWindow);
+				sharer_op(MPI_LOCK_EXCLUSIVE, owner, classification_index_array[0],
+						[&](std::size_t win_index){
+						MPI_Accumulate(sharer_bit_mask.data(), classification_size, MPI_LONG, owner,
+								win_offset, classification_size, MPI_LONG,
+								MPI_BOR, sharer_windows[win_index]);
+					});
+				//TODO: This should probably be in one window
 			}
 		}
 	}
@@ -528,26 +540,29 @@ void handler(int sig, siginfo_t *si, void *context){
 
 	std::uint64_t id = static_cast<std::uint64_t>(1) << getID();
 	std::uint64_t invid = ~id;
+	std::size_t win_offset = get_window_offset(classidx);
 
-	//pthread_mutex_lock(&cachemutex);
 	/* Acquire shared sync lock and first cache index lock */
-	//sync_mutex.shared_lock();
 	pthread_rwlock_rdlock(&sync_lock);
 	cache_locks[startIndex].lock();
 
-
 	/* page is local */
 	if(homenode == (getID())){
-		std::uint64_t sharers;
-		MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-		std::uint64_t prevsharer = (globalSharers[classidx])&id;
-		MPI_Win_unlock(workrank, sharerWindow);
-
+		std::uint64_t sharers, prevsharer;
+		{
+			auto op = [&](std::size_t win_index) {
+				prevsharer = (globalSharers[classidx])&id;
+			};
+			sharer_op(MPI_LOCK_SHARED, workrank, classidx, op);
+		}
 		if(prevsharer != id){
-			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-			sharers = globalSharers[classidx];
-			globalSharers[classidx] |= id;
-			MPI_Win_unlock(workrank, sharerWindow);
+			{
+				auto op = [&](std::size_t win_index) {
+					sharers = globalSharers[classidx];
+					globalSharers[classidx] |= id;
+				};
+				sharer_op(MPI_LOCK_EXCLUSIVE, workrank, classidx, op);
+			}
 			if(sharers != 0 && sharers != id && isPowerOf2(sharers)){
 				std::uint64_t ownid = sharers&invid;
 				argo::node_id_t owner = workrank;
@@ -562,9 +577,11 @@ void handler(int sig, siginfo_t *si, void *context){
 				}
 				else{
 					/* update remote private holder to shared */
-					MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-					MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx, 1, MPI_LONG, MPI_BOR, sharerWindow);
-					MPI_Win_unlock(owner, sharerWindow);
+					{
+						auto op = [&](std::size_t win_index){
+							MPI_Accumulate(&id, 1, MPI_LONG, owner, win_offset,1,MPI_LONG,MPI_BOR,sharer_windows[win_index]); };
+						sharer_op(MPI_LOCK_EXCLUSIVE, owner, classidx, op);
+					}
 				}
 			}
 			/* set page to permit reads and map it to the page cache */
@@ -581,11 +598,15 @@ void handler(int sig, siginfo_t *si, void *context){
 			}
 
 			/* get current sharers/writers and then add your own id */
-			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-			std::uint64_t sharers = globalSharers[classidx];
-			std::uint64_t writers = globalSharers[classidx+1];
-			globalSharers[classidx+1] |= id;
-			MPI_Win_unlock(workrank, sharerWindow);
+			std::uint64_t sharers, writers;
+			{
+				auto op = [&](std::size_t win_index){
+					sharers = globalSharers[classidx];
+					writers = globalSharers[classidx+1];
+					globalSharers[classidx+1] |= id;
+				};
+				sharer_op(MPI_LOCK_EXCLUSIVE, workrank, classidx, op);
+			}
 
 			/* remote single writer */
 			if(writers != id && writers != 0 && isPowerOf2(writers&invid)){
@@ -596,26 +617,31 @@ void handler(int sig, siginfo_t *si, void *context){
 						break;
 					}
 				}
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-				MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx+1, 1, MPI_LONG, MPI_BOR, sharerWindow);
-				MPI_Win_unlock(owner, sharerWindow);
+				{
+					auto op = [&](std::size_t win_index){
+						MPI_Accumulate(&id, 1, MPI_LONG, owner, win_offset+1,1,MPI_LONG,MPI_BOR,sharer_windows[win_index]);
+					};
+					sharer_op(MPI_LOCK_EXCLUSIVE, owner, classidx, op);
+				}
 			}
 			else if(writers == id || writers == 0){
 				for(argo::node_id_t n = 0; n < numtasks; n++){
 					if(n != workrank && ((static_cast<std::uint64_t>(1) << n)&sharers) != 0){
-						MPI_Win_lock(MPI_LOCK_EXCLUSIVE, n, 0, sharerWindow);
-						MPI_Accumulate(&id, 1, MPI_LONG, n, classidx+1, 1, MPI_LONG, MPI_BOR, sharerWindow);
-						MPI_Win_unlock(n, sharerWindow);
+						{
+							auto op = [&](std::size_t win_index){
+								MPI_Accumulate(&id, 1, MPI_LONG, n, win_offset+1,1,MPI_LONG,MPI_BOR,sharer_windows[win_index]);
+							};
+							sharer_op(MPI_LOCK_EXCLUSIVE, n, classidx, op);
+						}
 					}
 				}
 			}
+
 			/* set page to permit read/write and map it to the page cache */
 			vm::map_memory(aligned_access_ptr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ|PROT_WRITE);
 		}
-		//pthread_mutex_unlock(&cachemutex);
 		/* Unlock shared sync lock and cache index lock */
 		cache_locks[startIndex].unlock();
-		//sync_mutex.unlock_shared();
 		pthread_rwlock_unlock(&sync_lock);
 		return;
 	}
@@ -649,9 +675,7 @@ void handler(int sig, siginfo_t *si, void *context){
 	line *= CACHELINE;
 
 	if(cacheControl[line].dirty == DIRTY){
-		//pthread_mutex_unlock(&cachemutex);
 		cache_locks[startIndex].unlock();
-		//sync_mutex.unlock_shared();
 		pthread_rwlock_unlock(&sync_lock);
 		return;
 	}
@@ -659,28 +683,43 @@ void handler(int sig, siginfo_t *si, void *context){
 	touchedcache[line] = 1;
 	cacheControl[line].dirty = DIRTY;
 
-	MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
-	std::uint64_t writers = globalSharers[classidx+1];
-	std::uint64_t sharers = globalSharers[classidx];
-	MPI_Win_unlock(workrank, sharerWindow);
+	std::uint64_t writers, sharers;
+	{
+		auto op = [&](std::size_t win_index){
+			writers = globalSharers[classidx+1];
+			sharers = globalSharers[classidx];
+		};
+		sharer_op(MPI_LOCK_SHARED, workrank, classidx, op);
+	}
+
 	/* Either already registered write - or 1 or 0 other writers already cached */
 	if(writers != id && isPowerOf2(writers)){
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-		globalSharers[classidx+1] |= id; //register locally
-		MPI_Win_unlock(workrank, sharerWindow);
+		{
+			auto op = [&](std::size_t win_index){
+				globalSharers[classidx+1] |= id; //register locally
+			};
+			sharer_op(MPI_LOCK_EXCLUSIVE, workrank, classidx, op);
+		}
 
 		/* register and get latest sharers / writers */
-		MPI_Win_lock(MPI_LOCK_SHARED, homenode, 0, sharerWindow);
-		MPI_Get_accumulate(&id, 1, MPI_LONG, &writers, 1, MPI_LONG, homenode,
-			classidx+1, 1, MPI_LONG, MPI_BOR, sharerWindow);
-		MPI_Get(&sharers, 1, MPI_LONG, homenode, classidx, 1, MPI_LONG, sharerWindow);
-		MPI_Win_unlock(homenode, sharerWindow);
+		{
+			auto op = [&](std::size_t win_index){
+				MPI_Get_accumulate(&id, 1,MPI_LONG,&writers,1,MPI_LONG,homenode,
+					win_offset+1,1,MPI_LONG,MPI_BOR,sharer_windows[win_index]);
+				MPI_Get(&sharers,1, MPI_LONG, homenode, win_offset, 1,MPI_LONG,sharer_windows[win_index]);
+			};
+			sharer_op(MPI_LOCK_SHARED, homenode, classidx+1, op);
+		}
+				
 		/* We get result of accumulation before operation so we need to account for that */
 		writers |= id;
 		/* Just add the (potentially) new sharers fetched to local copy */
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-		globalSharers[classidx] |= sharers;
-		MPI_Win_unlock(workrank, sharerWindow);
+		{
+			auto op = [&](std::size_t win_index){
+				globalSharers[classidx] |= sharers;
+			};
+			sharer_op(MPI_LOCK_EXCLUSIVE, workrank, classidx, op);
+		}
 
 		/* check if we need to update */
 		if(writers != id && writers != 0 && isPowerOf2(writers&invid)){
@@ -691,16 +730,16 @@ void handler(int sig, siginfo_t *si, void *context){
 					break;
 				}
 			}
-			MPI_Win_lock(MPI_LOCK_EXCLUSIVE, owner, 0, sharerWindow);
-			MPI_Accumulate(&id, 1, MPI_LONG, owner, classidx+1, 1, MPI_LONG, MPI_BOR, sharerWindow);
-			MPI_Win_unlock(owner, sharerWindow);
+			sharer_op(MPI_LOCK_EXCLUSIVE, owner, classidx+1, [&](std::size_t win_index){
+					MPI_Accumulate(&id, 1, MPI_LONG, owner, win_offset+1,1,MPI_LONG,MPI_BOR,sharer_windows[win_index]);
+					});
 		}
 		else if(writers == id || writers == 0){
 			for(argo::node_id_t n = 0; n < numtasks; n++){
 				if(n != workrank && ((static_cast<std::uint64_t>(1) << n)&sharers) != 0){
-					MPI_Win_lock(MPI_LOCK_EXCLUSIVE, n, 0, sharerWindow);
-					MPI_Accumulate(&id, 1, MPI_LONG, n, classidx+1, 1, MPI_LONG, MPI_BOR, sharerWindow);
-					MPI_Win_unlock(n, sharerWindow);
+					sharer_op(MPI_LOCK_EXCLUSIVE, n, classidx+1, [&](std::size_t win_index){
+							MPI_Accumulate(&id, 1, MPI_LONG, n, win_offset+1,1,MPI_LONG,MPI_BOR,sharer_windows[win_index]);
+							});
 				}
 			}
 		}
@@ -709,9 +748,7 @@ void handler(int sig, siginfo_t *si, void *context){
 	memcpy(copy, aligned_access_ptr, CACHELINE*pagesize);
 	argo_write_buffer->add(startIndex);
 	mprotect(aligned_access_ptr, pagesize*CACHELINE, PROT_WRITE|PROT_READ);
-	//pthread_mutex_unlock(&cachemutex);
 	cache_locks[startIndex].unlock();
-	//sync_mutex.unlock_shared();
 	pthread_rwlock_unlock(&sync_lock);
 	double t2 = MPI_Wtime();
 	stats.storetime += t2-t1;
@@ -794,7 +831,7 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	cachesize /= pagesize;
 	cache_locks.resize(cachesize);
 
-	win_granularity = env::mpi_win_granularity;
+	win_granularity = env::mpi_win_granularity();
 
 
 	classificationSize = 2*(argo_size/pagesize);
@@ -893,8 +930,14 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 									 MPI_INFO_NULL, MPI_COMM_WORLD, &globalDataWindow[i]);
 	}
 
-	MPI_Win_create(globalSharers, gwritersize, sizeof(std::uint64_t),
-								 MPI_INFO_NULL, MPI_COMM_WORLD, &sharerWindow);
+	// Create one sharer_window per page
+	std::size_t num_windows = std::ceil((classificationSize/2)/static_cast<double>(win_granularity));
+	sharer_windows.resize(num_windows);
+	for(i = 0; i < num_windows; i++){
+		std::size_t sharer_offset = i*2*win_granularity;
+		MPI_Win_create(&globalSharers[sharer_offset], 2*win_granularity*sizeof(unsigned long),
+				sizeof(unsigned long), MPI_INFO_NULL, MPI_COMM_WORLD, &sharer_windows[i]);
+	}
 
 	if (dd::is_first_touch_policy()) {
 		MPI_Win_create(global_owners_dir, owners_dir_size_bytes, sizeof(std::uintptr_t),
@@ -932,7 +975,9 @@ void argo_finalize(){
 	for(i = 0; i < numtasks; i++){
 		MPI_Win_free(&globalDataWindow[i]);
 	}
-	MPI_Win_free(&sharerWindow);
+	for(auto window : sharer_windows){
+		MPI_Win_free(&window);
+	}
 	if (dd::is_first_touch_policy()) {
 		MPI_Win_free(&owners_dir_window);
 		MPI_Win_free(&offsets_tbl_window);
@@ -959,7 +1004,8 @@ void self_invalidation(){
 				argo_write_buffer->flush();
 				flushed = 1;
 			}
-			MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharerWindow);
+			std::size_t win_index = get_window_index(classidx);
+			MPI_Win_lock(MPI_LOCK_SHARED, workrank, 0, sharer_windows[win_index]);
 			if(
 				 // node is single writer
 				 (globalSharers[classidx+1] == id)
@@ -967,12 +1013,12 @@ void self_invalidation(){
 				 // No writer and assert that the node is a sharer
 				 ((globalSharers[classidx+1] == 0) && ((globalSharers[classidx]&id) == id))
 				 ){
-				MPI_Win_unlock(workrank, sharerWindow);
+				MPI_Win_unlock(workrank, sharer_windows[win_index]);
 				touchedcache[i] = 1;
 				/*nothing - we keep the pages, SD is done in flushWB*/
 			}
 			else{ //multiple writer or SO
-				MPI_Win_unlock(workrank, sharerWindow);
+				MPI_Win_unlock(workrank, sharer_windows[win_index]);
 				cacheControl[i].dirty = CLEAN;
 				cacheControl[i].state = INVALID;
 				touchedcache[i] = 0;
@@ -989,7 +1035,6 @@ void self_upgrade(upgrade_type upgrade) {
 		   upgrade == upgrade_type::upgrade_all);
 	const std::uint64_t node_id_bit = static_cast<std::uint64_t>(1) << getID();
 
-	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
 	for(std::size_t i = 0; i < classificationSize; i+=2) {
 		std::size_t page_index = i/2;
 		std::uintptr_t page_addr = page_index*pagesize*CACHELINE;
@@ -998,11 +1043,13 @@ void self_upgrade(upgrade_type upgrade) {
 		bool is_sharer = globalSharers[i]&node_id_bit;
 		bool is_writer = globalSharers[i+1]&node_id_bit;
 
-		// Reset globalSharers for this page
-		if(upgrade == upgrade_type::upgrade_all) {
-			globalSharers[i] = 0;
-		}
-		globalSharers[i+1] = 0;
+		sharer_op(MPI_LOCK_SHARED, workrank, i, [&](std::size_t){
+			// Reset globalSharers for this page
+			if(upgrade == upgrade_type::upgrade_all) {
+				globalSharers[i] = 0;
+			}
+			globalSharers[i+1] = 0;
+		});
 
 		// Apply the correct mprotection and cache state
 		if(is_cached) {
@@ -1020,7 +1067,6 @@ void self_upgrade(upgrade_type upgrade) {
 			}
 		}
 	}
-	MPI_Win_unlock(workrank, sharerWindow);
 }
 
 void swdsm_argo_barrier(int n, upgrade_type upgrade){
@@ -1040,8 +1086,6 @@ void swdsm_argo_barrier(int n, upgrade_type upgrade){
 	// Let one thread per node perform MPI operations
 	if(pthread_mutex_trylock(&barriermutex) == 0){
 		barrierlockholder = pthread_self();
-		//pthread_mutex_lock(&cachemutex);
-		//sync_mutex.lock();
 		pthread_rwlock_wrlock(&sync_lock);
 
 		// Perform SD followed by SI
@@ -1055,8 +1099,6 @@ void swdsm_argo_barrier(int n, upgrade_type upgrade){
 			MPI_Barrier(workcomm);
 		}
 
-		//pthread_mutex_unlock(&cachemutex);
-		//sync_mutex.unlock()
 		pthread_rwlock_unlock(&sync_lock);
 	}
 
@@ -1080,12 +1122,13 @@ void argo_reset_coherence(){
 		cacheControl[i].dirty = CLEAN;
 	}
 
-	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-	for(std::size_t i = 0; i < classificationSize; i++){
-		globalSharers[i] = 0;
+	for(std::size_t i=0; i<classificationSize; i+=win_granularity){
+		sharer_op(MPI_LOCK_EXCLUSIVE, workrank, i, [&](std::size_t win_index){
+				for(j = i; j < i+win_granularity; j++){
+					globalSharers[j] = 0;
+				}
+			});
 	}
-	MPI_Win_unlock(workrank, sharerWindow);
-
 	if (dd::is_first_touch_policy()) {
 		/**
 		 * @note initialize the first-touch directory with a magic value,
@@ -1112,26 +1155,18 @@ void argo_reset_coherence(){
 
 void argo_acquire() {
 	int flag;
-	//pthread_mutex_lock(&cachemutex);
-	//sync_mutex.lock();
 	pthread_rwlock_wrlock(&sync_lock);
 	self_invalidation();
 	MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
-	//pthread_mutex_unlock(&cachemutex);
-	//sync_mutex.unlock();
 	pthread_rwlock_unlock(&sync_lock);
 }
 
 
 void argo_release() {
 	int flag;
-	//pthread_mutex_lock(&cachemutex);
-	//sync_mutex.lock();
 	pthread_rwlock_wrlock(&sync_lock);
 	argo_write_buffer->flush();
 	MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
-	//pthread_mutex_unlock(&cachemutex);
-	//sync_mutex.unlock();
 	pthread_rwlock_unlock(&sync_lock);
 }
 
@@ -1230,4 +1265,20 @@ bool _is_cached(std::uintptr_t addr) {
 	// Return true for pages which are either local or already cached
 	return ((homenode == getID()) || (cacheControl[cache_index].tag == aligned_address &&
 				cacheControl[cache_index].state == VALID));
+}
+
+void sharer_op(int lock_type, int rank, int offset,
+		std::function<void(const std::size_t window_index)> op) {
+	std::size_t win_index = get_window_index(offset);
+	MPI_Win_lock(lock_type, rank, 0, sharer_windows[win_index]);
+	op(win_index);
+	MPI_Win_unlock(rank, sharer_windows[win_index]);
+}
+
+std::size_t get_window_index(int offset){
+	return (offset/2)/win_granularity;
+}
+
+std::size_t get_window_offset(int classification_index){
+	return classification_index%(win_granularity*2);
 }

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -198,7 +198,7 @@ std::size_t peek_offset(std::uintptr_t addr) {
 void load_cache_entry(std::uintptr_t aligned_access_offset) {
 	/* If it's not an ArgoDSM address, do not handle it */
 	if(aligned_access_offset >= size_of_all){
-		//TODO: Must probably unlock here?
+		// XXX: Must probably unlock here?
 		printf("WARNING: UNSAFE CASE!!!\n");
 		return;
 	}
@@ -530,7 +530,7 @@ void handler(int sig, siginfo_t *si, void *context){
 					sharer_op(MPI_LOCK_EXCLUSIVE, owner, classidx,
 							[&](std::size_t win_index){
 							MPI_Accumulate(&id, 1, MPI_LONG, owner, sharer_win_offset,
-									1,MPI_LONG,MPI_BOR,sharer_windows[win_index][owner]);
+									1, MPI_LONG, MPI_BOR, sharer_windows[win_index][owner]);
 							});
 				}
 			}
@@ -641,12 +641,12 @@ void handler(int sig, siginfo_t *si, void *context){
 		sharer_op(MPI_LOCK_SHARED, homenode, classidx+1,
 				[&](std::size_t win_index){
 				MPI_Get_accumulate(&id, 1, MPI_LONG, &writers,
-						1, MPI_LONG,homenode, sharer_win_offset+1,
-						1, MPI_LONG,MPI_BOR, sharer_windows[win_index][homenode]);
+						1, MPI_LONG, homenode, sharer_win_offset+1,
+						1, MPI_LONG, MPI_BOR, sharer_windows[win_index][homenode]);
 				MPI_Get(&sharers, 1, MPI_LONG, homenode, sharer_win_offset,
 						1, MPI_LONG, sharer_windows[win_index][homenode]);
 				});
-				
+
 		/* We get result of accumulation before operation so we need to account for that */
 		writers |= id;
 		/* Just add the (potentially) new sharers fetched to local copy */
@@ -1086,7 +1086,7 @@ void argo_reset_coherence(){
 		cacheControl[i].dirty = CLEAN;
 	}
 
-	for(std::size_t i=0; i<classificationSize; i+=(load_size*2)){
+	for(std::size_t i = 0; i < classificationSize; i += (load_size*2)){
 		sharer_op(MPI_LOCK_EXCLUSIVE, workrank, i, [&](std::size_t){
 				for(std::size_t j = i; j < i+(load_size*2); j++){
 					globalSharers[j] = 0;
@@ -1184,7 +1184,7 @@ void argo_reset_stats(){
 
 void storepageDIFF(std::size_t index, std::uintptr_t addr){
 	int cnt = 0;
-	
+
 	// This might differ depending on allocation policy, must take into account
 	const argo::node_id_t homenode = get_homenode(addr);
 	const std::size_t offset = get_offset(addr);
@@ -1387,7 +1387,7 @@ void print_statistics(){
 		for(argo::num_nodes_t i = 0; i < numtasks; i++){
 			MPI_Barrier(MPI_COMM_WORLD);
 			if(i == workrank){
-				printf("#" YEL "  ### PROCESS ID %d ###\n" RESET,workrank);
+				printf("#" YEL "  ### PROCESS ID %d ###\n" RESET, workrank);
 
 				/* Print remote access info */
 				printf("#  " CYN "# Remote accesses\n" RESET);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1307,70 +1307,98 @@ void print_statistics(){
 	/**
 	 *	Store MPI lock statistics for the data lock
 	 */
-	double data_total_lock_time(0), data_avg_lock_time(0), data_max_lock_time(0);
-	double data_total_unlock_time(0), data_avg_unlock_time(0), data_max_unlock_time(0);
-	double data_mpi_lock_time(0), data_mpi_unlock_time(0);
-	double data_total_hold_time(0), data_avg_hold_time(0), data_max_hold_time(0);
-	int data_num_locks(0);
+	std::size_t data_num_locks(0);
+	double data_spin_lock_time(0), data_spin_avg_lock_time(0), data_spin_max_lock_time(0);
+	double data_spin_hold_time(0), data_spin_avg_hold_time(0), data_spin_max_hold_time(0);
+
+	double data_mpi_lock_time(0), data_mpi_avg_lock_time(0), data_mpi_max_lock_time(0);
+	double data_mpi_unlock_time(0), data_mpi_avg_unlock_time(0), data_mpi_max_unlock_time(0);
+	double data_mpi_hold_time(0), data_mpi_avg_hold_time(0), data_mpi_max_hold_time(0);
 
 	for(std::size_t i=0; i<num_data_windows; i++){
 		for(int j=0; j<numtasks; j++){
-			data_total_lock_time += mpi_lock_data[i][j].get_locktime();
-			data_total_unlock_time += mpi_lock_data[i][j].get_unlocktime();
-			data_mpi_lock_time += mpi_lock_data[i][j].get_mpilocktime();
-			data_mpi_unlock_time += mpi_lock_data[i][j].get_mpiunlocktime();
-			data_total_hold_time += mpi_lock_data[i][j].get_holdtime();
+			/* Get number of locks */
+			data_num_locks += mpi_lock_data[i][j].get_num_locks();
 
-			if(mpi_lock_data[i][j].get_maxlocktime() > data_max_lock_time){
-				data_max_lock_time = mpi_lock_data[i][j].get_maxlocktime();
+			/* Get spin lock stats */
+			data_spin_lock_time 		+= 	mpi_lock_data[i][j].get_spin_lock_time();
+			data_spin_hold_time 		+= 	mpi_lock_data[i][j].get_spin_hold_time();
+			if(mpi_lock_data[i][j].get_max_spin_lock_time() > data_spin_max_lock_time){
+				data_spin_max_lock_time = mpi_lock_data[i][j].get_max_spin_lock_time();
 			}
-			if(mpi_lock_data[i][j].get_maxunlocktime() > data_max_unlock_time){
-				data_max_unlock_time = mpi_lock_data[i][j].get_maxunlocktime();
+			if(mpi_lock_data[i][j].get_max_spin_hold_time() > data_spin_max_hold_time){
+				data_spin_max_hold_time = mpi_lock_data[i][j].get_max_spin_hold_time();
 			}
-			if(mpi_lock_data[i][j].get_maxholdtime() > data_max_hold_time){
-				data_max_hold_time = mpi_lock_data[i][j].get_maxholdtime();
+
+			/* Get mpi lock stats */
+			data_mpi_lock_time 			+= 	mpi_lock_data[i][j].get_mpi_lock_time();
+			data_mpi_unlock_time 		+= 	mpi_lock_data[i][j].get_mpi_unlock_time();
+			data_mpi_hold_time 			+=	mpi_lock_data[i][j].get_mpi_hold_time();
+			if(mpi_lock_data[i][j].get_max_mpi_lock_time() > data_mpi_max_lock_time){
+				data_mpi_max_lock_time = mpi_lock_data[i][j].get_max_mpi_lock_time();
 			}
-			data_num_locks += mpi_lock_data[i][j].get_numlocks();
+			if(mpi_lock_data[i][j].get_max_mpi_unlock_time() > data_mpi_max_unlock_time){
+				data_mpi_max_unlock_time = mpi_lock_data[i][j].get_max_mpi_unlock_time();
+			}
+			if(mpi_lock_data[i][j].get_max_mpi_hold_time() > data_mpi_max_hold_time){
+				data_mpi_max_hold_time = mpi_lock_data[i][j].get_max_mpi_hold_time();
+			}
 		}
 	}
 	/** Get averages */
-	data_avg_lock_time = data_total_lock_time / data_num_locks;
-	data_avg_unlock_time = data_total_unlock_time / data_num_locks;
-	data_avg_hold_time = data_total_hold_time / data_num_locks;
+	data_spin_avg_lock_time 	= data_spin_lock_time / data_num_locks;
+	data_spin_avg_hold_time 	= data_spin_hold_time / data_num_locks;
+	data_mpi_avg_lock_time 		= data_mpi_lock_time / data_num_locks;
+	data_mpi_avg_unlock_time 	= data_mpi_unlock_time / data_num_locks;
+	data_mpi_avg_hold_time 		= data_mpi_hold_time / data_num_locks;
 
 	/**
 	 *	Store MPI lock statistics for the sharer lock
 	 */
-	double sharer_total_lock_time(0), sharer_avg_lock_time(0), sharer_max_lock_time(0);
-	double sharer_total_unlock_time(0), sharer_avg_unlock_time(0), sharer_max_unlock_time(0);
-	double sharer_mpi_lock_time(0), sharer_mpi_unlock_time(0);
-	double sharer_total_hold_time(0), sharer_avg_hold_time(0), sharer_max_hold_time(0);
-	int sharer_num_locks(0);
+	std::size_t sharer_num_locks(0);
+	double sharer_spin_lock_time(0), sharer_spin_avg_lock_time(0), sharer_spin_max_lock_time(0);
+	double sharer_spin_hold_time(0), sharer_spin_avg_hold_time(0), sharer_spin_max_hold_time(0);
+
+	double sharer_mpi_lock_time(0), sharer_mpi_avg_lock_time(0), sharer_mpi_max_lock_time(0);
+	double sharer_mpi_unlock_time(0), sharer_mpi_avg_unlock_time(0), sharer_mpi_max_unlock_time(0);
+	double sharer_mpi_hold_time(0), sharer_mpi_avg_hold_time(0), sharer_mpi_max_hold_time(0);
 
 	for(std::size_t i=0; i<num_sharer_windows; i++){
 		for(int j=0; j<numtasks; j++){
-			sharer_total_lock_time += mpi_lock_sharer[i][j].get_locktime();
-			sharer_total_unlock_time += mpi_lock_sharer[i][j].get_unlocktime();
-			sharer_mpi_lock_time += mpi_lock_sharer[i][j].get_mpilocktime();
-			sharer_mpi_unlock_time += mpi_lock_sharer[i][j].get_mpiunlocktime();
-			sharer_total_hold_time += mpi_lock_sharer[i][j].get_holdtime();
+			/* Get number of locks */
+			sharer_num_locks += mpi_lock_sharer[i][j].get_num_locks();
 
-			if(mpi_lock_sharer[i][j].get_maxlocktime() > sharer_max_lock_time){
-				sharer_max_lock_time = mpi_lock_sharer[i][j].get_maxlocktime();
+			/* Get spin lock stats */
+			sharer_spin_lock_time 		+= 	mpi_lock_sharer[i][j].get_spin_lock_time();
+			sharer_spin_hold_time 		+= 	mpi_lock_sharer[i][j].get_spin_hold_time();
+			if(mpi_lock_sharer[i][j].get_max_spin_lock_time() > sharer_spin_max_lock_time){
+				sharer_spin_max_lock_time = mpi_lock_sharer[i][j].get_max_spin_lock_time();
 			}
-			if(mpi_lock_sharer[i][j].get_maxunlocktime() > sharer_max_unlock_time){
-				sharer_max_unlock_time = mpi_lock_sharer[i][j].get_maxunlocktime();
+			if(mpi_lock_sharer[i][j].get_max_spin_hold_time() > sharer_spin_max_hold_time){
+				sharer_spin_max_hold_time = mpi_lock_sharer[i][j].get_max_spin_hold_time();
 			}
-			if(mpi_lock_sharer[i][j].get_maxholdtime() > sharer_max_hold_time){
-				sharer_max_hold_time = mpi_lock_sharer[i][j].get_maxholdtime();
+
+			/* Get mpi lock stats */
+			sharer_mpi_lock_time 			+= 	mpi_lock_sharer[i][j].get_mpi_lock_time();
+			sharer_mpi_unlock_time 		+= 	mpi_lock_sharer[i][j].get_mpi_unlock_time();
+			sharer_mpi_hold_time 			+=	mpi_lock_sharer[i][j].get_mpi_hold_time();
+			if(mpi_lock_sharer[i][j].get_max_mpi_lock_time() > sharer_mpi_max_lock_time){
+				sharer_mpi_max_lock_time = mpi_lock_sharer[i][j].get_max_mpi_lock_time();
 			}
-			sharer_num_locks += mpi_lock_sharer[i][j].get_numlocks();
+			if(mpi_lock_sharer[i][j].get_max_mpi_unlock_time() > sharer_mpi_max_unlock_time){
+				sharer_mpi_max_unlock_time = mpi_lock_sharer[i][j].get_max_mpi_unlock_time();
+			}
+			if(mpi_lock_sharer[i][j].get_max_mpi_hold_time() > sharer_mpi_max_hold_time){
+				sharer_mpi_max_hold_time = mpi_lock_sharer[i][j].get_max_mpi_hold_time();
+			}
 		}
 	}
 	/** Get averages */
-	sharer_avg_lock_time = sharer_total_lock_time / sharer_num_locks;
-	sharer_avg_unlock_time = sharer_total_unlock_time / sharer_num_locks;
-	sharer_avg_hold_time = sharer_total_hold_time / sharer_num_locks;
+	sharer_spin_avg_lock_time 	= sharer_spin_lock_time / sharer_num_locks;
+	sharer_spin_avg_hold_time 	= sharer_spin_hold_time / sharer_num_locks;
+	sharer_mpi_avg_lock_time 		= sharer_mpi_lock_time / sharer_num_locks;
+	sharer_mpi_avg_unlock_time 	= sharer_mpi_unlock_time / sharer_num_locks;
+	sharer_mpi_avg_hold_time 		= sharer_mpi_hold_time / sharer_num_locks;
 
 
 	/** Nicely format and print the results */
@@ -1429,26 +1457,31 @@ void print_statistics(){
 					cache_lock_time);
 
 			/* Print data lock info */
-			printf("#  " CYN "# Data lock  \t(%d locks held)\n" RESET, data_num_locks);
-			printf("#  ttl lock time: %10.4fs   avg lock time: %10.4fs   max lock time: %10.4fs\n",
-					data_total_lock_time, data_avg_lock_time, data_max_lock_time);
-			printf("#  ttl unlock time: %8.4fs   avg unlock time: %8.4fs   max unlock time: %8.4fs\n",
-					data_total_unlock_time, data_avg_unlock_time, data_max_unlock_time);
-			printf("#  ttl hold time: %10.4fs   avg hold time: %10.4fs   max hold time: %10.4fs\n",
-					data_total_hold_time, data_avg_hold_time, data_max_hold_time);
-			printf("#  mpi lock time: %10.4fs   mpi unlock time: %8.4fs\n",
-					data_mpi_lock_time, data_mpi_unlock_time);
+			printf("#  " CYN "# Data lock  \t(%zu locks held)\n" RESET, data_num_locks);
+			printf("#  spin lock time: %9.4fs   avg lock time: %10.4fs   max lock time: %10.4fs\n",
+					data_spin_lock_time, data_spin_avg_lock_time, data_spin_max_lock_time);
+			printf("#  spin hold time: %9.4fs   avg hold time: %10.4fs   max hold time: %10.4fs\n",
+					data_spin_hold_time, data_spin_avg_hold_time, data_spin_max_hold_time);
+			printf("#  mpi lock time: %10.4fs   avg lock time: %10.4fs   max lock time: %10.4fs\n",
+					data_mpi_lock_time, data_mpi_avg_lock_time, data_mpi_max_lock_time);
+			printf("#  mpi unlock time: %8.4fs   avg unlock time: %8.4fs   max unlock time: %8.4fs\n",
+					data_mpi_unlock_time, data_mpi_avg_unlock_time, data_mpi_max_unlock_time);
+			printf("#  mpi hold time: %10.4fs   avg hold time: %10.4fs   max hold time: %10.4fs\n",
+					data_mpi_hold_time, data_mpi_avg_hold_time, data_mpi_max_hold_time);
+
 
 			/* Print sharer lock info */
-			printf("#  " CYN "# Sharer lock\t(%d locks held)\n" RESET, sharer_num_locks);
-			printf("#  ttl lock time: %10.4fs   avg lock time: %10.4fs   max lock time: %10.4fs\n",
-					sharer_total_lock_time, sharer_avg_lock_time, sharer_max_lock_time);
-			printf("#  ttl unlock time: %8.4fs   avg unlock time: %8.4fs   max unlock time: %8.4fs\n",
-					sharer_total_unlock_time, sharer_avg_unlock_time, sharer_max_unlock_time);
-			printf("#  ttl hold time: %10.4fs   avg hold time: %10.4fs   max hold time: %10.4fs\n",
-					sharer_total_hold_time, sharer_avg_hold_time, sharer_max_hold_time);
-			printf("#  mpi lock time: %10.4fs   mpi unlock time: %8.4fs\n",
-					sharer_mpi_lock_time, sharer_mpi_unlock_time);
+			printf("#  " CYN "# Sharer lock  \t(%zu locks held)\n" RESET, sharer_num_locks);
+			printf("#  spin lock time: %9.4fs   avg lock time: %10.4fs   max lock time: %10.4fs\n",
+					sharer_spin_lock_time, sharer_spin_avg_lock_time, sharer_spin_max_lock_time);
+			printf("#  spin hold time: %9.4fs   avg hold time: %10.4fs   max hold time: %10.4fs\n",
+					sharer_spin_hold_time, sharer_spin_avg_hold_time, sharer_spin_max_hold_time);
+			printf("#  mpi lock time: %10.4fs   avg lock time: %10.4fs   max lock time: %10.4fs\n",
+					sharer_mpi_lock_time, sharer_mpi_avg_lock_time, sharer_mpi_max_lock_time);
+			printf("#  mpi unlock time: %8.4fs   avg unlock time: %8.4fs   max unlock time: %8.4fs\n",
+					sharer_mpi_unlock_time, sharer_mpi_avg_unlock_time, sharer_mpi_max_unlock_time);
+			printf("#  mpi hold time: %10.4fs   avg hold time: %10.4fs   max hold time: %10.4fs\n",
+					sharer_mpi_hold_time, sharer_mpi_avg_hold_time, sharer_mpi_max_hold_time);
 			printf("\n");
 			fflush(stdout);
 		}

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1484,13 +1484,10 @@ std::size_t get_sharer_win_offset(int classification_index){
 	return classification_index%(win_granularity*2);
 }
 
-std::size_t get_data_win_index(int offset){
+std::size_t get_data_win_index(std::size_t offset){
 	return (offset/(pagesize*CACHELINE))/win_granularity;
 }
 
-std::size_t get_data_win_offset(int offset){
-	//printf("[%d] Offset: %d\t Mod: %lu\t Return: %lu\n",
-	//		getID(), offset, (win_granularity*pagesize*CACHELINE),
-	//		offset%(win_granularity*(pagesize*CACHELINE)));
+std::size_t get_data_win_offset(std::size_t offset){
 	return offset%(win_granularity*(pagesize*CACHELINE));
 }

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -730,6 +730,7 @@ void handler(int sig, siginfo_t *si, void *context){
 			};
 			sharer_op(MPI_LOCK_SHARED, homenode, classidx+1, op);
 			//TODO: Test if this can still be SHARED
+			//TODO: We can remove one MPI operation here by using a bitmask and storing both
 		}
 				
 		/* We get result of accumulation before operation so we need to account for that */
@@ -1228,8 +1229,6 @@ void clearStatistics() {
 	stats.selfinvtime = 0;
 	stats.loadtime = 0;
 	stats.storetime = 0;
-	stats.flushtime = 0;
-	stats.writebacktime = 0;
 	stats.locktime = 0;
 	stats.barriertime = 0;
 	stats.stores = 0;
@@ -1290,9 +1289,10 @@ void printStatistics(){
 	printf("# PROCESS ID %d \n", workrank);
 	printf("cachesize:%ld,CACHELINE:%ld wbsize:%ld\n", cachesize, CACHELINE,
 			env::write_buffer_size()/CACHELINE);
-	printf("     writebacktime+=(t2-t1): %lf\n", stats.writebacktime);
+	printf("     writebacktime+=(t2-t1): %lf\n", argo_write_buffer->get_write_back_time());
 	printf("# Storetime : %lf , loadtime :%lf flushtime:%lf, writebacktime: %lf\n",
-		stats.storetime, stats.loadtime, stats.flushtime, stats.writebacktime);
+		stats.storetime, stats.loadtime, argo_write_buffer->get_flush_time(),
+		argo_write_buffer->get_write_back_time());
 	printf("# SSDtime:%lf, SSItime:%lf\n", stats.ssdtime, stats.ssitime);
 	printf("# Barriertime : %lf, selfinvtime %lf\n", stats.barriertime, stats.selfinvtime);
 	printf("stores:%lu, loads:%lu, barriers:%lu\n", stats.stores, stats.loads, stats.barriers);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -49,6 +49,8 @@ argo_byte * touchedcache;
 char* cacheData;
 /** @brief Copy of the local cache to keep twinpages for later being able to DIFF stores */
 char * pagecopy;
+/** @brief The number of pages protected by an MPI Window */
+std::size_t win_granularity;
 /** @brief Pointer to locks protecting the page cache */
 std::vector<cache_lock> cache_locks;
 /** @brief Mutex ensuring that only one thread can perform sync */
@@ -790,9 +792,10 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	/** At least two pages are required to prevent endless eviction loops */
 	cachesize = std::max(cachesize, static_cast<std::size_t>(pagesize*CACHELINE*2));
 	cachesize /= pagesize;
-
-	/* Create the cache locks */
 	cache_locks.resize(cachesize);
+
+	win_granularity = env::mpi_win_granularity;
+
 
 	classificationSize = 2*(argo_size/pagesize);
 	argo_write_buffer = new write_buffer<std::size_t>();

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -600,8 +600,8 @@ void handler(int sig, siginfo_t *si, void *context){
 		else{
 			/* Do not register as writer if this is a confirmed read miss */
 			if(miss_type == sig::access_type::read) {
-				sem_post(&ibsem);
-				pthread_mutex_unlock(&cachemutex);
+				cache_locks[startIndex].unlock();
+				pthread_rwlock_unlock(&sync_lock);
 				return;
 			}
 
@@ -666,8 +666,7 @@ void handler(int sig, siginfo_t *si, void *context){
 		(miss_type == sig::access_type::undefined && performed_load)) {
 		assert(cacheControl[startIndex].state == VALID);
 		assert(cacheControl[startIndex].tag == aligned_access_offset);
-		//pthread_mutex_unlock(&cachemutex);
-		//sync_mutex.unlock_shared();
+		cache_locks[startIndex].unlock();
 		pthread_rwlock_unlock(&sync_lock);
 		double t2 = MPI_Wtime();
 		std::lock_guard<std::mutex> load_lock(stats.load_time_mutex);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -779,9 +779,9 @@ void handler(int sig, siginfo_t *si, void *context){
 	return;
 }
 
-void initmpi() {
+void initmpi(){
 	int ret, initialized, thread_status;
-	int thread_level = (ARGO_ENABLE_MT == 1) ? MPI_THREAD_MULTIPLE : MPI_THREAD_SERIALIZED;
+	int thread_level = MPI_THREAD_MULTIPLE;
 	MPI_Initialized(&initialized);
 	if (!initialized) {
 		ret = MPI_Init_thread(NULL, NULL, thread_level, &thread_status);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1018,13 +1018,13 @@ void argo_finalize(){
 	MPI_Barrier(MPI_COMM_WORLD);
 
 	// Free data windows
-	for(auto win_index : data_windows){
+	for(auto &win_index : data_windows){
 		for( auto window : win_index){
 			MPI_Win_free(&window);
 		}
 	}
 	// Free sharer windows
-	for(auto win_index : sharer_windows){
+	for(auto &win_index : sharer_windows){
 		for( auto window : win_index){
 			MPI_Win_free(&window);
 		}
@@ -1300,7 +1300,7 @@ void print_statistics(){
 	 * Store statistics for the cache lock
 	 */
 	double cache_lock_time = 0;
-	for( auto cache_lock : cache_locks ) {
+	for( auto &cache_lock : cache_locks ) {
 		cache_lock_time += cache_lock.get_lock_time();
 	}
 
@@ -1386,9 +1386,9 @@ void print_statistics(){
 		}
 
 		printf("\n#################################" YEL" ArgoDSM statistics " RESET "##################################\n");
-		printf("#  memory size: %12.2f%s  page size (p): %10dB   cache size:%14ldp\n",
+		printf("#  memory size: %12.2f%s  page size (p): %10dB   cache size: %13ldp\n",
 				mem_size_readable, sizes[order], pagesize, cachesize);
-		printf("#  write buffer size: %6ldp   write back size: %8ldp   CACHELINE:%15ldp\n",
+		printf("#  write buffer size: %6ldp   write back size: %8ldp   CACHELINE: %14ldp\n",
 				env::write_buffer_size()/CACHELINE,
 				env::write_buffer_write_back_size()/CACHELINE,
 				CACHELINE);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -501,7 +501,10 @@ void load_cache_entry(std::uintptr_t aligned_access_offset) {
 			touchedcache[idx] = 1;
 			cacheControl[idx].state = VALID;
 			cacheControl[idx].dirty = CLEAN;
-			cache_locks[idx].unlock();
+			/* Unlock every lock but that for start_index */
+			if(idx != start_index) {
+				cache_locks[idx].unlock();
+			}
 		}
 	}
 }

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1219,8 +1219,6 @@ void argo_reset_stats(){
 	stats.load_time = 0;
 	stats.store_time = 0;
 	stats.sync_lock_time = 0;
-	stats.inittime = 0;
-	stats.exectime = 0;
 	stats.barriertime = 0;
 	stats.write_misses.store(0);
 	stats.read_misses.store(0);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -856,7 +856,9 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 		vm::map_memory(tmpcache, offsets_tbl_size_bytes, current_offset, PROT_READ|PROT_WRITE);
 	}
 
-	mpi_windows = env::mpi_windows();
+	// Get the number of MPI windows requested and adjust for number of nodes
+	// On a single node, the number of windows defaults to 1 for performance reasons
+	mpi_windows = numtasks > 1 ? env::mpi_windows_per_node()*numtasks : 1;
 
 	// Create one data_window per page chunk
 	data_windows.resize(mpi_windows, std::vector<MPI_Win>(numtasks));

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -997,14 +997,14 @@ void argo_finalize(){
 	MPI_Barrier(MPI_COMM_WORLD);
 
 	// Free data windows
-	for(auto &win_index : data_windows){
-		for( auto window : win_index){
+	for(auto& win_index : data_windows){
+		for(auto& window : win_index){
 			MPI_Win_free(&window);
 		}
 	}
 	// Free sharer windows
-	for(auto &win_index : sharer_windows){
-		for( auto window : win_index){
+	for(auto& win_index : sharer_windows){
+		for(auto& window : win_index){
 			MPI_Win_free(&window);
 		}
 	}
@@ -1241,7 +1241,7 @@ void argo_reset_stats(){
 	stats.ssd_time = 0;
 
 	// Clear the cache lock statistics
-	for( auto &cache_lock : cache_locks ){
+	for( auto& cache_lock : cache_locks ){
 		cache_lock.reset_stats();
 	}
 
@@ -1334,7 +1334,7 @@ void print_statistics(){
 	 */
 	double cache_lock_time = 0;
 	std::size_t num_cache_locks = 0;
-	for( auto &cache_lock : cache_locks ) {
+	for( const auto& cache_lock : cache_locks ) {
 		cache_lock_time += cache_lock.get_lock_time();
 		num_cache_locks += cache_lock.get_num_locks();
 	}

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -406,13 +406,13 @@ std::size_t get_classification_index(std::uintptr_t addr);
 bool _is_cached(std::uintptr_t addr);
 
 /**
- * @brief TODO
+ * @brief TODO document this
  */
 void sharer_op(int lock_type, int rank, int offset,
 		std::function<void(const std::size_t window_index)> op);
 
 /**
- * @brief TODO
+ * @brief TODO document all these
  */
 std::size_t get_sharer_win_index(int classification_index);
 std::size_t get_sharer_win_offset(int classification_index);

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <mutex>
 #include <functional>
+#include <cmath>
 //#include <shared_mutex>
 
 #include "argo.h"
@@ -408,6 +409,8 @@ void sharer_op(int lock_type, int rank, int offset,
 /**
  * @brief TODO
  */
-std::size_t get_window_index(int offset);
-std::size_t get_window_offset(int classification_index);
+std::size_t get_sharer_win_index(int classification_index);
+std::size_t get_sharer_win_offset(int classification_index);
+std::size_t get_data_win_index(int offset);
+std::size_t get_data_win_offset(int offset);
 #endif /* argo_swdsm_h */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -10,13 +10,13 @@
 #define argo_swdsm_h argo_swdsm_h
 
 /* Includes */
-#include <cstdint>
-#include <type_traits>
-#include <mutex>
-#include <functional>
-#include <cmath>
-#include <vector>
 #include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <type_traits>
+#include <vector>
 
 #include <assert.h>
 #include <errno.h>

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -85,10 +85,6 @@ typedef struct argo_statisticsStruct
 		double loadtime;
 		/** @brief Time spent storing pages */
 		double storetime;
-		/** @brief Time spent writing back from the writebuffer */
-		double writebacktime;
-		/** @brief Time spent flushing the writebuffer */
-		double flushtime;
 		/** @brief Time spent in global barrier */
 		double barriertime;
 		/** @brief Number of stores */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -87,6 +87,10 @@ typedef struct argo_statisticsStruct
 		double storetime;
 		/** @brief Time spent in global barrier */
 		double barriertime;
+		/** @brief Time spent initializing ArgoDSM */
+		double inittime;
+		/** @brief Time between init and finalize */
+		double exectime;
 		/** @brief Number of stores */
 		std::size_t stores;
 		/** @brief Number of loads */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -12,6 +12,11 @@
 /* Includes */
 #include <cstdint>
 #include <type_traits>
+#include <mutex>
+#include <functional>
+#include <cmath>
+#include <vector>
+#include <atomic>
 
 #include <assert.h>
 #include <errno.h>
@@ -31,11 +36,6 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
-#include <mutex>
-#include <functional>
-#include <cmath>
-#include <vector>
-#include <atomic>
 
 #include "argo.h"
 #include "backend/backend.hpp"
@@ -134,7 +134,9 @@ class alignas(64) cache_lock {
 		std::size_t num_locks;
 
 	public:
-		/** @brief Constructor */
+		/**
+		 * @brief Constructor
+		 */
 		cache_lock()
 			: wait_time(0),
 			hold_time(0),
@@ -142,6 +144,10 @@ class alignas(64) cache_lock {
 			num_locks(0)
 		{ };
 
+		/**
+		 * @brief Copy constructor
+		 * @param _other cache_lock to copy from
+		 */
 		cache_lock( const cache_lock& _other )
 			: wait_time(_other.wait_time),
 			hold_time(_other.hold_time),
@@ -149,6 +155,10 @@ class alignas(64) cache_lock {
 			num_locks(_other.num_locks)
 		{ };
 
+		/**
+		 * @brief Move constructor
+		 * @param _other cache_lock to move
+		 */
 		cache_lock( const cache_lock&& _other )
 			: wait_time(std::move(_other.wait_time)),
 			hold_time(std::move(_other.hold_time)),
@@ -156,7 +166,7 @@ class alignas(64) cache_lock {
 			num_locks(std::move(_other.num_locks))
 		{ };
 
-		/** Destructor */
+		/** @brief Destructor */
 		~cache_lock() { };
 
 		/** @brief Acquire a cache lock */
@@ -169,6 +179,10 @@ class alignas(64) cache_lock {
 			num_locks++;
 		}
 
+		/**
+		 * @brief Attempt to acquire a cache lock
+		 * @return True if successful, else false
+		 */
 		bool try_lock(){
 			return c_mutex.try_lock();
 		}
@@ -456,16 +470,48 @@ std::size_t get_classification_index(std::uintptr_t addr);
 bool _is_cached(std::uintptr_t addr);
 
 /**
- * @brief TODO document this
+ * @brief Locks the correct mpi_lock_sharer, performs operation
+ * op and then unlocks the locked mpi_lock_sharer
+ * @param lock_type MPI lock type
+ * @param rank remote node to perform op on
+ * @param offset the offset in to the remote node's globalSharer
+ * data structure
+ * @param op A function to execute
  */
 void sharer_op(int lock_type, int rank, int offset,
 		std::function<void(const std::size_t window_index)> op);
 
 /**
- * @brief TODO document all these
+ * @brief Gets the sharer window index based on the classification
+ * index
+ * @param classification_index the page classification index
+ * @return the sharer window index
  */
 std::size_t get_sharer_win_index(int classification_index);
+
+/**
+ * @brief Gets the sharer window offset based on the classification
+ * index
+ * @param classification_index the page classification index
+ * @return the offset in to the sharer window
+ */
 std::size_t get_sharer_win_offset(int classification_index);
+
+/**
+ * @brief Gets the data window index based on the offset into the
+ * node's backing store
+ * @param offset the page offset in to the remote node's backing
+ * store
+ * @return the data window index
+ */
 std::size_t get_data_win_index(std::size_t offset);
+
+/**
+ * @brief Gets the sharer window offset based on the classification
+ * index
+ * @param offset the page offset in to the remote node's backing
+ * store
+ * @return the offset in to the sharer window
+ */
 std::size_t get_data_win_offset(std::size_t offset);
 #endif /* argo_swdsm_h */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -152,6 +152,15 @@ class alignas(64) cache_lock {
 		void unlock(){
 			c_mutex.unlock();
 		}
+
+		/**
+		 * @brief	Get the time spent waiting for the lock
+		 * @return	The time in seconds
+		 */
+		double get_lock_time(){
+			return wait_time;
+		}
+
 };
 
 /*constants for control values*/
@@ -255,7 +264,7 @@ void clearStatistics();
 /**
  * @brief Prints collected statistics
  */
-void printStatistics();
+void print_statistics();
 
 /**
  * @brief Resets current ArgoDSM coherence

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -205,7 +205,7 @@ class alignas(64) cache_lock {
 		 * @brief	Get the time spent waiting for the lock
 		 * @return	The time in seconds
 		 */
-		double get_lock_time(){
+		double get_lock_time() const {
 			return wait_time;
 		}
 
@@ -213,7 +213,7 @@ class alignas(64) cache_lock {
 		 * @brief	Get the time spent holding the lock
 		 * @return	The time in seconds
 		 */
-		double get_hold_time(){
+		double get_hold_time() const {
 			return hold_time;
 		}
 
@@ -221,7 +221,7 @@ class alignas(64) cache_lock {
 		 * @brief	Get the number of times this lock was held
 		 * @return	The number of times this lock was held
 		 */
-		std::size_t get_num_locks(){
+		std::size_t get_num_locks() const {
 			return num_locks;
 		}
 

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -76,18 +76,22 @@ typedef struct myControlData //global cache control data / directory
 } control_data;
 
 /** @brief Struct containing statistics */
-typedef struct argo_statisticsStruct
+typedef struct argo_statistics_struct
 {
-		/** @brief Time spend locking */
-		double locktime;
 		/** @brief Time spent self invalidating */
 		double selfinvtime;
 		/** @brief Time spent loading pages */
-		std::atomic<double> load_time;
+		double load_time;
+		/** @brief Mutex to update load_time */
+		std::mutex load_time_mutex;
 		/** @brief Time spent storing pages */
-		std::atomic<double> store_time;
+		double store_time;
+		/** @brief Mutex to update store_time */
+		std::mutex store_time_mutex;
 		/** @brief Time spent locking the sync lock */
-		std::atomic<double> sync_lock_time;
+		double sync_lock_time;
+		/** @brief Mutex to update sync_lock_time */
+		std::mutex sync_lock_time_mutex;
 		/** @brief Time spent in global barrier */
 		double barriertime;
 		/** @brief Time spent initializing ArgoDSM */
@@ -103,9 +107,13 @@ typedef struct argo_statisticsStruct
 		/** @brief Number of locks */
 		int locks;
 		/** @brief Time spent performing selective acquire */
-		std::atomic<double> ssi_time;
+		double ssi_time;
+		/** @brief Mutex to update ssi_time */
+		std::mutex ssi_time_mutex;
 		/** @brief Time spent performing selective release */
-		std::atomic<double> ssd_time;
+		double ssd_time;
+		/** @brief Mutex to update ssd_time */
+		std::mutex ssd_time_mutex;
 } argo_statistics;
 
 /**

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -34,7 +34,7 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
-#include <shared_mutex
+#include <shared_mutex>
 #include <type_traits>
 #include <vector>
 

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -32,6 +32,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <mutex>
+#include <functional>
 //#include <shared_mutex>
 
 #include "argo.h"
@@ -397,5 +398,16 @@ std::size_t get_classification_index(std::uintptr_t addr);
  * @todo This should be moved in to a dedicated cache class
  */
 bool _is_cached(std::uintptr_t addr);
-#endif /* argo_swdsm_h */
 
+/**
+ * @brief TODO
+ */
+void sharer_op(int lock_type, int rank, int offset,
+		std::function<void(const std::size_t window_index)> op);
+
+/**
+ * @brief TODO
+ */
+std::size_t get_window_index(int offset);
+std::size_t get_window_offset(int classification_index);
+#endif /* argo_swdsm_h */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -416,6 +416,6 @@ void sharer_op(int lock_type, int rank, int offset,
  */
 std::size_t get_sharer_win_index(int classification_index);
 std::size_t get_sharer_win_offset(int classification_index);
-std::size_t get_data_win_index(int offset);
-std::size_t get_data_win_offset(int offset);
+std::size_t get_data_win_index(std::size_t offset);
+std::size_t get_data_win_offset(std::size_t offset);
 #endif /* argo_swdsm_h */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -554,7 +554,7 @@ std::size_t get_classification_index(std::uintptr_t addr);
  * @param addr Address in the global address space
  * @return true if cached or locally backed, else false
  * @warning This is strictly meant for testing prefetching
- * @todo This should be moved in to a dedicated cache class
+ * @todo This should be moved into a dedicated cache class
  */
 bool _is_cached(std::uintptr_t addr);
 
@@ -563,7 +563,7 @@ bool _is_cached(std::uintptr_t addr);
  * op and then unlocks the locked mpi_lock_sharer
  * @param lock_type MPI lock type
  * @param rank remote node to perform op on
- * @param offset the offset in to the remote node's globalSharer
+ * @param offset the offset into the remote node's globalSharer
  * data structure
  * @param op A function to execute
  */
@@ -582,14 +582,14 @@ std::size_t get_sharer_win_index(int classification_index);
  * @brief Gets the sharer window offset based on the classification
  * index
  * @param classification_index the page classification index
- * @return the offset in to the sharer window
+ * @return the offset into the sharer window
  */
 std::size_t get_sharer_win_offset(int classification_index);
 
 /**
  * @brief Gets the data window index based on the offset into the
  * node's backing store
- * @param offset the page offset in to the remote node's backing
+ * @param offset the page offset into the remote node's backing
  * store
  * @return the data window index
  */
@@ -598,9 +598,9 @@ std::size_t get_data_win_index(std::size_t offset);
 /**
  * @brief Gets the sharer window offset based on the classification
  * index
- * @param offset the page offset in to the remote node's backing
+ * @param offset the page offset into the remote node's backing
  * store
- * @return the offset in to the sharer window
+ * @return the offset into the sharer window
  */
 std::size_t get_data_win_offset(std::size_t offset);
 #endif /* argo_swdsm_h */

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -493,11 +493,11 @@ size_t argo_get_global_size();
  */
 void initmpi();
 /**
- * @brief Initializes a mpi data structure for writing cacheb control data over the network * @brief 
+ * @brief Initializes an MPI data structure for writing cache control data over the network
  */
 void init_mpi_struct(void);
 /**
- * @brief Initializes a mpi data structure for writing cacheblocks over the network
+ * @brief Initializes an MPI data structure for writing cache blocks over the network
  */
 void init_mpi_cacheblock(void);
 /**
@@ -571,16 +571,14 @@ void sharer_op(int lock_type, int rank, int offset,
 		std::function<void(const std::size_t window_index)> op);
 
 /**
- * @brief Gets the sharer window index based on the classification
- * index
+ * @brief Gets the sharer window index based on the classification index
  * @param classification_index the page classification index
  * @return the sharer window index
  */
 std::size_t get_sharer_win_index(int classification_index);
 
 /**
- * @brief Gets the sharer window offset based on the classification
- * index
+ * @brief Gets the sharer window offset based on the classification index
  * @param classification_index the page classification index
  * @return the offset into the sharer window
  */
@@ -589,17 +587,14 @@ std::size_t get_sharer_win_offset(int classification_index);
 /**
  * @brief Gets the data window index based on the offset into the
  * node's backing store
- * @param offset the page offset into the remote node's backing
- * store
+ * @param offset the page offset into the remote node's backing store
  * @return the data window index
  */
 std::size_t get_data_win_index(std::size_t offset);
 
 /**
- * @brief Gets the sharer window offset based on the classification
- * index
- * @param offset the page offset into the remote node's backing
- * store
+ * @brief Gets the sharer window offset based on the classification index
+ * @param offset the page offset into the remote node's backing store
  * @return the offset into the sharer window
  */
 std::size_t get_data_win_offset(std::size_t offset);

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -34,7 +34,7 @@
 #include <mutex>
 #include <functional>
 #include <cmath>
-//#include <shared_mutex>
+#include <vector>
 
 #include "argo.h"
 #include "backend/backend.hpp"

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -38,7 +38,6 @@
 #include <type_traits>
 #include <vector>
 
-#include "argo.h"
 #include "backend/backend.hpp"
 #include "mpi_lock.hpp"
 
@@ -145,7 +144,7 @@ class alignas(64) cache_lock {
 		/**
 		 * @brief Constructor
 		 */
-		cache_lock() { };
+		cache_lock() {}
 
 		/**
 		 * @brief Copy constructor
@@ -172,7 +171,7 @@ class alignas(64) cache_lock {
 		}
 
 		/** @brief Destructor */
-		~cache_lock() { };
+		~cache_lock() {}
 
 		/** @brief Acquire a cache lock */
 		void lock(){

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -268,7 +268,6 @@ class write_buffer
 		/**
 		 * @brief	Copy constructor
 		 * @param	other The write_buffer object to copy from
-		 * @note	with c++14 we could use std::shared_lock for lock_other
 		 */
 		write_buffer(const write_buffer & other) {
 			// Ensure protection of data
@@ -290,7 +289,6 @@ class write_buffer
 		 * @brief	Copy assignment operator
 		 * @param	other the write_buffer object to copy assign from
 		 * @return	reference to the created copy
-		 * @note	with c++14 we could use std::shared_lock for lock_other
 		 */
 		write_buffer& operator=(const write_buffer & other) {
 			if(&other != this) {

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -81,7 +81,7 @@ class write_buffer
 		 * @brief	Check if the write buffer is empty
 		 * @return	True if empty, else False
 		 */
-		bool empty() {
+		bool empty() const {
 			return _buffer.empty();
 		}
 
@@ -89,7 +89,7 @@ class write_buffer
 		 * @brief	Get the size of the buffer
 		 * @return	The size of the buffer
 		 */
-		size_t size() {
+		size_t size() const {
 			return _buffer.size();
 		}
 
@@ -98,7 +98,7 @@ class write_buffer
 		 * @param	i The requested buffer index
 		 * @return	The element at index i of type T
 		 */
-		T at(std::size_t i){
+		T at(std::size_t i) const {
 			return _buffer.at(i);
 		}
 
@@ -140,7 +140,7 @@ class write_buffer
 		void write_back_index(std::size_t cache_index) {
 			cache_locks[cache_index].lock();
 			assert(cacheControl[cache_index].dirty == DIRTY);
-			std::uintptr_t page_address = cacheControl[cache_index].tag;
+			const std::uintptr_t page_address = cacheControl[cache_index].tag;
 			void* page_ptr = static_cast<char*>(
 				argo::virtual_memory::start_address()) + page_address;
 

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -24,12 +24,6 @@
 const std::size_t block_size = page_size*CACHELINE;
 
 /**
- * @brief		Argo cache lock structure
- * @deprecated 	prototype implementation, should be replaced with API calls
- */
-extern std::vector<cache_lock> cache_locks;
-
-/**
  * @brief	A write buffer in FIFO style with the capability to erase any
  * element from the buffer while preserving ordering.
  * @tparam	T the type of the write buffer

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -368,7 +368,6 @@ class write_buffer
 
 		/**
 		 * @brief	Flushes the ArgoDSM write buffer to memory
-		 * @pre		Require ibsem to be taken until parallel MPI
 		 */
 		void flush() {
 			// Use an atomic flag to detect when flush is done
@@ -393,7 +392,6 @@ class write_buffer
 		/**
 		 * @brief	Adds a new element to the write buffer
 		 * @param	val The value of type T to add to the buffer
-		 * @pre		Require ibsem to be taken until parallel MPI
 		 */
 		void add(T val) {
 			double t_start = MPI_Wtime();

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -16,7 +16,6 @@
 #include <iterator>
 #include <mutex>
 #include <utility>
-#include <vector>
 
 #include "swdsm.h"
 

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -30,7 +30,10 @@ extern control_data* cacheControl;
 /** @brief Block size based on backend definition */
 const std::size_t block_size = page_size*CACHELINE;
 
-//TODO: Document
+/**
+ * @brief		Argo cache lock structure
+ * @deprecated 	prototype implementation, should be replaced with API calls
+ */
 extern std::vector<cache_lock> cache_locks;
 
 /**

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -22,12 +22,6 @@
 #include "qd.hpp"
 
 /**
- * @brief		Argo statistics struct
- * @deprecated 	This should be replaced with an API call
- */
-extern argo_statistics stats;
-
-/**
  * @brief		Argo cache data structure
  * @deprecated 	prototype implementation, should be replaced with API calls
  */
@@ -271,6 +265,7 @@ class write_buffer
 		/**
 		 * @brief	Copy constructor
 		 * @param	other The write_buffer object to copy from
+		 * @note	with c++14 we could use std::shared_lock for lock_other
 		 */
 		write_buffer(const write_buffer & other) {
 			// Ensure protection of data
@@ -292,6 +287,7 @@ class write_buffer
 		 * @brief	Copy assignment operator
 		 * @param	other the write_buffer object to copy assign from
 		 * @return	reference to the created copy
+		 * @note	with c++14 we could use std::shared_lock for lock_other
 		 */
 		write_buffer& operator=(const write_buffer & other) {
 			if(&other != this) {

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -126,6 +126,8 @@ namespace argo {
 			return true;
 		}
 
+		void argo_reset_stats() {}
+
 		void finalize() {
 		}
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -126,7 +126,7 @@ namespace argo {
 			return true;
 		}
 
-		void argo_reset_stats() {}
+		void reset_stats() {}
 
 		void finalize() {
 		}

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -65,7 +65,7 @@ namespace {
 
 	/**
 	 * @brief default requested statistics level (if environment variable is unset)
-	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 * @see @ref ARGO_PRINT_STATISTICS
 	 */
 	const std::size_t default_print_statistics = 2; // default 2 is basic node statistics
 
@@ -119,7 +119,7 @@ namespace {
 
 	/**
 	 * @brief environment variable used for requesting statistics level
-	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 * @see @ref ARGO_PRINT_STATISTICS
 	 */
 	const std::string env_print_statistics = "ARGO_PRINT_STATISTICS";
 

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -59,9 +59,9 @@ namespace {
 
 	/**
 	 * @brief default number of MPI windows (if environment variable is unset)
-	 * @see @ref ARGO_MPI_WINDOWS
+	 * @see @ref ARGO_MPI_WINDOWS_PER_NODE
 	 */
-	const std::size_t default_mpi_windows = 4;
+	const std::size_t default_mpi_windows_per_node = 4;
 
 	/**
 	 * @brief default requested statistics level (if environment variable is unset)
@@ -113,9 +113,9 @@ namespace {
 
 	/**
 	 * @brief environment variable used for requesting the number of MPI windows
-	 * @see @ref ARGO_MPI_WINDOWS
+	 * @see @ref ARGO_MPI_WINDOWS_PER_NODE
 	 */
-	const std::string env_mpi_windows = "ARGO_MPI_WINDOWS";
+	const std::string env_mpi_windows_per_node = "ARGO_MPI_WINDOWS_PER_NODE";
 
 	/**
 	 * @brief environment variable used for requesting statistics level
@@ -167,9 +167,9 @@ namespace {
 	std::size_t value_load_size;
 
 	/**
-	 * @brief number of MPI windows requested through the environment variable @ref ARGO_MPI_WINDOWS
+	 * @brief number of MPI windows requested through the environment variable @ref ARGO_MPI_WINDOWS_PER_NODE
 	 */
-	std::size_t value_mpi_windows;
+	std::size_t value_mpi_windows_per_node;
 
 	/**
 	 * @brief statistics output level requested through the environment variable @ref ARGO_PRINT_STATISTICS
@@ -240,7 +240,7 @@ namespace argo {
 			value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
 			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
-			value_mpi_windows = parse_env<std::size_t>(env_mpi_windows, default_mpi_windows).second;
+			value_mpi_windows_per_node = parse_env<std::size_t>(env_mpi_windows_per_node, default_mpi_windows_per_node).second;
 			value_print_statistics = parse_env<std::size_t>(env_print_statistics, default_print_statistics).second;
 
 			is_initialized = true;
@@ -281,9 +281,9 @@ namespace argo {
 			return value_load_size;
 		}
 
-		std::size_t mpi_windows() {
+		std::size_t mpi_windows_per_node() {
 			assert_initialized();
-			return value_mpi_windows;
+			return value_mpi_windows_per_node;
 		}
 
 		std::size_t print_statistics() {

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -58,10 +58,10 @@ namespace {
 	const std::size_t default_load_size = 8;
 
 	/**
-	 * @brief default requested cache lock granularity (if environment variable is unset)
-	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 * @brief default number of MPI windows (if environment variable is unset)
+	 * @see @ref ARGO_MPI_WINDOWS
 	 */
-	const std::size_t default_mpi_win_granularity = 64;
+	const std::size_t default_mpi_windows = 4;
 
 	/**
 	 * @brief default requested statistics level (if environment variable is unset)
@@ -112,10 +112,10 @@ namespace {
 	const std::string env_load_size = "ARGO_LOAD_SIZE";
 
 	/**
-	 * @brief environment variable used for requesting cache lock granularity
-	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 * @brief environment variable used for requesting the number of MPI windows
+	 * @see @ref ARGO_MPI_WINDOWS
 	 */
-	const std::string env_mpi_win_granularity = "ARGO_MPI_WIN_GRANULARITY";
+	const std::string env_mpi_windows = "ARGO_MPI_WINDOWS";
 
 	/**
 	 * @brief environment variable used for requesting statistics level
@@ -167,9 +167,9 @@ namespace {
 	std::size_t value_load_size;
 
 	/**
-	 * @brief cache lock granularity requested through the environment variable @ref ARGO_MPI_WIN_GRANULARITY
+	 * @brief number of MPI windows requested through the environment variable @ref ARGO_MPI_WINDOWS
 	 */
-	std::size_t value_mpi_win_granularity;
+	std::size_t value_mpi_windows;
 
 	/**
 	 * @brief statistics output level requested through the environment variable @ref ARGO_PRINT_STATISTICS
@@ -240,8 +240,8 @@ namespace argo {
 			value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
 			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
-			value_mpi_win_granularity = parse_env<std::size_t>(env_mpi_win_granularity,
-					default_mpi_win_granularity).second;
+			value_mpi_windows = parse_env<std::size_t>(env_mpi_windows,
+					default_mpi_windows).second;
 			value_print_statistics = parse_env<std::size_t>(env_print_statistics, default_print_statistics).second;
 
 			is_initialized = true;
@@ -282,9 +282,9 @@ namespace argo {
 			return value_load_size;
 		}
 
-		std::size_t mpi_win_granularity() {
+		std::size_t mpi_windows() {
 			assert_initialized();
-			return value_mpi_win_granularity;
+			return value_mpi_windows;
 		}
 
 		std::size_t print_statistics() {

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -58,6 +58,12 @@ namespace {
 	const std::size_t default_load_size = 8;
 
 	/**
+	 * @brief default requested cache lock granularity (if environment variable is unset)
+	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 */
+	const std::size_t default_mpi_win_granularity = 16;
+
+	/**
 	 * @brief environment variable used for requesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
@@ -98,6 +104,12 @@ namespace {
 	 * @see @ref ARGO_LOAD_SIZE
 	 */
 	const std::string env_load_size = "ARGO_LOAD_SIZE";
+
+	/**
+	 * @brief environment variable used for requesting cache lock granularity
+	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 */
+	const std::string env_mpi_win_granularity = "ARGO_MPI_WIN_GRANULARITY";
 
 	/** @brief error message string */
 	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
@@ -141,6 +153,10 @@ namespace {
 	 * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
 	 */
 	std::size_t value_load_size;
+
+	/**
+	 * @brief cache lock granularity requested through the environment variable @ref ARGO_MPI_WIN_GRANULARITY */
+	std::size_t value_mpi_win_granularity;
 
 	/** @brief flag to allow checking that environment variables have been read before accessing their values */
 	bool is_initialized = false;
@@ -206,6 +222,8 @@ namespace argo {
 			value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
 			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
+			value_mpi_win_granularity = parse_env<std::size_t>(env_mpi_win_granularity,
+					default_mpi_win_granularity).second;
 
 			is_initialized = true;
 		}
@@ -243,6 +261,11 @@ namespace argo {
 		std::size_t load_size() {
 			assert_initialized();
 			return value_load_size;
+		}
+
+		std::size_t mpi_win_granularity() {
+			assert_initialized();
+			return value_mpi_win_granularity;
 		}
 	} // namespace env
 } // namespace argo

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -240,8 +240,7 @@ namespace argo {
 			value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
 			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
-			value_mpi_windows = parse_env<std::size_t>(env_mpi_windows,
-					default_mpi_windows).second;
+			value_mpi_windows = parse_env<std::size_t>(env_mpi_windows, default_mpi_windows).second;
 			value_print_statistics = parse_env<std::size_t>(env_print_statistics, default_print_statistics).second;
 
 			is_initialized = true;

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -61,7 +61,7 @@ namespace {
 	 * @brief default requested cache lock granularity (if environment variable is unset)
 	 * @see @ref ARGO_MPI_WIN_GRANULARITY
 	 */
-	const std::size_t default_mpi_win_granularity = 16;
+	const std::size_t default_mpi_win_granularity = 64;
 
 	/**
 	 * @brief environment variable used for requesting memory size

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -64,6 +64,12 @@ namespace {
 	const std::size_t default_mpi_win_granularity = 64;
 
 	/**
+	 * @brief default requested statistics level (if environment variable is unset)
+	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 */
+	const std::size_t default_print_statistics = 2; // default 2 is basic node statistics
+
+	/**
 	 * @brief environment variable used for requesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
@@ -111,6 +117,12 @@ namespace {
 	 */
 	const std::string env_mpi_win_granularity = "ARGO_MPI_WIN_GRANULARITY";
 
+	/**
+	 * @brief environment variable used for requesting statistics level
+	 * @see @ref ARGO_MPI_WIN_GRANULARITY
+	 */
+	const std::string env_print_statistics = "ARGO_PRINT_STATISTICS";
+
 	/** @brief error message string */
 	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
 	/** @brief error message string */
@@ -155,8 +167,14 @@ namespace {
 	std::size_t value_load_size;
 
 	/**
-	 * @brief cache lock granularity requested through the environment variable @ref ARGO_MPI_WIN_GRANULARITY */
+	 * @brief cache lock granularity requested through the environment variable @ref ARGO_MPI_WIN_GRANULARITY
+	 */
 	std::size_t value_mpi_win_granularity;
+
+	/**
+	 * @brief statistics output level requested through the environment variable @ref ARGO_PRINT_STATISTICS
+	 */
+	std::size_t value_print_statistics;
 
 	/** @brief flag to allow checking that environment variables have been read before accessing their values */
 	bool is_initialized = false;
@@ -224,6 +242,7 @@ namespace argo {
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
 			value_mpi_win_granularity = parse_env<std::size_t>(env_mpi_win_granularity,
 					default_mpi_win_granularity).second;
+			value_print_statistics = parse_env<std::size_t>(env_print_statistics, default_print_statistics).second;
 
 			is_initialized = true;
 		}
@@ -266,6 +285,11 @@ namespace argo {
 		std::size_t mpi_win_granularity() {
 			assert_initialized();
 			return value_mpi_win_granularity;
+		}
+
+		std::size_t print_statistics() {
+			assert_initialized();
+			return value_print_statistics;
 		}
 	} // namespace env
 } // namespace argo

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -46,10 +46,11 @@
  * 			are fetched on each remote load operation. It can be accessed through
  *          @ref argo::env::load_size() after argo::env::init() has been called.
  *
- * @envvar{ARGO_MPI_WIN_GRANULARITY} request a specific number of pages per MPI Window
- * @details This environment variable determines the amount of DSM pages that are
- * 			are protected by a single MPI Window. It can be accessed through
- *          @ref argo::env::mpi_win_granularity() after argo::env::init() has been called.
+ * @envvar{ARGO_MPI_WINDOWS} request a specific number of MPI Windows
+ * @details This environment variable determines the amount of MPI windows that are
+ * 			used to protect the global data and pyxis data structures. It can be
+ * 			accessed through @ref argo::env::mpi_windows() after argo::env::init()
+ * 			has been called.
  *
  * @envvar{ARGO_PRINT_STATISTICS} control the detail of statistics printed at end
  * @details This environment variable determines the amount of statistics printed at once
@@ -124,11 +125,11 @@ namespace argo {
 		std::size_t load_size();
 
 		/**
-		 * @brief get the number of pages protected by an MPI Window
+		 * @brief get the number of MPI windows per global data structure requested
 		 * @return the number of pages
-		 * @see @ref ARGO_MPI_WIN_GRANULARITY
+		 * @see @ref ARGO_MPI_WINDOWS
 		 */
-		std::size_t mpi_win_granularity();
+		std::size_t mpi_windows();
 
 		/**
 		 * @brief Get the level of statistics print

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -132,8 +132,8 @@ namespace argo {
 		std::size_t mpi_windows();
 
 		/**
-		 * @brief Get the level of statistics print
-		 * @return The initialized level
+		 * @brief Get the requested statistics print level
+		 * @return The requested statistics print level
 		 * @see @ref ARGO_PRINT_STATISTICS
 		 */
 		std::size_t print_statistics();

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -46,11 +46,12 @@
  * 			are fetched on each remote load operation. It can be accessed through
  *          @ref argo::env::load_size() after argo::env::init() has been called.
  *
- * @envvar{ARGO_MPI_WINDOWS} request a specific number of MPI Windows
+ * @envvar{ARGO_MPI_WINDOWS_PER_NODE} request a specific number of MPI Windows
  * @details This environment variable determines the amount of MPI windows that are
- * 			used to protect the global data and pyxis data structures. It can be
- * 			accessed through @ref argo::env::mpi_windows() after argo::env::init()
- * 			has been called.
+ * 			used to protect the global data and pyxis data structures. Each structure
+ * 			uses the requested number of MPI windows per node, multiplied by the
+ * 			number of nodes in the system. It can be accessed through
+ * 			@ref argo::env::mpi_windows_per_node() after argo::env::init() has been called.
  *
  * @envvar{ARGO_PRINT_STATISTICS} control the detail of statistics printed at end
  * @details This environment variable determines the amount of statistics printed at once
@@ -125,11 +126,11 @@ namespace argo {
 		std::size_t load_size();
 
 		/**
-		 * @brief get the number of MPI windows per global data structure requested
-		 * @return the number of pages
-		 * @see @ref ARGO_MPI_WINDOWS
+		 * @brief get the number of MPI windows per node requested
+		 * @return the number of MPI windows per node
+		 * @see @ref ARGO_MPI_WINDOWS_PER_NODE
 		 */
-		std::size_t mpi_windows();
+		std::size_t mpi_windows_per_node();
 
 		/**
 		 * @brief Get the requested statistics print level

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -132,6 +132,8 @@ namespace argo {
 
 		/**
 		 * @brief Get the level of statistics print
+		 * @return The initialized level
+		 * @see @ref ARGO_PRINT_STATISTICS
 		 */
 		std::size_t print_statistics();
 	} // namespace env

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -50,6 +50,13 @@
  * @details This environment variable determines the amount of DSM pages that are
  * 			are protected by a single MPI Window. It can be accessed through
  *          @ref argo::env::mpi_win_granularity() after argo::env::init() has been called.
+ *
+ * @envvar{ARGO_PRINT_STATISTICS} control the detail of statistics printed at end
+ * @details This environment variable determines the amount of statistics printed at once
+ * 			ArgoDSM finalizes. 0 prints no statistics, 1 prints general system information,
+ * 			2 in addition prints basic node information, and 3 in addition prints detailed
+ * 			node information. It can be accessed through @ref argo::env::print_statistics()
+ * 			after argo::env::init() has been called.
  */
 
 namespace argo {
@@ -122,6 +129,11 @@ namespace argo {
 		 * @see @ref ARGO_MPI_WIN_GRANULARITY
 		 */
 		std::size_t mpi_win_granularity();
+
+		/**
+		 * @brief Get the level of statistics print
+		 */
+		std::size_t print_statistics();
 	} // namespace env
 } // namespace argo
 

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -45,6 +45,11 @@
  * @details This environment variable determines the maximum amount of DSM pages that
  * 			are fetched on each remote load operation. It can be accessed through
  *          @ref argo::env::load_size() after argo::env::init() has been called.
+ *
+ * @envvar{ARGO_MPI_WIN_GRANULARITY} request a specific number of pages per MPI Window
+ * @details This environment variable determines the amount of DSM pages that are
+ * 			are protected by a single MPI Window. It can be accessed through
+ *          @ref argo::env::mpi_win_granularity() after argo::env::init() has been called.
  */
 
 namespace argo {
@@ -110,6 +115,13 @@ namespace argo {
 		 * @see @ref ARGO_LOAD_SIZE
 		 */
 		std::size_t load_size();
+
+		/**
+		 * @brief get the number of pages protected by an MPI Window
+		 * @return the number of pages
+		 * @see @ref ARGO_MPI_WIN_GRANULARITY
+		 */
+		std::size_t mpi_win_granularity();
 	} // namespace env
 } // namespace argo
 

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+#include <atomic>
 
 namespace argo {
 	namespace globallock {

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -12,7 +12,6 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
-#include <atomic>
 
 namespace argo {
 	namespace globallock {

--- a/src/types/types.hpp
+++ b/src/types/types.hpp
@@ -9,14 +9,16 @@
 
 namespace argo {
 	/** @brief ArgoDSM node identifier type */
-	using node_id_t = int;
+	using node_id_t = unsigned int;
+
+	/** @brief ArgoDSM number of nodes type */
+	using num_nodes_t = unsigned int;
 
 	/**
 	 * @brief type of memory base addresses
 	 * @see dynamic_memory_pool
 	 */
 	using memory_t = char*;
-
 } // namespace argo
 
 #endif /* argo_types_types_hpp */

--- a/tests/allocators.cpp
+++ b/tests/allocators.cpp
@@ -265,10 +265,10 @@ TEST_F(AllocatorTest, StoringDynamicArrayInCollective){
 	collective_arr[argo::node_id()] = dynamic_arr;
 	argo::barrier();
 
-	for(int i = 0; i < argo::number_of_nodes(); i++){
-		for(int j = 0; j < entries; j++){
+	for(argo::num_nodes_t i = 0; i < argo::number_of_nodes(); i++){
+		for(unsigned int j = 0; j < entries; j++){
 			if(argo::node_id() == 0) {
-				ASSERT_TRUE(collective_arr[i][j] == i+j*10);
+				ASSERT_TRUE(collective_arr[i][j] == static_cast<int>(i+j*10));
 			}
 		}
 	}
@@ -302,12 +302,12 @@ TEST_F(AllocatorTest, StoringDynamicArrayInCollective){
 
 	collective_arr[argo::node_id()] = dynamic_arr;
 	argo::barrier();
-	for(int i = 0; i < argo::number_of_nodes(); i++){
-		for(int j = 0; j < entries; j++){
+	for(argo::num_nodes_t i = 0; i < argo::number_of_nodes(); i++){
+		for(unsigned int j = 0; j < entries; j++){
 			//			std::cout << "collective_arr : " << j << "," << i << " => "<< collective_arr[i][j] << " i+j*11 " << i+(j*11)<< std::endl;
 			//std::cout << "collective_arr2 : " << j << " => "<< collective_arr2[j] << std::endl;
-			ASSERT_TRUE(collective_arr[i][j] == i+j*11);
-			ASSERT_TRUE(collective_arr2[j] == j);
+			ASSERT_TRUE(collective_arr[i][j] == static_cast<int>(i+j*11));
+			ASSERT_TRUE(collective_arr2[j] == static_cast<int>(j));
 		}
 	}
 	argo::barrier();

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -887,10 +887,10 @@ TEST_F(backendTest, writeBufferLoad) {
 	argo::barrier();
 
 	// One node at a time, increment random elements num_writes times
-	for(argo::node_id_t i = 0; i < argo::number_of_nodes(); i++){
+	for(argo::num_nodes_t i = 0; i < argo::number_of_nodes(); i++){
 		if(i == argo::node_id()){
-			for(std::size_t j=0; j<num_writes; j++){
-				array[dist(rng)]+=1;
+			for(std::size_t j = 0; j < num_writes; j++){
+				array[dist(rng)] += 1;
 			}
 		}
 		argo::barrier();
@@ -900,7 +900,7 @@ TEST_F(backendTest, writeBufferLoad) {
 	if(argo::node_id() == 0){
 		int count = 0;
 		int expected = num_writes*argo::number_of_nodes();
-		for(std::size_t i=0; i<num_ints; i++){
+		for(std::size_t i = 0; i < num_ints; i++){
 			count += array[i];
 		}
 		ASSERT_EQ(count, expected);

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -221,7 +221,7 @@ TEST_F(backendTest, atomicXchgAtomicity) {
 	// Test if only one node succeeded
 	argo::barrier();
 	bool found = false;
-	for (int i = 0; i < argo::number_of_nodes(); ++i) {
+	for (argo::num_nodes_t i = 0; i < argo::number_of_nodes(); ++i) {
 		global_int _rcs(&rcs[i]);
 		if (argo::backend::atomic::load(_rcs)) {
 			ASSERT_FALSE(found);
@@ -301,7 +301,7 @@ TEST_F(backendTest, atomicCASAtomicity) {
 	// Test if only one node succeeded
 	argo::barrier();
 	int count = 0;
-	for (int i = 0; i < argo::number_of_nodes(); ++i) {
+	for (argo::num_nodes_t i = 0; i < argo::number_of_nodes(); ++i) {
 		global_uint _rcs(&rcs[i]);
 		if (argo::backend::atomic::load(_rcs)) {
 			++count;
@@ -887,7 +887,7 @@ TEST_F(backendTest, writeBufferLoad) {
 	argo::barrier();
 
 	// One node at a time, increment random elements num_writes times
-	for(int i=0; i<argo::number_of_nodes(); i++){
+	for(argo::node_id_t i = 0; i < argo::number_of_nodes(); i++){
 		if(i == argo::node_id()){
 			for(std::size_t j=0; j<num_writes; j++){
 				array[dist(rng)]+=1;

--- a/tests/lock.cpp
+++ b/tests/lock.cpp
@@ -79,7 +79,7 @@ TEST_F(LockTest,TAS_trylock_all) {
 	/* Init a counter and increment array to 0 */
 	if(argo::node_id() == 0){
 		*counter = 0;
-		for (int i = 0; i < argo::number_of_nodes(); i++){
+		for (argo::num_nodes_t i = 0; i < argo::number_of_nodes(); i++){
 			did_increment[i] = false;
 		}
 	}
@@ -98,7 +98,7 @@ TEST_F(LockTest,TAS_trylock_all) {
 	ASSERT_GE(argo::number_of_nodes(),*counter);
 
 	int sum = 0;
-	for (int i = 0; i < argo::number_of_nodes(); i++){
+	for (argo::num_nodes_t i = 0; i < argo::number_of_nodes(); i++){
 		if(did_increment[i])
 			sum++;
 	}
@@ -113,7 +113,7 @@ TEST_F(LockTest,TAS_trylock_all) {
 
 /** @brief Checks locking is working by implementing a custom barrier */
 TEST_F(LockTest,TAS_lock_custom_barrier) {
-	int tmp;
+	unsigned int tmp;
 
 	/* Checks this many times if barrier was successful */
 	long deadlock_threshold = 100000;


### PR DESCRIPTION
This PR introduces parallelisation of cache and remote operations in the ArgoDSM backend. The key changes include:
- Reliance on `MPI_THREAD_MULTIPLE` now mandatory, not optional.
- Removal of `ibsem` semaphore which was used to serialize remote MPI (infiniband) access
- `cachemutex` replaced by fine-grained cache lock
- Introduction of multiple-tier `MPI_Window` data structures `data_windows` (replacing `globalDataWindow`) and `sharer_windows` (replacing `sharerWindow`), and corresponding locks to govern multithread access to each MPI Window.

The final target is that every aspect of the backend that must not explicitly be serialised for correctness or external restrictions should be allowed to continue in parallel. Limiting factors may include the total number of MPI Windows each MPI implementation allows for, or the impact of too many MPI windows on performance or memory footprint.

This PR assumes:
- OpenMPI over Infiniband may require UCX support to avoid stalling, as `MPI_THREAD_MULTIPLE` support for one-sided communication in `osc/rdma` does not appear to guarantee progress.
- If using OpenUCX, it must be configured with `--enable-mt`
- Use of OpenMPI parameters `--mca pml ucx --mca osc ucx --mca btl ^openib` may be required

The following work may still yield improvements:
- Parallelize acquire (self-invalidation) operation when called by through barrier
- Parallelize release (self-downgrade) operation when called by through barrier