### PR TITLE
Fix const errors in virtual memory

### DIFF
--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -23,7 +23,7 @@
 namespace {
 	/* file constants */
 	/** @todo hardcoded start address */
-	const char* ARGO_START = (char*) 0x200000000000l;
+	char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
 	/** @todo hardcoded size */
 	const ptrdiff_t ARGO_SIZE = 0x80000000000l;
 
@@ -51,13 +51,13 @@ namespace argo {
 			/** @todo check desired range is free */
 			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED|MAP_NORESERVE;
 			backing_addr = static_cast<char*>(
-				::mmap((void*)ARGO_START, ARGO_SIZE, PROT_NONE, flags, -1, 0));
+				::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0));
 			if(backing_addr == MAP_FAILED) {
 				std::cerr << msg_main_mmap_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
 				exit(EXIT_FAILURE);
 			}
-			char* virtual_addr = (char*) ARGO_START + ARGO_SIZE/2l;
+			char* virtual_addr = ARGO_START + ARGO_SIZE/2l;
 			backing_offset = 0;
 			file_offset = virtual_addr - backing_addr;
 		}

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -22,9 +22,9 @@
 namespace {
 	/* file constants */
 	/** @todo hardcoded start address */
-	const char* ARGO_START = reinterpret_cast<char*>(0x200000000000l);
+	char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
 	/** @todo hardcoded end address */
-	const char* ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
+	char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
 	/** @todo hardcoded size */
 	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
 
@@ -54,7 +54,7 @@ namespace argo {
 			}
 			/** @todo check desired range is free */
 			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
-			start_addr = ::mmap(reinterpret_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0);
+			start_addr = ::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0);
 			if(start_addr == MAP_FAILED) {
 				std::cerr << msg_main_mmap_fail << std::endl;
 				/** @todo do something? */

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -24,9 +24,9 @@
 namespace {
 	/* file constants */
 	/** @todo hardcoded start address */
-	const char* ARGO_START = reinterpret_cast<char*>(0x200000000000l);
+	char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
 	/** @todo hardcoded end address */
-	const char* ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
+	char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
 	/** @todo hardcoded size */
 	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
 	/** @todo hardcoded maximum size */
@@ -72,7 +72,7 @@ namespace argo {
 			}
 			/** @todo check desired range is free */
 			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
-			start_addr = ::mmap((void*)ARGO_START, avail, PROT_NONE, flags, -1, 0);
+			start_addr = ::mmap(static_cast<void*>(ARGO_START), avail, PROT_NONE, flags, -1, 0);
 			if(start_addr == MAP_FAILED) {
 				std::cerr << msg_main_mmap_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);


### PR DESCRIPTION
This PR fixes an error in `virtual_memory/memfd` where a pointer to
const data is passed to `mmap` causing a compiler error when
building with MEMFD support. We can not pass a _pointer to const
data_ to `mmap` as `mmap` will attempt to alter the protection. The
_pointer itself_ can however be const.

Alternatively, If we explicitly want `ARGO_START` and
`ARGO_END` to point to const data, we need to cast the const
away with an explicit `const_cast` instead before passing it to
mmap. This does not feel like an intuitive solution to me, but correct
me if I'm wrong!

It also applies c++ casts where c casts were
used in `virtual_memory/anonymous`.