### PR TITLE
Introduce a dedicated MPI window for the mempool offset

### DIFF
--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -33,8 +33,6 @@ namespace argo {
 			requested_argo_size = env::memory_size();
 		}
 		using mp = mem::global_memory_pool<>;
-		/* add some space for internal use, see issue #22 */
-		requested_argo_size += mp::reserved;
 
 		std::size_t requested_cache_size = cache_size;
 		if(requested_cache_size == 0) {

--- a/tests/allocators.cpp
+++ b/tests/allocators.cpp
@@ -48,7 +48,7 @@ class AllocatorTest : public testing::Test {
  * @brief Unittest that checks that the global address space is at least as large as requested
  */
 TEST_F(AllocatorTest, InitialSize) {
-	ASSERT_GE(default_global_mempool->available(),size - mem::global_memory_pool<>::reserved);
+	ASSERT_GE(default_global_mempool->available(), size);
 }
 
 /**
@@ -87,8 +87,8 @@ TEST_F(AllocatorTest, Collective200MBTwiceAlloc) {
  * @brief Unittest that checks that allocating the whole requested memory space collectively - also checks that the remaining memory is non-negative
  */
 TEST_F(AllocatorTest, CollectiveAllocRequestedSize) {
-	ASSERT_NO_THROW(collective_alloc(size - mem::global_memory_pool<>::reserved));
-	ASSERT_GE(default_global_mempool->available(),std::size_t{0});
+	ASSERT_NO_THROW(collective_alloc(size));
+	ASSERT_GE(default_global_mempool->available(), std::size_t{0});
 }
 
 /**
@@ -168,7 +168,7 @@ TEST_F(AllocatorTest, DynamicCommonAlloc) {
  */
 TEST_F(AllocatorTest, DynamicAllocRequestedSize) {
 	if(argo::node_id() == 0){
-		ASSERT_NO_THROW(dynamic_alloc(size - mem::global_memory_pool<>::reserved));
+		ASSERT_NO_THROW(dynamic_alloc(size));
 	}
 	argo::barrier();
 	ASSERT_GE(default_global_mempool->available(),std::size_t{0});


### PR DESCRIPTION
This PR aims to resolve #22.

This is a long awaited patch that basically removes the need to reserve a page from global memory (`0x200000000000`) to host the currently available amount of pool memory (`offset`) and it's associated lock structure to atomically (and also globally) update it.

Applying this patch, globally allocated data will start from the virtual address `0x200000000000` instead of `0x200000001000`.

Aside from the issues stated in #22, hanging was also observed when multiple nodes/processes were trying to claim ownership of the first page under the _first-touch_ memory allocation policy. Responsible code block:
https://github.com/etascale/argodsm/blob/ecc418cedc5f4b9c5588ab3902fff520775b2aff/src/mempools/global_mempool.hpp#L63-L67

<hr style="border:2px solid gray"> </hr>

**This is a draft PR. Open to any suggestions!**

**This PR currently**:
:heavy_check_mark: Passes all MPI tests for both `DEBUG=ON/OFF`.
:x: Fails all Singlenode tests due to the exposure of the single process to MPI operations.

**Q_0**: Best way to work around the single node issue?
**Q_1**: Would it be better to transition to shared locking and use `MPI_Get_Accumulate` (with `MPI_NO_OP`) instead of `MPI_Get`?