### PR TITLE
Replace std::mutex with QD lock in write buffer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "qd"]
+	path = extern/qd
+	url = ../../davidklaftenegger/qd_library.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "qd"]
 	path = extern/qd
-	url = ../../davidklaftenegger/qd_library.git
+	url = https://github.com/davidklaftenegger/qd_library.git
 	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,28 +36,28 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
 if("${isSystemDir}" STREQUAL "-1")
-   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
 # Attempt to update submodules from Git
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
 	# Update submodules as needed
-    option(GIT_SUBMODULE "Check submodules during build" ON)
-    if(GIT_SUBMODULE)
-        message(STATUS "Submodule update")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --remote
-                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        RESULT_VARIABLE GIT_SUBMOD_RESULT)
-        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-            message(FATAL_ERROR "git submodule update --init --recursive --remote failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-        endif()
-    endif()
+	option(GIT_SUBMODULE "Check submodules during build" ON)
+	if(GIT_SUBMODULE)
+		message(STATUS "Submodule update")
+		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --remote
+			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+			RESULT_VARIABLE GIT_SUBMOD_RESULT)
+		if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+			message(FATAL_ERROR "git submodule update --init --recursive --remote failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+		endif()
+	endif()
 endif()
 
 # Check for presence of QD library submodule
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/qd/CMakeLists.txt")
-    message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
+	message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
 else()
 	option(QD_TESTS OFF)
 	add_subdirectory(extern/qd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,18 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# Attempt to update submodules
+# Build with internal RPATH
+set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+# Set RPATH for installed libs to point to the lib install dir
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
+# Attempt to update submodules from Git
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
 	# Update submodules as needed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,31 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# Attempt to update submodules
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+	# Update submodules as needed
+    option(GIT_SUBMODULE "Check submodules during build" ON)
+    if(GIT_SUBMODULE)
+        message(STATUS "Submodule update")
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive --remote
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "git submodule update --init --recursive --remote failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        endif()
+    endif()
+endif()
+
+# Check for presence of QD library submodule
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/qd/CMakeLists.txt")
+    message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
+else()
+	option(QD_TESTS OFF)
+	add_subdirectory(extern/qd)
+	include_directories(extern/qd)
+endif()
+
 include_directories("${PROJECT_SOURCE_DIR}/src")
 add_subdirectory(src)
 

--- a/src/backend/mpi/CMakeLists.txt
+++ b/src/backend/mpi/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
 add_library(argobackend-mpi SHARED mpi.cpp swdsm.cpp coherence.cpp)
+target_link_libraries(argobackend-mpi qd)
 
 install(TARGETS argobackend-mpi
 	COMPONENT "Runtime"

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1135,6 +1135,8 @@ void storepageDIFF(std::size_t index, std::uintptr_t addr){
 }
 
 void printStatistics(){
+	stats.flushtime = argo_write_buffer->get_flush_time();
+	stats.writebacktime = argo_write_buffer->get_write_back_time();
 	printf("#####################STATISTICS#########################\n");
 	printf("# PROCESS ID %d \n",workrank);
 	printf("cachesize:%ld,CACHELINE:%ld wbsize:%ld\n",cachesize,CACHELINE,

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -74,9 +74,9 @@ class write_buffer
 		/** @brief Mutex to protect reading/writing to the statistics */
 		mutable std::mutex _stat_mutex;
 
-		/** @brief Number of pages added to the write buffer */
+		/** @brief Statistic of the total number of pages added to the write buffer */
 		std::size_t _page_count{0};
-		/** @brief Number of times partially flushed (when full) */
+		/** @brief Statistic of the number of times the write buffer was partially flushed */
 		std::size_t _partial_flush_count{0};
 
 		/** @brief Statistic of time spent flushing the write buffer */


### PR DESCRIPTION
This PR proposes to replace `std::mutex` with a **QD lock** in the ArgoDSM write buffer. To achieve this, the [QD library](https://github.com/davidklaftenegger/qd_library) is added as a submodule of ArgoDSM and is automatically fetched by CMake during the build procedure.

The goal of using a QD lock instead of `std::mutex` is to allow delegation to the current lock holder of the `write_buffer::add`, `write_buffer::erase` and `write_buffer::flush` operations. The benefit of delegating these operations will not be apparent until the removal of both the global `cachemutex` and `ibsem`, as these currently serialize write buffer operations regardless. With future removal of these restrictions, addition to or deletion from the write buffer can be done asynchronously without awaiting completion should the write buffer lock currently be held by someone else.