### PR TITLE
Remove checks for using obsolete compilers

### DIFF
--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -435,12 +435,10 @@ namespace argo {
 					"It is not possible to implicitly convert \'desired\' to an"
 					" object of type T.");
 				T desired_buffer(desired);
-#if __GNUC__ >= 5 || __clang__
 				static_assert(
 					std::is_trivially_copy_assignable<T>::value,
 					"T must be trivially copy assignable"
 				);
-#endif // __GNUC__ >= 5 || __clang__
 
 				if (order == memory_order::acq_rel || order == memory_order::release)
 					release();
@@ -471,12 +469,10 @@ namespace argo {
 					"It is not possible to implicitly convert \'desired\' to an"
 					" object of type T.");
 				T desired_buffer(desired);
-#if __GNUC__ >= 5 || __clang__
 				static_assert(
 					std::is_trivially_copy_assignable<T>::value,
 					"T must be trivially copy assignable"
 				);
-#endif // __GNUC__ >= 5 || __clang__
 
 				if (order == memory_order::acq_rel || order == memory_order::release)
 					release();
@@ -500,12 +496,10 @@ namespace argo {
 			template<typename T>
 			T load(global_ptr<T> obj, memory_order order = memory_order::acquire) {
 				T out_buffer;
-#if __GNUC__ >= 5 || __clang__
 				static_assert(
 					std::is_trivially_copy_assignable<T>::value,
 					"T must be trivially copy assignable"
 				);
-#endif // __GNUC__ >= 5 || __clang__
 
 				if (order == memory_order::acq_rel || order == memory_order::release)
 					release();
@@ -545,12 +539,10 @@ namespace argo {
 					" object of type T.");
 				T expected_buffer(expected);
 				T desired_buffer(desired);
-#if __GNUC__ >= 5 || __clang__
 				static_assert(
 					std::is_trivially_copy_assignable<T>::value,
 					"T must be trivially copy assignable"
 				);
-#endif // __GNUC__ >= 5 || __clang__
 
 				if (order == memory_order::acq_rel || order == memory_order::release)
 					release();
@@ -584,12 +576,10 @@ namespace argo {
 					"It is not possible to implicitly convert \'desired\' to an"
 					" object of type T.");
 				T value_buffer(value);
-#if __GNUC__ >= 5 || __clang__
 				static_assert(
 					std::is_trivially_copy_assignable<T>::value,
 					"T must be trivially copy assignable"
 				);
-#endif // __GNUC__ >= 5 || __clang__
 
 				if (order == memory_order::acq_rel || order == memory_order::release)
 					release();


### PR DESCRIPTION
It is highly unlikely that Argo will be compiled with anything else
than relatively modern versions of GCC or Clang. Remove some checks
around code which was not included if compiling with an old version
of GCC or some compiler othen than modern GCC or Clang.