### PR TITLE
Fix two empty while loop bodies

### DIFF
--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -374,7 +374,7 @@ class write_buffer
 
 			// Wait until flush is completed
 			double w_start = MPI_Wtime();
-			while(!w_flag.load(std::memory_order_acquire));
+			while(!w_flag.load(std::memory_order_acquire)) {}
 			double w_end = MPI_Wtime();
 
 			std::lock_guard<std::mutex> stat_lock(_stat_mutex);

--- a/src/synchronization/intranode/ticket_lock.hpp
+++ b/src/synchronization/intranode/ticket_lock.hpp
@@ -31,7 +31,7 @@ namespace locallock {
 			 */
 			void lock() {
 				int ticket = in_counter.fetch_add(1, std::memory_order_relaxed);
-				while(out_counter.load(std::memory_order_acquire) != ticket);
+				while(out_counter.load(std::memory_order_acquire) != ticket) {}
 			}
 
 			/**


### PR DESCRIPTION
by using {} instead of a ; for their empty body.