### PR TITLE
Enable compiler warnings regardless of optimization level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,16 @@
 cmake_minimum_required(VERSION 3.3)
 project(ArgoDSM VERSION 0.1)
 
-set(DEFAULT_C_FLAGS "-std=c17 -pthread")
-set(DEFAULT_CXX_FLAGS "-std=c++17 -pthread -DOMPI_SKIP_MPICXX=1")
+set(DEFAULT_C_FLAGS "-std=c17 -pthread -Wall -Wextra -Werror")
+set(DEFAULT_CXX_FLAGS "-std=c++17 -pthread -DOMPI_SKIP_MPICXX=1 -Wall -Wextra -Werror")
 set(DEFAULT_LINK_FLAGS "")
 
 option(ARGO_DEBUG
 	"Build ArgoDSM without optimization and with debugging symbols" OFF)
 if(ARGO_DEBUG)
-	set(DEFAULT_C_FLAGS "${DEFAULT_C_FLAGS} -O0 -g -Wall -Wextra -Werror")
-	set(DEFAULT_CXX_FLAGS
-		"${DEFAULT_CXX_FLAGS} -O0 -g -Wall -Wextra -Werror")
-	set(DEFAULT_LINK_FLAGS "${DEFAULT_LINK_FLAGS} -g -Wall -Wextra -Werror")
+	set(DEFAULT_C_FLAGS "${DEFAULT_C_FLAGS} -O0 -g")
+	set(DEFAULT_CXX_FLAGS "${DEFAULT_CXX_FLAGS} -O0 -g")
+	set(DEFAULT_LINK_FLAGS "${DEFAULT_LINK_FLAGS} -g")
 else(ARGO_DEBUG)
 	set(DEFAULT_C_FLAGS "${DEFAULT_C_FLAGS} -O3 -DNDEBUG")
 	set(DEFAULT_CXX_FLAGS "${DEFAULT_CXX_FLAGS} -O3 -DNDEBUG")

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -478,7 +478,7 @@ void handler(int sig, siginfo_t *si, void *context){
 #endif /* REG_ERR */
 	double t1 = MPI_Wtime();
 	std::uintptr_t tag;
-	argo_byte owner,state;
+	argo_byte state;
 
 	/* compute offset in distributed memory in bytes, always positive */
 	const std::size_t access_offset = static_cast<char*>(si->si_addr) - static_cast<char*>(startAddr);
@@ -579,9 +579,10 @@ void handler(int sig, siginfo_t *si, void *context){
 
 			/* remote single writer */
 			if(writers != id && writers != 0 && isPowerOf2(writers&invid)){
+				argo::node_id_t owner = 0;
 				for(argo::node_id_t n = 0; n < numtasks; n++){
 					if((static_cast<std::uint64_t>(1)<<n)==(writers&invid)){
-						owner = n; //just get rank...
+						owner = n;  // just get rank...
 						break;
 					}
 				}
@@ -667,9 +668,10 @@ void handler(int sig, siginfo_t *si, void *context){
 
 		/* check if we need to update */
 		if(writers != id && writers != 0 && isPowerOf2(writers&invid)){
+			argo::node_id_t owner = 0;
 			for(argo::node_id_t n = 0; n < numtasks; n++){
 				if((static_cast<std::uint64_t>(1)<<n)==(writers&invid)){
-					owner = n; //just get rank...
+					owner = n;  // just get rank...
 					break;
 				}
 			}


### PR DESCRIPTION
Compiler warnings should be enabled regardless of whether building
with debugging support or with optimizations on.

Also, compiler warning command-line options do not make sense when
linking, so they can be taken out from there.

While at it, fix some compiler warning that only shows up with -O3.