### PR TITLE
Introduce classification upgrade barriers

### DIFF
--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -108,8 +108,12 @@ namespace argo {
 		/**
 		 * @brief a simple collective barrier
 		 * @param threadcount number of threads on each node that go into the barrier
+		 * @param upgrade_level controls if the barrier should upgrade pages:
+		 *	- 0 upgrade no pages
+		 * 	- 1 upgrade all pages to at least S
+		 * 	- 2 upgrade all pages to P
 		 */
-		void barrier(std::size_t threadcount=1);
+		void barrier(std::size_t threadcount=1, std::size_t upgrade_level=0);
 
 		/**
 		 * @brief broadcast-style collective synchronization

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -40,6 +40,15 @@ namespace argo {
 
 	namespace backend {
 		/**
+		 * @brief Type of classification upgrade for the barrier operation
+		 */
+		enum class upgrade_type {
+			upgrade_none,	// Don't upgrade anything
+			upgrade_writers,// Upgrade all S-SW/MW to S-NW
+			upgrade_all		// Upgrade all S-NW/SW/MW to P
+		};
+
+		/**
 		 * @brief initialize backend
 		 * @param argo_size the size (in bytes) of the global memory to initialize
 		 * @param cache_size the size (in bytes) of the cache used by ArgoDSM
@@ -108,12 +117,9 @@ namespace argo {
 		/**
 		 * @brief a simple collective barrier
 		 * @param threadcount number of threads on each node that go into the barrier
-		 * @param upgrade_level controls if the barrier should upgrade pages:
-		 *	- 0 upgrade no pages
-		 * 	- 1 upgrade all pages to at least S
-		 * 	- 2 upgrade all pages to P
+		 * @param upgrade the type of classification upgrade to perform
 		 */
-		void barrier(std::size_t threadcount=1, std::size_t upgrade_level=0);
+		void barrier(std::size_t threadcount=1, upgrade_type upgrade = upgrade_type::upgrade_none);
 
 		/**
 		 * @brief broadcast-style collective synchronization

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -195,8 +195,8 @@ namespace argo {
 			argo_reset_coherence();
 		}
 
-		void barrier(std::size_t tc, std::size_t upgrade_level) {
-			argo_barrier(tc, upgrade_level);
+		void barrier(std::size_t tc, upgrade_type upgrade) {
+			argo_barrier(tc, upgrade);
 		}
 
 		template<typename T>

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -195,8 +195,8 @@ namespace argo {
 			argo_reset_coherence();
 		}
 
-		void barrier(std::size_t tc) {
-			swdsm_argo_barrier(tc);
+		void barrier(std::size_t tc, std::size_t upgrade_level) {
+			argo_barrier(tc, upgrade_level);
 		}
 
 		template<typename T>

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -196,7 +196,7 @@ namespace argo {
 		}
 
 		void barrier(std::size_t tc, upgrade_type upgrade) {
-			argo_barrier(tc, upgrade);
+			swdsm_argo_barrier(tc, upgrade);
 		}
 
 		template<typename T>

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -909,11 +909,11 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 
 void argo_finalize(){
 	int i;
-	argo_barrier(1);
+	swdsm_argo_barrier(1);
 	if(getID() == 0){
 		printf("ArgoDSM shutting down\n");
 	}
-	argo_barrier(1);
+	swdsm_argo_barrier(1);
 	mprotect(startAddr,size_of_all,PROT_WRITE|PROT_READ);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1018,7 +1018,7 @@ void self_upgrade(upgrade_type upgrade) {
 	MPI_Win_unlock(workrank, sharerWindow);
 }
 
-void argo_barrier(int n, upgrade_type upgrade){
+void swdsm_argo_barrier(int n, upgrade_type upgrade){
 	pthread_t barrierlockholder;
 	double t1 = MPI_Wtime();
 
@@ -1099,9 +1099,9 @@ void argo_reset_coherence(){
 	}
 
 	sem_post(&ibsem);
-	argo_barrier(1);
+	swdsm_argo_barrier(1);
 	mprotect(startAddr,size_of_all,PROT_NONE);
-	argo_barrier(1);
+	swdsm_argo_barrier(1);
 	clearStatistics();
 }
 

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -18,6 +18,8 @@ namespace vm = argo::virtual_memory;
 namespace sig = argo::signal;
 namespace env = argo::env;
 
+using namespace argo::backend;
+
 /** @brief For matching threads to more sensible thread IDs */
 pthread_t tid[NUM_THREADS] = {0};
 
@@ -977,9 +979,9 @@ void self_invalidation(){
 	stats.selfinvtime += (t2-t1);
 }
 
-void self_upgrade(argo::backend::upgrade_type upgrade) {
-	assert(upgrade == argo::backend::upgrade_type::upgrade_writers ||
-		   upgrade == argo::backend::upgrade_type::upgrade_all);
+void self_upgrade(upgrade_type upgrade) {
+	assert(upgrade == upgrade_type::upgrade_writers ||
+		   upgrade == upgrade_type::upgrade_all);
 	const std::uint64_t node_id_bit = static_cast<std::uint64_t>(1) << getID();
 	const std::size_t reserved_indices = 2; // The last page is system reserved
 
@@ -993,7 +995,7 @@ void self_upgrade(argo::backend::upgrade_type upgrade) {
 		bool is_writer = globalSharers[i+1]&node_id_bit;
 
 		// Reset globalSharers for this page
-		if(upgrade == argo::backend::upgrade_type::upgrade_all) {
+		if(upgrade == upgrade_type::upgrade_all) {
 			globalSharers[i] = 0;
 		}
 		globalSharers[i+1] = 0;
@@ -1001,7 +1003,7 @@ void self_upgrade(argo::backend::upgrade_type upgrade) {
 		// Apply the correct mprotection and cache state
 		if(is_cached) {
 			// Must invalidate all pages upgrading to P
-			if(upgrade == argo::backend::upgrade_type::upgrade_all && is_sharer) {
+			if(upgrade == upgrade_type::upgrade_all && is_sharer) {
 				std::size_t cache_index = getCacheIndex(page_addr);
 				mprotect(global_addr,block_size,PROT_NONE);
 				cacheControl[cache_index].dirty = CLEAN;
@@ -1017,7 +1019,7 @@ void self_upgrade(argo::backend::upgrade_type upgrade) {
 	MPI_Win_unlock(workrank, sharerWindow);
 }
 
-void argo_barrier(int n, argo::backend::upgrade_type upgrade){
+void argo_barrier(int n, upgrade_type upgrade){
 	pthread_t barrierlockholder;
 	double t1 = MPI_Wtime();
 
@@ -1043,7 +1045,7 @@ void argo_barrier(int n, argo::backend::upgrade_type upgrade){
 		self_invalidation();
 
 		// Perform upgrade if requested
-		if(upgrade != argo::backend::upgrade_type::upgrade_none) {
+		if(upgrade != upgrade_type::upgrade_none) {
 			self_upgrade(upgrade);
 			MPI_Barrier(workcomm);
 		}

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -980,10 +980,10 @@ void self_invalidation(){
 void self_upgrade(std::size_t upgrade_level) {
 	assert(upgrade_level == 1 || upgrade_level == 2);
 	const std::uint64_t node_id_bit = static_cast<std::uint64_t>(1) << getID();
+	const std::size_t reserved_indices = 2; // The last page is system reserved
 
 	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-	// @todo this loop condition should be changed after merging PR#85
-	for(std::size_t i = 2; i < classificationSize; i+=2) {
+	for(std::size_t i = 0; i < classificationSize-reserved_indices; i+=2) {
 		std::size_t page_index = i/2;
 		std::uintptr_t page_addr = page_index*pagesize*CACHELINE;
 		void* global_addr = static_cast<char*>(startAddr) + page_addr;

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -983,10 +983,9 @@ void self_upgrade(upgrade_type upgrade) {
 	assert(upgrade == upgrade_type::upgrade_writers ||
 		   upgrade == upgrade_type::upgrade_all);
 	const std::uint64_t node_id_bit = static_cast<std::uint64_t>(1) << getID();
-	const std::size_t reserved_indices = 2; // The last page is system reserved
 
 	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, workrank, 0, sharerWindow);
-	for(std::size_t i = 0; i < classificationSize-reserved_indices; i+=2) {
+	for(std::size_t i = 0; i < classificationSize; i+=2) {
 		std::size_t page_index = i/2;
 		std::uintptr_t page_addr = page_index*pagesize*CACHELINE;
 		void* global_addr = static_cast<char*>(startAddr) + page_addr;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include "argo.h"
+#include "backend/backend.hpp"
 
 #ifndef CACHELINE
 /** @brief Size of a ArgoDSM cacheline in number of pages */
@@ -159,23 +160,18 @@ void self_invalidation();
 
 /**
  * @brief Perform upgrade of page classifications
- * @param upgrade_level controls what classifications are upgraded
- * 	- 1 upgrade all pages to at least S
- * 	- 2 upgrade all pages to P
- * @pre upgrade_level must be 1 or 2
+ * @param upgrade the type of classification upgrade to perform
  */
-void self_upgrade(std::size_t upgrade_level);
+void self_upgrade(argo::backend::upgrade_type upgrade);
 
 /**
  * @brief Global barrier for ArgoDSM - needs to be called by every thread in the
  *        system that need coherent view of the memory
  * @param n number of local thread participating
- * @param upgrade_level controls if the barrier should upgrade pages:
- *	- 0 upgrade no pages
- * 	- 1 upgrade all pages to at least S
- * 	- 2 upgrade all pages to P
+ * @param upgrade the type of classification upgrade to perform
  */
-void argo_barrier(int n, std::size_t upgrade_level = 0);
+void argo_barrier(int n, argo::backend::upgrade_type upgrade =
+				  argo::backend::upgrade_type::upgrade_none);
 
 /**
  * @brief acquire function for ArgoDSM (Acquire according to Release Consistency)

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -170,7 +170,7 @@ void self_upgrade(argo::backend::upgrade_type upgrade);
  * @param n number of local thread participating
  * @param upgrade the type of classification upgrade to perform
  */
-void argo_barrier(int n, argo::backend::upgrade_type upgrade =
+void swdsm_argo_barrier(int n, argo::backend::upgrade_type upgrade =
 				  argo::backend::upgrade_type::upgrade_none);
 
 /**

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -158,11 +158,24 @@ void argo_finalize();
 void self_invalidation();
 
 /**
+ * @brief Perform upgrade of page classifications
+ * @param upgrade_level controls what classifications are upgraded
+ * 	- 1 upgrade all pages to at least S
+ * 	- 2 upgrade all pages to P
+ * @pre upgrade_level must be 1 or 2
+ */
+void self_upgrade(std::size_t upgrade_level);
+
+/**
  * @brief Global barrier for ArgoDSM - needs to be called by every thread in the
  *        system that need coherent view of the memory
  * @param n number of local thread participating
+ * @param upgrade_level controls if the barrier should upgrade pages:
+ *	- 0 upgrade no pages
+ * 	- 1 upgrade all pages to at least S
+ * 	- 2 upgrade all pages to P
  */
-void swdsm_argo_barrier(int n);
+void argo_barrier(int n, std::size_t upgrade_level = 0);
 
 /**
  * @brief acquire function for ArgoDSM (Acquire according to Release Consistency)

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -20,6 +20,7 @@
 
 namespace vm = argo::virtual_memory;
 namespace sig = argo::signal;
+using namespace argo::backend;
 
 /** @brief a lock for atomically executed operations */
 std::mutex atomic_op_mutex;
@@ -148,7 +149,7 @@ namespace argo {
 			}
 		}
 
-		void barrier(std::size_t threadcount, argo::backend::upgrade_type upgrade) {
+		void barrier(std::size_t threadcount, upgrade_type upgrade) {
 			(void)upgrade;
 			/* initially: flag = false */
 			std::unique_lock<std::mutex> barrier_lock(barrier_mutex);

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -148,8 +148,8 @@ namespace argo {
 			}
 		}
 
-		void barrier(std::size_t threadcount, std::size_t upgrade_level) {
-			(void)upgrade_level;
+		void barrier(std::size_t threadcount, argo::backend::upgrade_type upgrade) {
+			(void)upgrade;
 			/* initially: flag = false */
 			std::unique_lock<std::mutex> barrier_lock(barrier_mutex);
 			barrier_counter++;

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -148,7 +148,8 @@ namespace argo {
 			}
 		}
 
-		void barrier(std::size_t threadcount) {
+		void barrier(std::size_t threadcount, std::size_t upgrade_level) {
+			(void)upgrade_level;
 			/* initially: flag = false */
 			std::unique_lock<std::mutex> barrier_lock(barrier_mutex);
 			barrier_counter++;

--- a/src/synchronization/synchronization.cpp
+++ b/src/synchronization/synchronization.cpp
@@ -8,12 +8,28 @@
 
 namespace argo {
 	void barrier(std::size_t threadcount) {
-		backend::barrier(threadcount);
+		backend::barrier(threadcount, 0);
+	}
+
+	void barrier_upgrade_writers(std::size_t threadcount) {
+		backend::barrier(threadcount, 1);
+	}
+
+	void barrier_upgrade_all(std::size_t threadcount) {
+		backend::barrier(threadcount, 2);
 	}
 } // namespace argo
 
 extern "C" {
 	void argo_barrier(size_t threadcount) {
 		argo::barrier(threadcount);
+	}
+
+	void argo_barrier_upgrade_writers(size_t threadcount) {
+		argo::barrier_upgrade_writers(threadcount);
+	}
+
+	void argo_barrier_upgrade_all(size_t threadcount) {
+		argo::barrier_upgrade_all(threadcount);
 	}
 }

--- a/src/synchronization/synchronization.cpp
+++ b/src/synchronization/synchronization.cpp
@@ -8,15 +8,15 @@
 
 namespace argo {
 	void barrier(std::size_t threadcount) {
-		backend::barrier(threadcount, 0);
+		backend::barrier(threadcount, backend::upgrade_type::upgrade_none);
 	}
 
 	void barrier_upgrade_writers(std::size_t threadcount) {
-		backend::barrier(threadcount, 1);
+		backend::barrier(threadcount, backend::upgrade_type::upgrade_writers);
 	}
 
 	void barrier_upgrade_all(std::size_t threadcount) {
-		backend::barrier(threadcount, 2);
+		backend::barrier(threadcount, backend::upgrade_type::upgrade_all);
 	}
 } // namespace argo
 

--- a/src/synchronization/synchronization.h
+++ b/src/synchronization/synchronization.h
@@ -10,12 +10,32 @@
 #include <stddef.h>
 
 /**
- * @brief a barrier for threads
- * @param threadcount number of threads on each ArgoDSM node
+ * @brief a barrier for ArgoDSM nodes
+ * @param threadcount number of threads on each ArgoDSM node to wait for
  * @details this barrier waits until threadcount threads have reached this
- *          barrier call on EACH ArgoDSM node.
- * @todo better explanation
+ *          barrier call on each ArgoDSM node, then performs self-downgrade
+ *          and self-invalidation on each node.
  */
 void argo_barrier(size_t threadcount);
+
+/**
+ * @brief a barrier for ArgoDSM nodes
+ * @param threadcount number of threads on each ArgoDSM node to wait for
+ * @details this barrier waits until threadcount threads have reached this
+ *          barrier call on each ArgoDSM node, then performs self-downgrade
+ *          and self-invalidation on each node. Additionally, this barrier
+ *          upgrades all pages with registered writers to a shared state.
+ */
+void argo_barrier_upgrade_writers(size_t threadcount);
+
+/**
+ * @brief a barrier for ArgoDSM nodes
+ * @param threadcount number of threads on each ArgoDSM node to wait for
+ * @details this barrier waits until threadcount threads have reached this
+ *          barrier call on each ArgoDSM node, then performs self-downgrade
+ *          and self-invalidation on each node. Additionally, this barrier
+ *          upgrades all pages to a private state.
+ */
+void argo_barrier_upgrade_all(size_t threadcount);
 
 #endif /* argo_synchronization_h */

--- a/src/synchronization/synchronization.hpp
+++ b/src/synchronization/synchronization.hpp
@@ -13,13 +13,33 @@
 
 namespace argo {
 	/**
-	 * @brief a barrier for threads
-	 * @param threadcount number of threads on each ArgoDSM node
+	 * @brief a barrier for ArgoDSM nodes
+	 * @param threadcount number of threads on each ArgoDSM node to wait for
 	 * @details this barrier waits until threadcount threads have reached this
-	 *          barrier call on EACH ArgoDSM node.
-	 * @todo better explanation
+	 *          barrier call on each ArgoDSM node, then performs self-downgrade
+	 *          and self-invalidation on each node.
 	 */
 	void barrier(std::size_t threadcount=1);
+
+	/**
+	 * @brief a barrier for ArgoDSM nodes
+	 * @param threadcount number of threads on each ArgoDSM node to wait for
+	 * @details this barrier waits until threadcount threads have reached this
+	 *          barrier call on each ArgoDSM node, then performs self-downgrade
+	 *          and self-invalidation on each node. Additionally, this barrier
+	 *          upgrades all pages with registered writers to a shared state.
+	 */
+	void barrier_upgrade_writers(std::size_t threadcount=1);
+
+	/**
+	 * @brief a barrier for ArgoDSM nodes
+	 * @param threadcount number of threads on each ArgoDSM node to wait for
+	 * @details this barrier waits until threadcount threads have reached this
+	 *          barrier call on each ArgoDSM node, then performs self-downgrade
+	 *          and self-invalidation on each node. Additionally, this barrier
+	 *          upgrades all pages to a private state.
+	 */
+	void barrier_upgrade_all(std::size_t threadcount=1);
 } // namespace argo
 
 extern "C" {

--- a/tests/barrier.cpp
+++ b/tests/barrier.cpp
@@ -14,6 +14,8 @@
 constexpr std::size_t size = 1<<30;
 /** @brief ArgoDSM cache size */
 constexpr std::size_t cache_size = size/8;
+/** @brief Size of an ArgoDSM page */
+constexpr std::size_t page_size = 4096;
 
 /** @brief Maximum number of threads to run in the stress tests */
 constexpr int max_threads = 128;
@@ -39,6 +41,169 @@ class barrierTest : public testing::Test, public ::testing::WithParamInterface<i
  */
 TEST_F(barrierTest, simpleBarrier) {
 	ASSERT_NO_THROW(argo::barrier());
+}
+
+/**
+ * @brief Unittest that checks that pages that have been written
+ * transition from S/SW to S following an upgrade barrier, and that
+ * these pages remain in the node cache following self-invalidation.
+ */
+TEST_F(barrierTest, barrierUpgradeWriters) {
+	std::size_t num_pages = 32;
+	const char a = 'a';
+	char* c_array = argo::conew_array<char>(page_size*num_pages);
+
+	// Write data on node 0
+	if(argo::node_id() == 0) {
+		for(std::size_t i = 0; i < page_size*num_pages; i++) {
+			c_array[i] = a;
+		}
+	}
+	argo::barrier();
+
+	// Read data on all nodes
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], a);
+	}
+	// Upgrade all non-private pages to shared
+	argo::barrier_upgrade_writers();
+
+	// Read data on all nodes and self-invalidate through a barrier
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], a);
+	}
+	argo::barrier();
+
+	// Check that all nodes have all pages cached (or local)
+	for(std::size_t n = 0; n < num_pages; n++) {
+		ASSERT_TRUE(argo::backend::is_cached(&c_array[n*page_size]));
+	}
+}
+
+/**
+ * @brief Unittest that checks that pages that have been upgraded
+ * before being accessed for the first time are correctly
+ * recognized as state S, and not invalidated at self-invalidation.
+ */
+TEST_F(barrierTest, barrierReadUpgraded) {
+	std::size_t num_pages = 32;
+	const char a = 'a';
+	char* c_array = argo::conew_array<char>(page_size*num_pages);
+
+	// Write data on node 0
+	if(argo::node_id() == 0) {
+		for(std::size_t i = 0; i < page_size*num_pages; i++) {
+			c_array[i] = a;
+		}
+	}
+	// Upgrade all non-private pages to shared
+	argo::barrier_upgrade_writers();
+
+	// Read data on all nodes and self-invalidate through a barrier
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], a);
+	}
+	argo::barrier();
+
+	// Check that all nodes have all pages cached (or local)
+	for(std::size_t n = 0; n < num_pages; n++) {
+		ASSERT_TRUE(argo::backend::is_cached(&c_array[n*page_size]));
+	}
+}
+
+/**
+ * @brief Unittest that checks that pages that have been upgraded
+ * and subsequently written correctly transition from S to S/SW
+ * and are invalidated from the node cache at self-invalidation.
+ */
+TEST_F(barrierTest, barrierDowngradeAfterUpgrade) {
+	const std::size_t num_pages = 32;
+	const char a = 'a';
+	const char b = 'b';
+	char* c_array = argo::conew_array<char>(page_size*num_pages);
+
+	// Write data on node 0
+	if(argo::node_id() == 0) {
+		for(std::size_t i = 0; i < page_size*num_pages; i++) {
+			c_array[i] = a;
+		}
+	}
+	argo::barrier();
+
+	// Read data on all nodes
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], a);
+	}
+	// Upgrade all non-private pages to shared
+	argo::barrier_upgrade_writers();
+
+	// Write to the same pages again
+	if(argo::node_id() == 0) {
+		for(std::size_t i = 0; i < page_size*num_pages; i++) {
+			c_array[i] = b;
+		}
+	}
+	argo::barrier();
+
+	// Read data again all nodes
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], b);
+	}
+	argo::barrier();
+
+	// Check that no node besides 0 has anything cached
+	if(argo::node_id() != 0) {
+		for(std::size_t n = 0; n < num_pages; n++) {
+			if(argo::get_homenode(&c_array[n*page_size]) != argo::node_id()) {
+				ASSERT_FALSE(argo::backend::is_cached(&c_array[n*page_size]));
+			}
+		}
+	}
+}
+
+/**
+ * @brief Unittest that checks that pages transition to state P following
+ * an upgrade all barrier, and that all of these pages remain in the node
+ * cache following self-invalidation.
+ */
+TEST_F(barrierTest, barrierUpgradeAll) {
+	const std::size_t num_pages = 32;
+	const char a = 'a';
+	char* c_array = argo::conew_array<char>(page_size*num_pages);
+
+	// Write data on node 0
+	if(argo::node_id() == 0) {
+		for(std::size_t i = 0; i < page_size*num_pages; i++) {
+			c_array[i] = a;
+		}
+	}
+	argo::barrier();
+
+	// Read data on all nodes
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], a);
+	}
+
+	// Upgrade all pages to private
+	argo::barrier_upgrade_all();
+
+	// Check that no node has anything cached
+	for(std::size_t n = 0; n < num_pages; n++) {
+		if(argo::get_homenode(&c_array[n*page_size]) != argo::node_id()) {
+			ASSERT_FALSE(argo::backend::is_cached(&c_array[n*page_size]));
+		}
+	}
+
+	// Read data on all nodes
+	for(std::size_t i = 0; i < page_size*num_pages; i++) {
+		ASSERT_EQ(c_array[i], a);
+	}
+	argo::barrier();
+
+	// Check that all nodes have all pages cached (or local)
+	for(std::size_t n = 0; n < num_pages; n++) {
+		ASSERT_TRUE(argo::backend::is_cached(&c_array[n*page_size]));
+	}
 }
 
 /**
@@ -80,6 +245,7 @@ TEST_P(barrierTest, threadBarrier) {
 
 /** @brief Test from 0 threads to max_threads, both inclusive */
 INSTANTIATE_TEST_CASE_P(threadCount, barrierTest, ::testing::Range(0, max_threads+1));
+
 
 /**
  * @brief The main function that runs the tests


### PR DESCRIPTION
This PR introduces two classification upgrade barriers, both extensions of the regular ArgoDSM barrier. These barriers provide the missing classification upgrades from _shared with at least one writer to shared_, as well as _shared (with or without writers) to private_. 

The benefit of the first barrier (`argo::barrier_upgrade_writers()` upgrade to S) is apparent in the case where data is written at one point, and afterwards repeatedly read but not written. Transitioning all pages to at worst S means these can be kept in the cache at each synchronization point.
The benefit of the second barrier (`argo::barrier_upgrade_all()`upgrade to P) is less apparent, but may be useful if pages with many readers, but at most one writer, introduces a second writer, as this prevents remotely downgrading many sharers (_S>S+SW_ or _S+SW>S+MW_).

Four unit tests that test the functionality of the barriers are also included. Suggestions for better API function names are welcome.