### PR TITLE
Move extern declarations to swdsm.h

### DIFF
--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -7,14 +7,6 @@
 #include "../backend.hpp"
 #include "swdsm.h"
 #include "virtual_memory/virtual_memory.hpp"
-#include "write_buffer.hpp"
-
-/**
- * @brief Write buffer to ensure selectively handled pages can be removed
- * @deprecated This should eventually be handled by a cache module
- * @see swdsm.cpp
- */
-extern write_buffer<std::size_t>* argo_write_buffer;
 
 namespace argo {
 	namespace backend {

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -6,53 +6,13 @@
 
 #include "../backend.hpp"
 #include "swdsm.h"
-#include "write_buffer.hpp"
 #include "virtual_memory/virtual_memory.hpp"
+#include "write_buffer.hpp"
 
-// EXTERNAL VARIABLES FROM BACKEND
-/**
- * @brief This is needed to access page information from the cache
- * @deprecated Should be replaced with a cache API
- */
-extern control_data *cacheControl;
-/**
- * @brief globalSharers is needed to access and modify the pyxis directory
- * @deprecated Should eventually be handled by a cache module
- */
-extern std::uint64_t *globalSharers;
-/**
- * @brief A cache mutex protects all operations on cacheControl
- * @deprecated Should eventually be handled by a cache module
- */
-extern pthread_mutex_t cachemutex;
-/**
- * @brief ibsem is used to serialize all Infiniband (MPI) operations
- * @deprecated Should not be needed once the cache module is implemented
- */
-extern sem_t ibsem;
-/**
- * @brief sharerWindow protects the pyxis directory
- * @deprecated Should not be needed once the pyxis directory is
- * managed from elsewhere through a cache module.
- */
-extern MPI_Win sharerWindow;
-/**
- * @brief Needed to update argo statistics
- * @deprecated Should be replaced by API calls to a stats module
- */
-extern argo_statistics stats;
-/**
- * @brief Needed to update information about cache pages touched
- * @deprecated Should eventually be handled by a cache module
- */
-extern argo_byte *touchedcache;
-/**
- * @brief workcomm is needed to poke the MPI system during one sided RMA
- */
-extern MPI_Comm workcomm;
 /**
  * @brief Write buffer to ensure selectively handled pages can be removed
  * @deprecated This should eventually be handled by a cache module
+ * @see swdsm.cpp
  */
 extern write_buffer<std::size_t>* argo_write_buffer;
 

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -14,54 +14,6 @@
 #include "swdsm.h"
 
 /**
- * @brief MPI communicator for node processes
- * @deprecated prototype implementation detail
- * @see swdsm.h
- * @see swdsm.cpp
- */
-extern MPI_Comm workcomm;
-/**
- * @todo MPI communication channel for exclusive accesses
- * @deprecated prototype implementation detail
- * @see swdsm.h
- * @see swdsm.cpp
- */
-extern MPI_Win  *globalDataWindow;
-
-/**
- * @brief MPI window for the first-touch data distribution
- * @see swdsm.cpp
- * @see first_touch_distribution.hpp
- */
-extern MPI_Win owners_dir_window;
-/**
- * @brief MPI window for the first-touch data distribution
- * @see swdsm.cpp
- * @see first_touch_distribution.hpp
- */
-extern MPI_Win offsets_tbl_window;
-/**
- * @brief MPI directory for the first-touch data distribution
- * @see swdsm.cpp
- * @see first_touch_distribution.hpp
- */
-extern std::uintptr_t *global_owners_dir;
-/**
- * @brief MPI table for the first-touch data distribution
- * @see swdsm.cpp
- * @see first_touch_distribution.hpp
- */
-extern std::uintptr_t *global_offsets_tbl;
-
-/**
- * @todo should be changed to qd-locking (but need to be replaced in the other files as well)
- *       or removed when infiniband/the mpi implementations allows for multithreaded accesses to the interconnect
- * @deprecated prototype implementation detail
- */
-#include <semaphore.h>
-extern sem_t ibsem;
-
-/**
  * @brief Returns an MPI integer type that exactly matches in size the argument given
  *
  * @param size The size of the datatype to be returned

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -11,7 +11,6 @@
 #include "virtual_memory/virtual_memory.hpp"
 #include "data_distribution/global_ptr.hpp"
 #include "swdsm.h"
-#include "write_buffer.hpp"
 
 namespace dd = argo::data_distribution;
 namespace vm = argo::virtual_memory;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -124,6 +124,87 @@ static const argo_byte READER = 5;
  */
 constexpr std::size_t page_size = 4096;
 
+/* External declarations */
+/**
+ * @brief Argo cache data structure
+ * @deprecated Should be replaced with a cache API
+ */
+extern control_data* cacheControl;
+/**
+ * @brief globalSharers is needed to access and modify the pyxis directory
+ * @deprecated Should eventually be handled by a cache module
+ * @see swdsm.cpp
+ */
+extern std::uint64_t* globalSharers;
+/**
+ * @brief A cache mutex protects all operations on cacheControl
+ * @deprecated Should eventually be handled by a cache module
+ * @see swdsm.cpp
+ */
+extern pthread_mutex_t cachemutex;
+/**
+ * @brief ibsem is used to serialize all Infiniband (MPI) operations
+ * @deprecated Should not be needed once the cache module or a parallel
+ * MPI communication is allowed.
+ * @see swdsm.cpp
+ */
+extern sem_t ibsem;
+/**
+ * @todo MPI communication channel for exclusive accesses
+ * @deprecated MPI communication should be handled by a module and
+ * accessed through a proper API
+ * @see swdsm.cpp
+ */
+extern MPI_Win* globalDataWindow;
+/**
+ * @brief sharerWindow protects the pyxis directory
+ * @deprecated Should not be needed once the pyxis directory is
+ * managed from elsewhere through a cache module.
+ * @see swdsm.cpp
+ */
+extern MPI_Win sharerWindow;
+/**
+ * @brief Needed to update argo statistics
+ * @deprecated Should be replaced by API calls to a stats module
+ * @see swdsm.cpp
+ */
+extern argo_statistics stats;
+/**
+ * @brief Needed to update information about cache pages touched
+ * @deprecated Should eventually be handled by a cache module
+ */
+extern argo_byte* touchedcache;
+/**
+ * @brief MPI communicator for node processes
+ * @deprecated prototype implementation detail
+ * @see swdsm.cpp
+ */
+extern MPI_Comm workcomm;
+/**
+ * @brief MPI window for the first-touch data distribution
+ * @see swdsm.cpp
+ * @see first_touch_distribution.hpp
+ */
+extern MPI_Win owners_dir_window;
+/**
+ * @brief MPI window for the first-touch data distribution
+ * @see swdsm.cpp
+ * @see first_touch_distribution.hpp
+ */
+extern MPI_Win offsets_tbl_window;
+/**
+ * @brief MPI directory for the first-touch data distribution
+ * @see swdsm.cpp
+ * @see first_touch_distribution.hpp
+ */
+extern std::uintptr_t* global_owners_dir;
+/**
+ * @brief MPI table for the first-touch data distribution
+ * @see swdsm.cpp
+ * @see first_touch_distribution.hpp
+ */
+extern std::uintptr_t* global_offsets_tbl;
+
 /*Handler*/
 /**
  * @brief Catches memory accesses to memory not yet cached in ArgoDSM. Launches remote requests for memory not present.

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -205,6 +205,22 @@ extern std::uintptr_t* global_owners_dir;
  */
 extern std::uintptr_t* global_offsets_tbl;
 
+/**
+ * @brief stores a page remotely - only writing back what has been written locally since last synchronization point
+ * @param index index in local page cache
+ * @param addr address to page in global address space
+ */
+extern void storepageDIFF(std::size_t index, std::uintptr_t addr);
+
+/*Write Buffer*/
+#include "write_buffer.hpp"  // Needed only in the line below
+/**
+ * @brief Write buffer to ensure selectively handled pages can be removed
+ * @deprecated This should eventually be handled by a cache module
+ * @see swdsm.cpp
+ */
+extern write_buffer<std::size_t>* argo_write_buffer;
+
 /*Handler*/
 /**
  * @brief Catches memory accesses to memory not yet cached in ArgoDSM. Launches remote requests for memory not present.
@@ -268,13 +284,6 @@ void argo_release();
  *        according to Release Consistency)
  */
 void argo_acq_rel();
-
-/**
- * @brief stores a page remotely - only writing back what has been written locally since last synchronization point
- * @param index index in local page cache
- * @param addr address to page in global address space
- */
-void storepageDIFF(std::size_t index, std::uintptr_t addr);
 
 /*Statistics*/
 /**

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -20,18 +20,6 @@
 #include "swdsm.h"
 #include "qd.hpp"
 
-/**
- * @brief		Argo statistics struct
- * @deprecated 	This should be replaced with an API call
- */
-extern argo_statistics stats;
-
-/**
- * @brief		Argo cache data structure
- * @deprecated 	prototype implementation, should be replaced with API calls
- */
-extern control_data* cacheControl;
-
 /** @brief Block size based on backend definition */
 const std::size_t block_size = page_size*CACHELINE;
 

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -17,7 +17,6 @@
 #include "backend/backend.hpp"
 #include "env/env.hpp"
 #include "virtual_memory/virtual_memory.hpp"
-#include "swdsm.h"
 #include "qd.hpp"
 
 /** @brief Block size based on backend definition */


### PR DESCRIPTION
This PR moves all external declarations to `swdsm.h`.
This is suitable as all of their definitions exist in `swdsm.cpp`.