### PR TITLE
Reserve the last page of global memory for internal use

### DIFF
--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -55,12 +55,14 @@ namespace argo {
 					using namespace data_distribution;
 					base_distribution<0>::set_memory_space(nodes, memory, max_size);
 
-					// Move back one page as the last page is left for internal use
+					// Reset maximum size to the full memory size minus the space reserved for internal use
 					max_size -= reserved;
+					// Attach memory pool offset to the start of the reserved space
 					offset = new (&memory[max_size]) ptrdiff_t;
 
 					using tas_lock = argo::globallock::global_tas_lock;
-					tas_lock::internal_field_type* field = new (&memory[max_size+sizeof(std::size_t)]) tas_lock::internal_field_type;
+					// Attach internal lock field sizeof(ptrdiff_t) bytes after the start of the reserved space
+					tas_lock::internal_field_type* field = new (&memory[max_size+sizeof(std::ptrdiff_t)]) tas_lock::internal_field_type;
 					global_tas_lock = new tas_lock(field);
 
 					// Node0 makes sure that offset points to Argo's starting address

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -65,8 +65,9 @@ namespace argo {
 					tas_lock::internal_field_type* field = new (&memory[max_size+sizeof(std::ptrdiff_t)]) tas_lock::internal_field_type;
 					global_tas_lock = new tas_lock(field);
 
-					// Node0 makes sure that offset points to Argo's starting address
-					if(backend::node_id() == 0){
+					// Home node makes sure that offset points to Argo's starting address
+					global_ptr<char> gptr(&memory[max_size]);
+					if(backend::node_id() == gptr.node()){
 						*offset = static_cast<std::ptrdiff_t>(0);
 					}
 					backend::barrier();
@@ -89,8 +90,10 @@ namespace argo {
 					// Move back one page as the last page is left for internal use
 					max_size = backend::global_size() - reserved;
 
-					// Node0 makes sure that offset points to Argo's starting address
-					if(backend::node_id() == 0){
+					// Home node makes sure that offset points to Argo's starting address
+					using namespace data_distribution;
+					global_ptr<char> gptr(&memory[max_size]);
+					if(backend::node_id() == gptr.node()){
 						*offset = static_cast<std::ptrdiff_t>(0);
 					}
 					backend::barrier();

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -115,16 +115,16 @@ TEST_F(PrefetchTest, AccessPrefetched) {
 		 * to be contiguious in both global memory and backing store
 		 */
 		stride = std::min(block_size, load_size);
-		start_page = block_size-1; //first block may already be fetched in init
+		start_page = 0; //first block may already be fetched in init
 	} else {
 		/*
 		 * For the first touch policiy, at most
 		 * (alloc_size/4096)/num_nodes are guaranteed to be contiguious 
 		 * in both global memory and backing store.
 		 */
-		stride = (load_size < ((size/page_size)/num_nodes)) ?
-				load_size : (size/page_size)/num_nodes - 1;
-		start_page = stride-1; //First stride may already be fetched in init
+		stride = (load_size < ((alloc_size/page_size)/num_nodes)) ?
+				load_size : (alloc_size/page_size)/num_nodes - 1;
+		start_page = 0; //First stride may already be fetched in init
 	}
 	std::size_t end_page = start_page+stride;
 

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -115,7 +115,7 @@ TEST_F(PrefetchTest, AccessPrefetched) {
 		 * to be contiguious in both global memory and backing store
 		 */
 		stride = std::min(block_size, load_size);
-		start_page = 0; //first block may already be fetched in init
+		start_page = 0;
 	} else {
 		/*
 		 * For the first touch policiy, at most
@@ -124,7 +124,7 @@ TEST_F(PrefetchTest, AccessPrefetched) {
 		 */
 		stride = (load_size < ((alloc_size/page_size)/num_nodes)) ?
 				load_size : (alloc_size/page_size)/num_nodes - 1;
-		start_page = 0; //First stride may already be fetched in init
+		start_page = 0;
 	}
 	std::size_t end_page = start_page+stride;
 


### PR DESCRIPTION
This PR aims to resolve #22.

This patch reserves the last instead of the first page of global memory to host the currently available amount of pool memory (offset) and its associated lock structure to atomically (and also globally) update it.
Applying this patch, globally allocated data will start from the virtual address 0x200000000000 instead of 0x200000001000.

NOTE: This PR will close #81.