### PR TITLE
Modify atomic tests to use atomic load

### DIFF
--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -68,18 +68,19 @@ class backendTest : public testing::Test, public ::testing::WithParamInterface<i
 TEST_F(backendTest, atomicXchgAll) {
 	global_char _c(argo::conew_<char>(0));
 	argo::backend::atomic::exchange(_c, c_const);
-	ASSERT_EQ(c_const, *_c);
+	ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
 
 	global_int _i(argo::conew_<int>(0));
 	argo::backend::atomic::exchange(_i, i_const);
-	ASSERT_EQ(i_const, *_i);
+	ASSERT_EQ(i_const, argo::backend::atomic::load(_i));
+
 	global_uint _j(argo::conew_<unsigned>(0));
 	argo::backend::atomic::exchange(_j, j_const);
-	ASSERT_EQ(j_const, *_j);
+	ASSERT_EQ(j_const, argo::backend::atomic::load(_j));
 
 	global_double _d(argo::conew_<double>(0));
 	argo::backend::atomic::exchange(_d, d_const);
-	ASSERT_EQ(d_const, *_d);
+	ASSERT_EQ(d_const, argo::backend::atomic::load(_d));
 }
 
 /**
@@ -92,30 +93,31 @@ TEST_F(backendTest, atomicXchgOne) {
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::exchange(_c, c_const);
 	argo::backend::barrier();
-	ASSERT_EQ(c_const, *_c);
+	ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
 
 	global_int _i(argo::conew_<int>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::exchange(_i, i_const);
 	argo::backend::barrier();
-	ASSERT_EQ(i_const, *_i);
+	ASSERT_EQ(i_const, argo::backend::atomic::load(_i));
+
 	global_uint _j(argo::conew_<unsigned>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::exchange(_j, j_const);
 	argo::backend::barrier();
-	ASSERT_EQ(j_const, *_j);
+	ASSERT_EQ(j_const, argo::backend::atomic::load(_j));
 	argo::backend::barrier();
 	// The following test is here to test implicit type conversions
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::exchange(_j, i_const);
 	argo::backend::barrier();
-	ASSERT_EQ(static_cast<unsigned>(i_const), *_j);
+	ASSERT_EQ(static_cast<unsigned>(i_const), argo::backend::atomic::load(_j));
 
 	global_double _d(argo::conew_<double>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::exchange(_d, d_const);
 	argo::backend::barrier();
-	ASSERT_EQ(d_const, *_d);
+	ASSERT_EQ(d_const, argo::backend::atomic::load(_d));
 }
 
 /**
@@ -126,30 +128,31 @@ TEST_F(backendTest, storeOne) {
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::store(_c, c_const);
 	argo::backend::barrier();
-	ASSERT_EQ(c_const, *_c);
+	ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
 
 	global_int _i(argo::conew_<int>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::store(_i, i_const);
 	argo::backend::barrier();
-	ASSERT_EQ(i_const, *_i);
+	ASSERT_EQ(i_const, argo::backend::atomic::load(_i));
+
 	global_uint _j(argo::conew_<unsigned>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::store(_j, j_const);
 	argo::backend::barrier();
-	ASSERT_EQ(j_const, *_j);
+	ASSERT_EQ(j_const, argo::backend::atomic::load(_j));
 	argo::backend::barrier();
 	// The following test is here to test implicit type conversions
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::store(_j, i_const);
 	argo::backend::barrier();
-	ASSERT_EQ(static_cast<unsigned>(i_const), *_j);
+	ASSERT_EQ(static_cast<unsigned>(i_const), argo::backend::atomic::load(_j));
 
 	global_double _d(argo::conew_<double>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::store(_d, d_const);
 	argo::backend::barrier();
-	ASSERT_EQ(d_const, *_d);
+	ASSERT_EQ(d_const, argo::backend::atomic::load(_d));
 }
 
 /**
@@ -167,7 +170,6 @@ TEST_F(backendTest, loadOne) {
 		std::chrono::system_clock::now() + deadlock_threshold;
 	while(argo::backend::atomic::load(_c) != c_const)
 		ASSERT_LT(std::chrono::system_clock::now(), max_time);
-	ASSERT_EQ(c_const, *_c);
 
 	global_int _i(argo::conew_<int>());
 	if (argo::backend::node_id() == 0)
@@ -175,14 +177,13 @@ TEST_F(backendTest, loadOne) {
 	max_time = std::chrono::system_clock::now() + deadlock_threshold;
 	while(argo::backend::atomic::load(_i) != i_const)
 		ASSERT_LT(std::chrono::system_clock::now(), max_time);
-	ASSERT_EQ(i_const, *_i);
+
 	global_uint _j(argo::conew_<unsigned>());
 	if (argo::backend::node_id() == 0)
 		argo::backend::atomic::store(_j, j_const);
 	max_time = std::chrono::system_clock::now() + deadlock_threshold;
 	while(argo::backend::atomic::load(_j) != j_const)
 		ASSERT_LT(std::chrono::system_clock::now(), max_time);
-	ASSERT_EQ(j_const, *_j);
 
 	global_double _d(argo::conew_<double>());
 	if (argo::backend::node_id() == 0)
@@ -190,7 +191,6 @@ TEST_F(backendTest, loadOne) {
 	max_time = std::chrono::system_clock::now() + deadlock_threshold;
 	while(argo::backend::atomic::load(_d) != d_const)
 		ASSERT_LT(std::chrono::system_clock::now(), max_time);
-	ASSERT_EQ(d_const, *_d);
 }
 
 /**
@@ -215,7 +215,8 @@ TEST_F(backendTest, atomicXchgAtomicity) {
 	argo::barrier();
 	bool found = false;
 	for (int i = 0; i < argo::number_of_nodes(); ++i) {
-		if (rcs[i]) {
+		global_int _rcs(&rcs[i]);
+		if (argo::backend::atomic::load(_rcs)) {
 			ASSERT_FALSE(found);
 			found = true;
 		}
@@ -294,7 +295,8 @@ TEST_F(backendTest, atomicCASAtomicity) {
 	argo::barrier();
 	int count = 0;
 	for (int i = 0; i < argo::number_of_nodes(); ++i) {
-		if (rcs[i]) {
+		global_uint _rcs(&rcs[i]);
+		if (argo::backend::atomic::load(_rcs)) {
 			++count;
 		}
 	}
@@ -319,7 +321,7 @@ TEST_F(backendTest, atomicCASAtomicityStress) {
 	}
 
 	argo::barrier();
-	ASSERT_EQ(10000*argo::number_of_nodes(), *counter);
+	ASSERT_EQ(10000*argo::number_of_nodes(), argo::backend::atomic::load(counter));
 }
 
 /**
@@ -334,7 +336,7 @@ TEST_F(backendTest, atomicFetchAddInt) {
 	}
 
 	argo::barrier();
-	ASSERT_EQ(10000*argo::number_of_nodes(), *counter);
+	ASSERT_EQ(10000*argo::number_of_nodes(), argo::backend::atomic::load(counter));
 }
 
 /**
@@ -354,7 +356,7 @@ TEST_F(backendTest, atomicFetchAddUInt) {
 	}
 
 	argo::barrier();
-	ASSERT_EQ(std::numeric_limits<unsigned>::max(), *counter);
+	ASSERT_EQ(std::numeric_limits<unsigned>::max(), argo::backend::atomic::load(counter));
 }
 
 /**
@@ -371,7 +373,7 @@ TEST_F(backendTest, atomicFetchAddFloat) {
 	argo::barrier();
 	// If this fails, make sure it's not because of floating point precision
 	// issues
-	ASSERT_EQ(10000*argo::number_of_nodes(), *counter);
+	ASSERT_EQ(10000*argo::number_of_nodes(), argo::backend::atomic::load(counter));
 }
 
 /**
@@ -384,7 +386,7 @@ TEST_F(backendTest, atomicFetchAddPointer) {
 	// about the atomicity etc
 	if (argo::node_id() == 0) {
 		int * old_ptr = argo::backend::atomic::fetch_add(ptr, 2);
-		ASSERT_EQ(2, *ptr.get() - old_ptr);
+		ASSERT_EQ(2, argo::backend::atomic::load(ptr) - old_ptr);
 	}
 }
 


### PR DESCRIPTION
Modify the atomic tests in backendTests to use `atomic::load` rather than pure memory loads as per issue #20.
This as a standalone PR, but also when cherry-picking the commit from #83, passes all tests with both `DEBUG=ON/OFF`.