### PR TITLE
Add -pedantic to compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,8 @@
 cmake_minimum_required(VERSION 3.3)
 project(ArgoDSM VERSION 0.1)
 
-
-set(DEFAULT_C_FLAGS "-std=c17 -pthread -Wall -Wextra -Werror")
-set(DEFAULT_CXX_FLAGS "-std=c++17 -pthread -DOMPI_SKIP_MPICXX=1 -Wall -Wextra -Werror")
+set(DEFAULT_C_FLAGS "-std=c17 -pthread -Wall -Wextra -pedantic -Werror")
+set(DEFAULT_CXX_FLAGS "-std=c++17 -pthread -DOMPI_SKIP_MPICXX=1 -Wall -Wextra -pedantic -Werror")
 set(DEFAULT_LINK_FLAGS "")
 
 option(ARGO_DEBUG


### PR DESCRIPTION
From 2022 (when this PR was opened) up until now (using gcc 13.3.0), enabling the `-pedantic` compiler option does not result in any (additional) warnings from the compiler.  Therefore, I suggest we add this to get notified if we ever do any code modifications that break some of the pedantic compiler checks.