### PR TITLE
Update documentation with new environment variables and OpenMPI recommendations

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -15,6 +15,7 @@ ArgoDSM.
 - [Remote Page Loading and Prefetching](#remote-page-loading-and-prefetching)
 - [Write-buffer Tuning](#write-buffer-tuning)
 - [Multi-threaded MPI Support](#multi-threaded-mpi-support)
+- [ArgoDSM statistics](#argodsm-statistics)
 
 
 ## Allocation Parameters
@@ -229,3 +230,45 @@ export ARGO_WRITE_BUFFER_WRITE_BACK_SIZE=64
 
 ArgoDSM now requires and utilizes multi-threaded MPI. Please ensure that
 your MPI installation supports `MPI_THREAD_MULTIPLE`.
+
+ArgoDSM uses multiple MPI windows in order to achieve parallelism between
+simultaneous MPI operations. Greater possible parallelism can be achieved
+by increasing the amount of MPI windows used, but creating too many windows
+incurs an initialization and finalization time penalty. The number of MPI
+windows used can be controlled by setting the `ARGO_MPI_WINDOWS_PER_NODE`
+environment variable to the desired setting.
+
+```sh
+export ARGO_MPI_WINDOWS_PER_NODE=8
+```
+
+The default value of this environment variable is `4` when multiple
+ArgoDSM nodes are used, and `1` in a single node setting. Note that the
+total number of MPI windows created depends on the number of ArgoDSM nodes
+(MPI processes) for a total of `ARGO_MPI_WINDOWS_PER_NODE*$NNODES*$NNODES*2`
+MPI windows created per node. Your system may impose a hard limit on the
+number of MPI windows created, and while the default value should be suitable
+for most systems, if you experience significant startup times or crashes
+during startup, consider lowering the number of MPI windows per node.
+
+
+## ArgoDSM Statistics
+
+ArgoDSM prints basic statistics after shutting down in order to give the
+user an idea of how ArgoDSM behaves and to identify areas of improvement in
+ArgoDSM utilization and tuning. The detail of the statistics printed can be
+controlled by the `ARGO_PRINT_STATISTICS` environment variable as follows:
+
+```sh
+export ARGO_PRINT_STATISTICS=3
+```
+
+The different options available are detailed below.
+- 0: Disable the statistics printout
+- 1: Print overall system statistics
+- 2: In addition to 1, print basic statistics for each ArgoDSM node
+- 3: In addition to 2, print detailed statistics for each ArgoDSM node
+
+Finally, it may be convenient to record statistics from a certain point
+in the user code, such as after data initialization. To achieve this, the
+ArgoDSM statistics can be reset by calling `argo::backend::reset_stats()`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,11 @@ If you want to build the documentation,
 [doxygen](http://www.stack.nl/~dimitri/doxygen/) is required.
 
 The only distributed backend ArgoDSM currently supports is the MPI one, so a
-compiler and libraries for MPI are required. If you are using OpenMPI, make sure
-you are running at least version 1.8.4. Installing OpenMPI is [fairly
-easy](https://www.open-mpi.org/faq/?category=building#easy-build), but you
-should contact your system administrator if you are uncertain about it.
+compiler and libraries for MPI are required. If you are using OpenMPI, we
+recommend using the latest stable release avaiable for your system.
+Installing OpenMPI is
+[fairly easy](https://www.open-mpi.org/faq/?category=building#easy-build), but
+you should contact your system administrator if you are uncertain about it.
 
 ArgoDSM depends on the
 [C++ QD Locking Library](https://github.com/davidklaftenegger/qd_library).
@@ -139,22 +140,28 @@ details. If you are using OpenMPI on a cluster with InfiniBand interconnects, we
 recommend the following:
 
 ``` bash
-mpirun --map-by ppr:1:node      \
-       --mca mpi_leave_pinned 1 \
-       --mca btl openib,self,sm \
-       -n ${NNODES}             \
+mpirun --map-by ppr:1:node  \
+       --mca pml ucx        \
+       --mca osc ucx        \
        ${EXECUTABLE}
 ```
 
-`${NNODES}` is the number of hardware nodes you have available and
-`${EXECUTABLE}` is the application to run. If you are not using InfiniBand, you
-can use the default OpenMPI transports by skipping the `--mca btl
-openib,self,sm` part  of the command.
+The number of nodes is controlled by your job scheduling system or by supplying
+`mpirun` with a nodelist, and `${EXECUTABLE}` is the application to run.
 
 If you are running on a cluster, please consult your system administrator for
 details on how to access the cluster's resources. We recommend running ArgoDSM
 applications with one ArgoDSM node per hardware node. We also strongly recommend
-InfiniBand interconnects when using the MPI backend.
+InfiniBand interconnects when using the MPI backend. If you are not using
+InfiniBand, you can use the default OpenMPI transports by excluding the `--mca`
+parameters.
+
+If you are not running on a cluster, you can instead specify the number of
+ArgoDSM nodes to run by passing `-n ${NNODES}` to mpirun as:
+
+``` bash
+mpirun -n ${NNODES} ${EXECUTABLE}
+```
 
 We **strongly recommend** running all of the MPI tests on at least two nodes
 before continueing working with ArgoDSM, to ensure that your system is

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,6 @@ ArgoDSM uses the CMake build system. In the next section, we will describe how
 to build ArgoDSM from scratch. However, before doing that, some dependencies are
 required.
 
-If you want to build the documentation,
-[doxygen](http://www.stack.nl/~dimitri/doxygen/) is required.
-
 The only distributed backend ArgoDSM currently supports is the MPI one, so a
 compiler and libraries for MPI are required. If you are using OpenMPI, we
 recommend using the latest stable release avaiable for your system.
@@ -27,10 +24,13 @@ ArgoDSM depends on the
 [C++ QD Locking Library](https://github.com/davidklaftenegger/qd_library).
 This is included as a git submodule and is built automatically by CMake,
 requiring both git and an internet connection. For instructions on how to build
-offline, see [building ArgoDSM offline](#Building-ArgoDSM-offline).
+offline, see [building ArgoDSM offline](#building-argodsm-offline).
 
 Additionally, ArgoDSM requires `libnuma` to detect whether it is running on top
 of NUMA systems, and if so how they are structured internally.
+
+If you want to build the documentation,
+[doxygen](https://www.doxygen.nl/) is required.
 
 Finally, C and C++ compilers that support the C17 and C++17 standards
 respectively are required.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -196,8 +196,9 @@ support office. A generic example with OpenMPI on a cluster utilizing Slurm
 might look like this:
 
 ``` bash
-mpirun --map-by ppr:1:node                                               \
-	--mca mpi_leave_pinned 1 --mca btl openib,self,sm -n ${SLURM_NNODES} \
-	./argo_example
+mpirun --map-by ppr:1:node  \
+       --mca pml ucx        \
+       --mca osc ucx        \
+       ./argo_example
 ```
 


### PR DESCRIPTION
This PR updates the advanced documentation to include the newly introduced `ARGO_MPI_WINDOWS_PER_NODE` and `ARGO_PRINT_STATISTICS` environment variables.

It also updates the quickstart guide and tutorial to use ucx instead of the deprecated openib module when using OpenMPI.

Finally, two broken links are fixed.