### PR TITLE
Align all memory allocations

### DIFF
--- a/src/allocators/generic_allocator.hpp
+++ b/src/allocators/generic_allocator.hpp
@@ -221,7 +221,7 @@ namespace argo {
 
 					// Align the requested memory size in chunks of the alignment specified
 					// by max_align_t to ensure that all allocations are well aligned
-					std::size_t aligned_alloc_size = align_up(n*sizeof(T), alignof(std::max_align_t));
+					std::size_t aligned_alloc_size = align_up(n * sizeof(T), alignof(std::max_align_t));
 
 					// Update the number of elements that will actually be allocated after
 					// alignment so that the freelist and allocation_size table are correct
@@ -275,7 +275,7 @@ namespace argo {
 				 * @param n the number of elements of type T to deallocate
 				 */
 				void deallocate(T* ptr, size_t n) {
-					std::size_t aligned_alloc_size = align_up(n*sizeof(T), alignof(std::max_align_t));
+					std::size_t aligned_alloc_size = align_up(n * sizeof(T), alignof(std::max_align_t));
 					std::size_t aligned_n = aligned_alloc_size / sizeof(T);
 					lock->lock();
 					deallocate_nosync(ptr, aligned_n);


### PR DESCRIPTION
This PR ensures that all memory allocations are aligned to at least the alignment of `std::max_align_t` (defined since C++11). This is achieved by ensuring that the size of all allocations is a multiple of `std::max_align_t`. Aligning the size (end) of each allocation rather than the start of each allocation ensures that a scalar type allocation that has been deallocated (and added to the freelist) can be reused by other scalar types.

The PR fixes UCX errors regarding misaligned atomic instructions in the ArgoDSM atomic interface (also used by the global TAS lock and cohort locks).

I have also included two tests that:
- test the alignment for the different allocators functions available
- test reallocating deallocated memory