### PR TITLE
Migrate repository from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArgoDSM
 
-[![Build Status](https://travis-ci.org/etascale/argodsm.svg?branch=master)](https://travis-ci.org/etascale/argodsm)
+[![Build Status](https://app.travis-ci.com/etascale/argodsm.svg?branch=master)](https://app.travis-ci.com/etascale/argodsm)
 
 [ArgoDSM](https://www.it.uu.se/research/project/argo) is a software distributed
 shared memory system which aims to provide great performance with a simplified


### PR DESCRIPTION
[travis-ci.org](https://travis-ci.org/) states that:
Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.

Some steps will have to be taken in order to migrate the **argodsm** repository from [travis-ci.org](https://travis-ci.org/) to [travis-ci.com](https://www.travis-ci.com/).