### PR TITLE
Disable ArgoDSM atomics of size other than 4/8 bytes

### DIFF
--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -66,18 +66,21 @@ extern sem_t ibsem;
  *
  * @param size The size of the datatype to be returned
  * @return An MPI datatype with MPI_Type_size == size
+ * @todo Either remove the 1/2 byte case entirely, or return at least 4 bytes and
+ * enforce 4 byte alignment of any MPI operations using the returned type.
  */
 static MPI_Datatype fitting_mpi_int(std::size_t size) {
 	MPI_Datatype t_type;
 	using namespace argo;
 
 	switch (size) {
-	case 1:
-		t_type = MPI_INT8_T;
-		break;
-	case 2:
-		t_type = MPI_INT16_T;
-		break;
+	// Until UCX supports 1/2 byte atomics, they must be disabled
+	//case 1:
+	//	t_type = MPI_INT8_T;
+	//	break;
+	//case 2:
+	//	t_type = MPI_INT16_T;
+	//	break;
 	case 4:
 		t_type = MPI_INT32_T;
 		break;
@@ -86,7 +89,7 @@ static MPI_Datatype fitting_mpi_int(std::size_t size) {
 		break;
 	default:
 		throw std::invalid_argument(
-			"Invalid size (must be either 1, 2, 4 or 8)");
+			"Invalid size (must be either 4 or 8)");
 		break;
 	}
 
@@ -98,18 +101,21 @@ static MPI_Datatype fitting_mpi_int(std::size_t size) {
  *
  * @param size The size of the datatype to be returned
  * @return An MPI datatype with MPI_Type_size == size
+ * @todo Either remove the 1/2 byte case entirely, or return at least 4 bytes and
+ * enforce 4 byte alignment of any MPI operations using the returned type.
  */
 static MPI_Datatype fitting_mpi_uint(std::size_t size) {
 	MPI_Datatype t_type;
 	using namespace argo;
 
 	switch (size) {
-	case 1:
-		t_type = MPI_UINT8_T;
-		break;
-	case 2:
-		t_type = MPI_UINT16_T;
-		break;
+	// Until UCX supports 1/2 byte atomics, they must be disabled
+	//case 1:
+	//	t_type = MPI_UINT8_T;
+	//	break;
+	//case 2:
+	//	t_type = MPI_UINT16_T;
+	//	break;
 	case 4:
 		t_type = MPI_UINT32_T;
 		break;
@@ -118,7 +124,7 @@ static MPI_Datatype fitting_mpi_uint(std::size_t size) {
 		break;
 	default:
 		throw std::invalid_argument(
-			"Invalid size (must be either 1, 2, 4 or 8)");
+			"Invalid size (must be either 4 or 8)");
 		break;
 	}
 
@@ -142,12 +148,13 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 	case 8:
 		t_type = MPI_DOUBLE;
 		break;
-	case 16:
-		t_type = MPI_LONG_DOUBLE;
-		break;
+	// Until UCX supports 16 byte atomics, it must be disabled
+	//case 16:
+	//	t_type = MPI_LONG_DOUBLE;
+	//	break;
 	default:
 		throw std::invalid_argument(
-			"Invalid size (must be power either 4, 8 or 16)");
+			"Invalid size (must be power either 4, 8)");
 		break;
 	}
 

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -66,9 +66,11 @@ class backendTest : public testing::Test, public ::testing::WithParamInterface<i
  * The writes are performed by all the nodes at the same time
  */
 TEST_F(backendTest, atomicXchgAll) {
-	global_char _c(argo::conew_<char>(0));
-	argo::backend::atomic::exchange(_c, c_const);
-	ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
+	//@todo This test is disabled as OpenUCX only supports
+	//atomic MPI operations of size 4 and 8 bytes.
+	//global_char _c(argo::conew_<char>(0));
+	//argo::backend::atomic::exchange(_c, c_const);
+	//ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
 
 	global_int _i(argo::conew_<int>(0));
 	argo::backend::atomic::exchange(_i, i_const);
@@ -89,11 +91,13 @@ TEST_F(backendTest, atomicXchgAll) {
  * The writes are only performed by one node
  */
 TEST_F(backendTest, atomicXchgOne) {
-	global_char _c(argo::conew_<char>());
-	if (argo::backend::node_id() == 0)
-		argo::backend::atomic::exchange(_c, c_const);
-	argo::backend::barrier();
-	ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
+	//@todo This test is disabled as OpenUCX only supports
+	//atomic MPI operations of size 4 and 8 bytes.
+	//global_char _c(argo::conew_<char>());
+	//if (argo::backend::node_id() == 0)
+	//	argo::backend::atomic::exchange(_c, c_const);
+	//argo::backend::barrier();
+	//ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
 
 	global_int _i(argo::conew_<int>());
 	if (argo::backend::node_id() == 0)
@@ -124,11 +128,13 @@ TEST_F(backendTest, atomicXchgOne) {
  * @brief Test atomic stores
  */
 TEST_F(backendTest, storeOne) {
-	global_char _c(argo::conew_<char>());
-	if (argo::backend::node_id() == 0)
-		argo::backend::atomic::store(_c, c_const);
-	argo::backend::barrier();
-	ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
+	//@todo This test is disabled as OpenUCX only supports
+	//atomic MPI operations of size 4 and 8 bytes.
+	//global_char _c(argo::conew_<char>());
+	//if (argo::backend::node_id() == 0)
+	//	argo::backend::atomic::store(_c, c_const);
+	//argo::backend::barrier();
+	//ASSERT_EQ(c_const, argo::backend::atomic::load(_c));
 
 	global_int _i(argo::conew_<int>());
 	if (argo::backend::node_id() == 0)
@@ -163,13 +169,15 @@ TEST_F(backendTest, storeOne) {
  * To prevent deadlocks, there is a timeout in every spinloop.
  */
 TEST_F(backendTest, loadOne) {
-	global_char _c(argo::conew_<char>());
-	if (argo::backend::node_id() == 0)
-		argo::backend::atomic::store(_c, c_const);
-	std::chrono::system_clock::time_point max_time =
-		std::chrono::system_clock::now() + deadlock_threshold;
-	while(argo::backend::atomic::load(_c) != c_const)
-		ASSERT_LT(std::chrono::system_clock::now(), max_time);
+	std::chrono::system_clock::time_point max_time;
+	//@todo This test is disabled as OpenUCX only supports
+	//atomic MPI operations of size 4 and 8 bytes.
+	//global_char _c(argo::conew_<char>());
+	//if (argo::backend::node_id() == 0)
+	//	argo::backend::atomic::store(_c, c_const);
+	//max_time = std::chrono::system_clock::now() + deadlock_threshold;
+	//while(argo::backend::atomic::load(_c) != c_const)
+	//	ASSERT_LT(std::chrono::system_clock::now(), max_time);
 
 	global_int _i(argo::conew_<int>());
 	if (argo::backend::node_id() == 0)


### PR DESCRIPTION
This PR disables 1, 2 and 16 byte datatype support for ArgoDSM atomics and their related unit tests, and leaves only 4 and 8 byte support. This is due to lack of support in UCX for atomic MPI operations of size other than 4 and 8 bytes.

While 1 and 2 byte MPI atomics are supposed to _all back to active (two-sided) messaging_ in UCX, this does not always seem to happen for a number of MPI atomics (`MPI_Fetch_and_op` used to implement `argo::backend::atomic::exchange` most notably in our case), and is most likely not desirable for performance reasons in the first place.

My suggestion is to leave this commented out in the code for now, and add an issue to further research this and based on findings either implement a solution or entirely remove the commented code and document this.