### PR TITLE
Fix `bool` type C compilation issue

### DIFF
--- a/src/argo.h
+++ b/src/argo.h
@@ -7,6 +7,7 @@
 #ifndef argo_argo_h
 #define argo_argo_h argo_argo_h
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "allocators/allocators.h"


### PR DESCRIPTION
This PR fixes a C compilation issue related to type `bool`.

Output when compiling the VMS application with `mpicc`:
```bash
make -f Makefile.argo
make[1]: Entering directory '/home/johnpc/Desktop/github/vms/pure_c'
mpic++ -std=c++11 -DUSE_ARGO -DVMS_PROFILING -I/home/johnpc/argodsm-bench/argodsm/install/include/argo -L/home/johnpc/argodsm-bench/argodsm/install/lib -fopenmp -DUSE_OPENMP  -DVMS_PROFILING -O3 -march=native -g -c counters_impl.cpp -o argo/counters_impl.o 
mpicc -DUSE_ARGO -DVMS_PROFILING -I/home/johnpc/argodsm-bench/argodsm/install/include/argo -L/home/johnpc/argodsm-bench/argodsm/install/lib -fopenmp -DUSE_OPENMP  -DVMS_PROFILING -O3 -march=native -g -c predict.c -o argo/predict.o 
mpicc -DUSE_ARGO -DVMS_PROFILING -I/home/johnpc/argodsm-bench/argodsm/install/include/argo -L/home/johnpc/argodsm-bench/argodsm/install/lib -fopenmp -DUSE_OPENMP  -DVMS_PROFILING -O3 -march=native -g -c test_bench.c -o argo/test_bench.o 
mpicc -DUSE_ARGO -DVMS_PROFILING -I/home/johnpc/argodsm-bench/argodsm/install/include/argo -L/home/johnpc/argodsm-bench/argodsm/install/lib -fopenmp -DUSE_OPENMP  -DVMS_PROFILING -O3 -march=native -g -c mpi.c -o argo/mpi.o 
mpicc -DUSE_ARGO -DVMS_PROFILING -I/home/johnpc/argodsm-bench/argodsm/install/include/argo -L/home/johnpc/argodsm-bench/argodsm/install/lib -fopenmp -DUSE_OPENMP  -DVMS_PROFILING -O3 -march=native -g -c ompss.c -o argo/ompss.o 
In file included from ompss.c:10:
/home/johnpc/argodsm-bench/argodsm/install/include/argo/argo.h:57:1: error: unknown type name ‘bool’
   57 | bool argo_is_argo_address(void* addr);
      | ^~~~
make[1]: *** [Makefile.common:24: argo/ompss.o] Error 1
make[1]: Leaving directory '/home/johnpc/Desktop/github/vms/pure_c'
make: *** [Makefile:28: all] Error 2
```