### PR TITLE
Do not indent inside namespaces

### DIFF
--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -15,13 +15,15 @@ The ArgoDSM Programming Guidelines
 2. There are no specific rules for where lines should break, as long as the
    formatting makes sense.
 
-3. The code follows the C/C++11 standards
+3. The code follows the C/C++17 standards
 
 ## Spacing
 
-1. Tabs should be used both for indentation and for alignment
+1. Tabs should be used both for indentation and for alignment.
 
-2. Namespaces, as well as public/private/protected labels should be indented
+2. Public/private/protected labels should be indented.
+
+3. Namespaces should not be indented.
 
 ## Naming
 

--- a/src/allocators/allocators.hpp
+++ b/src/allocators/allocators.hpp
@@ -11,10 +11,10 @@
 #include "dynamic_allocator.hpp"
 
 namespace argo {
-	/**
-	 * @brief namespace for ArgoDSM's own allocators
-	 */
-	namespace allocators { }
-} // namespace argo
+/**
+ * @brief namespace for ArgoDSM's own allocators
+ */
+namespace allocators {}
+}  // namespace argo
 
 #endif  // ARGODSM_SRC_ALLOCATORS_ALLOCATORS_HPP_

--- a/src/allocators/collective_allocator.hpp
+++ b/src/allocators/collective_allocator.hpp
@@ -40,251 +40,251 @@ extern "C" {
 }
 
 namespace argo {
-	namespace allocators {
-		/**
-		 * @brief type alias for collective allocator: allocate from dynamically growing pool (backed by global memory allocator) without locking
-		 */
-		using collective_allocator = generic_allocator<char, mempools::dynamic_memory_pool<global_allocator, mempools::NODE_ZERO_ONLY>, null_lock>;
-
-		/**
-		 * @brief default collective allocator, using bytes as base unit
-		 */
-		extern collective_allocator default_collective_allocator;
-
-	} // namespace allocators
+namespace allocators {
+	/**
+	 * @brief type alias for collective allocator: allocate from dynamically growing pool (backed by global memory allocator) without locking
+	 */
+	using collective_allocator = generic_allocator<char, mempools::dynamic_memory_pool<global_allocator, mempools::NODE_ZERO_ONLY>, null_lock>;
 
 	/**
-	 * @brief template function to construct new objects using collective allocation
-	 * @tparam T type to construct
-	 * @tparam APs Allocation parameters
-	 * @tparam Ps parameter types for constructor
-	 * @param ps parameters for constructor
-	 * @return pointer to newly constructed object
-	 * @sa new_
-	 *
-	 * The function might choose to initialize or synchronize, depending on the
-	 * type constructed or the arguments provided by the user.
-	 *
-	 * -# Initialization is performed by default.
-	 * -# If the type is trivial, then no initialization is performed.
-	 * -# If the user has provided constructor arguments, then initialization is
-	 *    performed.
-	 * -# The user can explicitly override these defaults using the appropriate
-	 *    allocation parameters (@ref argo::allocation).
-	 * -# Synchronization is performed after initialization.
-	 * -# The user can override the behaviour by using the allocation
-	 *    parameters.
-	 *
+	 * @brief default collective allocator, using bytes as base unit
 	 */
-	template<typename T, allocation... APs, typename... Ps>
-	T* conew_(Ps&&... ps) {
-		using aps = _internal::alloc_params<APs...>;
-		bool initialize = true;
-		bool synchronize = true;
+	extern collective_allocator default_collective_allocator;
 
-		// If the type is trivial, do not initialize
-		if (std::is_trivial<T>::value) {
-			initialize = false;
-		}
-		// If constructor arguments are given by the user, initialize
-		if (sizeof...(Ps) > 0) {
-			initialize = true;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::initialize) {
-			initialize = true;
-		} else if (aps::no_initialize) {
-			initialize = false;
-		}
-		// Synchronization goes hand to hand with initialization
-		synchronize = initialize;
-		// Again, the user can override the default behaviour
-		if (aps::synchronize) {
-			synchronize = true;
-		} else if (aps::no_synchronize) {
-			synchronize = false;
-		}
+} // namespace allocators
 
-		void* ptr = collective_alloc(sizeof(T));
-		using namespace data_distribution;
-		global_ptr<void> gptr(ptr, false, false);
-		// The home node of ptr handles initialization
-		if (initialize && argo::backend::node_id() == gptr.node()) {
-			new (ptr) T(std::forward<Ps>(ps)...);
-		}
-		// Do not return uninitialized memory to the nodes.
-		if (synchronize) {
-			argo::backend::barrier();
-		}
-		return static_cast<T*>(ptr);
+/**
+ * @brief template function to construct new objects using collective allocation
+ * @tparam T type to construct
+ * @tparam APs Allocation parameters
+ * @tparam Ps parameter types for constructor
+ * @param ps parameters for constructor
+ * @return pointer to newly constructed object
+ * @sa new_
+ *
+ * The function might choose to initialize or synchronize, depending on the
+ * type constructed or the arguments provided by the user.
+ *
+ * -# Initialization is performed by default.
+ * -# If the type is trivial, then no initialization is performed.
+ * -# If the user has provided constructor arguments, then initialization is
+ *    performed.
+ * -# The user can explicitly override these defaults using the appropriate
+ *    allocation parameters (@ref argo::allocation).
+ * -# Synchronization is performed after initialization.
+ * -# The user can override the behaviour by using the allocation
+ *    parameters.
+ *
+ */
+template<typename T, allocation... APs, typename... Ps>
+T* conew_(Ps&&... ps) {
+	using aps = _internal::alloc_params<APs...>;
+	bool initialize = true;
+	bool synchronize = true;
+
+	// If the type is trivial, do not initialize
+	if (std::is_trivial<T>::value) {
+		initialize = false;
+	}
+	// If constructor arguments are given by the user, initialize
+	if (sizeof...(Ps) > 0) {
+		initialize = true;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::initialize) {
+		initialize = true;
+	} else if (aps::no_initialize) {
+		initialize = false;
+	}
+	// Synchronization goes hand to hand with initialization
+	synchronize = initialize;
+	// Again, the user can override the default behaviour
+	if (aps::synchronize) {
+		synchronize = true;
+	} else if (aps::no_synchronize) {
+		synchronize = false;
 	}
 
-	/**
-	 * @brief template function to delete objects that were allocated using collective_new
-	 * @tparam T type of the object to deallocate
-	 * @tparam APs deallocation parameters
-	 * @param ptr pointer to the object to deallocate
-	 * @note T can usually be inferred from the type of ptr
-	 *
-	 * This function might choose to destruct or synchronize.
-	 *
-	 * -# The destructors are called by default (deinitialization).
-	 * -# If the type is trivially destructible, no destructors are called.
-	 * -# The user can explicitly override this behaviour (@ref argo::allocation).
-	 * -# If the destructor is called, the function will also synchronize.
-	 * -# The user can explicitly override this behaviour.
-	 *
-	 */
-	template<typename T, allocation... APs>
-	void codelete_(T* ptr) {
-		using aps = _internal::alloc_params<APs...>;
-		bool deinitialize = true;
-		bool synchronize = true;
+	void* ptr = collective_alloc(sizeof(T));
+	using namespace data_distribution;
+	global_ptr<void> gptr(ptr, false, false);
+	// The home node of ptr handles initialization
+	if (initialize && argo::backend::node_id() == gptr.node()) {
+		new (ptr) T(std::forward<Ps>(ps)...);
+	}
+	// Do not return uninitialized memory to the nodes.
+	if (synchronize) {
+		argo::backend::barrier();
+	}
+	return static_cast<T*>(ptr);
+}
 
-		if (ptr == nullptr) {
-			return;
-		}
+/**
+ * @brief template function to delete objects that were allocated using collective_new
+ * @tparam T type of the object to deallocate
+ * @tparam APs deallocation parameters
+ * @param ptr pointer to the object to deallocate
+ * @note T can usually be inferred from the type of ptr
+ *
+ * This function might choose to destruct or synchronize.
+ *
+ * -# The destructors are called by default (deinitialization).
+ * -# If the type is trivially destructible, no destructors are called.
+ * -# The user can explicitly override this behaviour (@ref argo::allocation).
+ * -# If the destructor is called, the function will also synchronize.
+ * -# The user can explicitly override this behaviour.
+ *
+ */
+template<typename T, allocation... APs>
+void codelete_(T* ptr) {
+	using aps = _internal::alloc_params<APs...>;
+	bool deinitialize = true;
+	bool synchronize = true;
 
-		// If the type is trivially destructible, do not deinitialize
-		if (std::is_trivially_destructible<T>::value) {
-			deinitialize = false;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::deinitialize) {
-			deinitialize = true;
-		} else if (aps::no_deinitialize) {
-			deinitialize = false;
-		}
-		// Synchronization goes hand to hand with deinitialization
-		synchronize = deinitialize;
-		// Again, the user can override the default behaviour
-		if (aps::synchronize) {
-			synchronize = true;
-		} else if (aps::no_synchronize) {
-			synchronize = false;
-		}
-
-		using namespace data_distribution;
-		global_ptr<T> gptr(ptr, false, false);
-		// The home node of ptr handles deinitialization
-		if (deinitialize && argo::backend::node_id() == gptr.node()) {
-			ptr->~T();
-		}
-		// This barrier might be unnecessary, depending on how free is
-		// implemented, but let's just put it here to cover all cases.
-		if (synchronize) {
-			argo::backend::barrier();
-		}
-		collective_free(static_cast<void*>(ptr));
+	if (ptr == nullptr) {
+		return;
 	}
 
-	/**
-	 * @brief Collectively construct a new array of objects in the global memory
-	 * @tparam T type to construct
-	 * @tparam APs Allocation parameters
-	 * @tparam Ps parameter types for the constructor
-	 * @param size Number of elements in the array
-	 * @return A pointer to the newly constructed object
-	 * @sa conew_
-	 *
-	 * The array elements are default-initialized. For this function to work,
-	 * all the nodes need to call it with the same arguments at the same time.
-	 *
-	 */
-	template<typename T, allocation... APs>
-	T* conew_array(size_t size) {
-		using aps = _internal::alloc_params<APs...>;
-		bool initialize = true;
-		bool synchronize = true;
-
-		// If the type is trivial, do not initialize
-		if (std::is_trivial<T>::value) {
-			initialize = false;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::initialize) {
-			initialize = true;
-		} else if (aps::no_initialize) {
-			initialize = false;
-		}
-		// Synchronization goes hand to hand with initialization
-		synchronize = initialize;
-		// Again, the user can override the default behaviour
-		if (aps::synchronize) {
-			synchronize = true;
-		} else if (aps::no_synchronize) {
-			synchronize = false;
-		}
-
-		void* ptr = collective_alloc(sizeof(T) * size);
-		using namespace data_distribution;
-		global_ptr<void> gptr(ptr, false, false);
-		// The home node of ptr handles initialization
-		if (initialize && argo::backend::node_id() == gptr.node()) {
-			new (ptr) T[size]();
-		}
-		if (synchronize) {
-			argo::backend::barrier();
-		}
-		return static_cast<T*>(ptr);
+	// If the type is trivially destructible, do not deinitialize
+	if (std::is_trivially_destructible<T>::value) {
+		deinitialize = false;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::deinitialize) {
+		deinitialize = true;
+	} else if (aps::no_deinitialize) {
+		deinitialize = false;
+	}
+	// Synchronization goes hand to hand with deinitialization
+	synchronize = deinitialize;
+	// Again, the user can override the default behaviour
+	if (aps::synchronize) {
+		synchronize = true;
+	} else if (aps::no_synchronize) {
+		synchronize = false;
 	}
 
-	/**
-	 * @brief Delete a globally collectively allocated array of objects
-	 * @tparam T Type of the object to be deleted
-	 * @tparam APs Deallocation parameters
-	 * @param ptr Pointer to the object to be deleted
-	 * @ sa codelete_
-	 *
-	 * For this function to work, all nodes need to call it with the same
-	 * arguments at the same time.
-	 */
-	template<typename T, allocation... APs>
-	void codelete_array(T* ptr) {
-		using aps = _internal::alloc_params<APs...>;
-		bool deinitialize = true;
-		bool synchronize = true;
-
-		if (ptr == nullptr) {
-			return;
-		}
-
-		// If the type is trivially destructible, do not deinitialize
-		if (std::is_trivially_destructible<T>::value) {
-			deinitialize = false;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::deinitialize) {
-			deinitialize = true;
-		} else if (aps::no_deinitialize) {
-			deinitialize = false;
-		}
-		// Synchronization goes hand to hand with deinitialization
-		synchronize = deinitialize;
-		// Again, the user can override the default behaviour
-		if (aps::synchronize) {
-			synchronize = true;
-		} else if (aps::no_synchronize) {
-			synchronize = false;
-		}
-
-		using namespace data_distribution;
-		global_ptr<T> gptr(ptr, false, false);
-		// The home node of ptr handles deinitialization
-		if (deinitialize && argo::backend::node_id() == gptr.node()) {
-			auto elements =
-				argo::allocators::default_collective_allocator.allocated_space(
-					reinterpret_cast<char *>(ptr)) /
-				sizeof(T);
-			for (size_t i = 0; i < elements; ++i) {
-				ptr[i].~T();
-			}
-		}
-		if (synchronize) {
-			argo::backend::barrier();
-		}
-		collective_free(static_cast<void*>(ptr));
+	using namespace data_distribution;
+	global_ptr<T> gptr(ptr, false, false);
+	// The home node of ptr handles deinitialization
+	if (deinitialize && argo::backend::node_id() == gptr.node()) {
+		ptr->~T();
 	}
+	// This barrier might be unnecessary, depending on how free is
+	// implemented, but let's just put it here to cover all cases.
+	if (synchronize) {
+		argo::backend::barrier();
+	}
+	collective_free(static_cast<void*>(ptr));
+}
+
+/**
+ * @brief Collectively construct a new array of objects in the global memory
+ * @tparam T type to construct
+ * @tparam APs Allocation parameters
+ * @tparam Ps parameter types for the constructor
+ * @param size Number of elements in the array
+ * @return A pointer to the newly constructed object
+ * @sa conew_
+ *
+ * The array elements are default-initialized. For this function to work,
+ * all the nodes need to call it with the same arguments at the same time.
+ *
+ */
+template<typename T, allocation... APs>
+T* conew_array(size_t size) {
+	using aps = _internal::alloc_params<APs...>;
+	bool initialize = true;
+	bool synchronize = true;
+
+	// If the type is trivial, do not initialize
+	if (std::is_trivial<T>::value) {
+		initialize = false;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::initialize) {
+		initialize = true;
+	} else if (aps::no_initialize) {
+		initialize = false;
+	}
+	// Synchronization goes hand to hand with initialization
+	synchronize = initialize;
+	// Again, the user can override the default behaviour
+	if (aps::synchronize) {
+		synchronize = true;
+	} else if (aps::no_synchronize) {
+		synchronize = false;
+	}
+
+	void* ptr = collective_alloc(sizeof(T) * size);
+	using namespace data_distribution;
+	global_ptr<void> gptr(ptr, false, false);
+	// The home node of ptr handles initialization
+	if (initialize && argo::backend::node_id() == gptr.node()) {
+		new (ptr) T[size]();
+	}
+	if (synchronize) {
+		argo::backend::barrier();
+	}
+	return static_cast<T*>(ptr);
+}
+
+/**
+ * @brief Delete a globally collectively allocated array of objects
+ * @tparam T Type of the object to be deleted
+ * @tparam APs Deallocation parameters
+ * @param ptr Pointer to the object to be deleted
+ * @ sa codelete_
+ *
+ * For this function to work, all nodes need to call it with the same
+ * arguments at the same time.
+ */
+template<typename T, allocation... APs>
+void codelete_array(T* ptr) {
+	using aps = _internal::alloc_params<APs...>;
+	bool deinitialize = true;
+	bool synchronize = true;
+
+	if (ptr == nullptr) {
+		return;
+	}
+
+	// If the type is trivially destructible, do not deinitialize
+	if (std::is_trivially_destructible<T>::value) {
+		deinitialize = false;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::deinitialize) {
+		deinitialize = true;
+	} else if (aps::no_deinitialize) {
+		deinitialize = false;
+	}
+	// Synchronization goes hand to hand with deinitialization
+	synchronize = deinitialize;
+	// Again, the user can override the default behaviour
+	if (aps::synchronize) {
+		synchronize = true;
+	} else if (aps::no_synchronize) {
+		synchronize = false;
+	}
+
+	using namespace data_distribution;
+	global_ptr<T> gptr(ptr, false, false);
+	// The home node of ptr handles deinitialization
+	if (deinitialize && argo::backend::node_id() == gptr.node()) {
+		auto elements =
+			argo::allocators::default_collective_allocator.allocated_space(
+				reinterpret_cast<char *>(ptr)) /
+			sizeof(T);
+		for (size_t i = 0; i < elements; ++i) {
+			ptr[i].~T();
+		}
+	}
+	if (synchronize) {
+		argo::backend::barrier();
+	}
+	collective_free(static_cast<void*>(ptr));
+}
 } // namespace argo
 
 #endif  // ARGODSM_SRC_ALLOCATORS_COLLECTIVE_ALLOCATOR_HPP_

--- a/src/allocators/collective_allocator.hpp
+++ b/src/allocators/collective_allocator.hpp
@@ -41,15 +41,16 @@ extern "C" {
 
 namespace argo {
 namespace allocators {
-	/**
-	 * @brief type alias for collective allocator: allocate from dynamically growing pool (backed by global memory allocator) without locking
-	 */
-	using collective_allocator = generic_allocator<char, mempools::dynamic_memory_pool<global_allocator, mempools::NODE_ZERO_ONLY>, null_lock>;
 
-	/**
-	 * @brief default collective allocator, using bytes as base unit
-	 */
-	extern collective_allocator default_collective_allocator;
+/**
+ * @brief type alias for collective allocator: allocate from dynamically growing pool (backed by global memory allocator) without locking
+ */
+using collective_allocator = generic_allocator<char, mempools::dynamic_memory_pool<global_allocator, mempools::NODE_ZERO_ONLY>, null_lock>;
+
+/**
+ * @brief default collective allocator, using bytes as base unit
+ */
+extern collective_allocator default_collective_allocator;
 
 } // namespace allocators
 
@@ -285,6 +286,7 @@ void codelete_array(T* ptr) {
 	}
 	collective_free(static_cast<void*>(ptr));
 }
-} // namespace argo
+
+}  // namespace argo
 
 #endif  // ARGODSM_SRC_ALLOCATORS_COLLECTIVE_ALLOCATOR_HPP_

--- a/src/allocators/dynamic_allocator.hpp
+++ b/src/allocators/dynamic_allocator.hpp
@@ -38,322 +38,322 @@ extern "C" {
 }
 
 namespace argo {
-	namespace allocators {
+namespace allocators {
+
+/**
+ * @brief type alias for global allocation
+ * @tparam T type to allocate
+ * @note global_memory_pool is threadsafe, therefore no lock required
+ */
+template<typename T>
+using global_allocator = generic_allocator<T, mempools::global_memory_pool<>, null_lock>;
+
+/** @brief type alias for default dynamic allocatior */
+using default_dynamic_allocator_t = generic_allocator<char, mempools::dynamic_memory_pool<global_allocator, mempools::ALWAYS>, std::mutex>;
+
+/**
+ * @brief default allocator for global allocations
+ * @note not intended for direct use
+ * @see default_dynamic_allocator
+ */
+extern global_allocator<char> default_global_allocator;
+
+/**
+ * @brief default collective allocator, using bytes as base unit
+ */
+extern default_dynamic_allocator_t default_dynamic_allocator;
+
+/**
+ * @brief An allocator for allocating global shared memory
+ */
+template<typename T>
+class dynamic_allocator {
+	public:
+		/**
+		 * @brief the type that is allocated
+		 */
+		using value_type = T;
 
 		/**
-		 * @brief type alias for global allocation
-		 * @tparam T type to allocate
-		 * @note global_memory_pool is threadsafe, therefore no lock required
+		 * @brief pointer to element
 		 */
-		template<typename T>
-		using global_allocator = generic_allocator<T, mempools::global_memory_pool<>, null_lock>;
-
-		/** @brief type alias for default dynamic allocatior */
-		using default_dynamic_allocator_t = generic_allocator<char, mempools::dynamic_memory_pool<global_allocator, mempools::ALWAYS>, std::mutex>;
+		using pointer = T*;
 
 		/**
-		 * @brief default allocator for global allocations
-		 * @note not intended for direct use
-		 * @see default_dynamic_allocator
+		 * @brief reference to element
 		 */
-		extern global_allocator<char> default_global_allocator;
+		using reference = T&;
 
 		/**
-		 * @brief default collective allocator, using bytes as base unit
+		 * @brief pointer to constant element
 		 */
-		extern default_dynamic_allocator_t default_dynamic_allocator;
+		using const_pointer = const T*;
 
 		/**
-		 * @brief An allocator for allocating global shared memory
+		 * @brief reference to constant element
 		 */
-		template<typename T>
-		class dynamic_allocator {
-			public:
-				/**
-				 * @brief the type that is allocated
-				 */
-				using value_type = T;
+		using const_reference = const T&;
 
-				/**
-				 * @brief pointer to element
-				 */
-				using pointer = T*;
+		/**
+		 * @brief quantities of elements
+		 */
+		using size_type = std::size_t;
 
-				/**
-				 * @brief reference to element
-				 */
-				using reference = T&;
+		/**
+		 * @brief difference between two pointers
+		 */
+		using difference_type = std::ptrdiff_t;
 
-				/**
-				 * @brief pointer to constant element
-				 */
-				using const_pointer = const T*;
-
-				/**
-				 * @brief reference to constant element
-				 */
-				using const_reference = const T&;
-
-				/**
-				 * @brief quantities of elements
-				 */
-				using size_type = std::size_t;
-
-				/**
-				 * @brief difference between two pointers
-				 */
-				using difference_type = std::ptrdiff_t;
-
-				/**
-				 * @brief rebinding type
-				 */
-				template<typename U>
-				struct rebind {
-					/**
-					 * @brief Allocator of the other type
-					 */
-					using other = dynamic_allocator<U>;
-				};
-
-				/**
-				 * @brief default constructor
-				 */
-				dynamic_allocator() {}
-
-				/**
-				 * @brief conversion constructor from other dynamic_allocator
-				 * @param other The allocator to convert from
-				 */
-				template<typename U>
-				dynamic_allocator(const dynamic_allocator<U>& other) {}
-
-				/**
-				 * @brief allocate Ts using the default dynamic allocator
-				 * @param n number of Ts to allocate
-				 * @return pointer to the allocated Ts
-				 */
-				pointer allocate(size_type n) {
-					return reinterpret_cast<pointer>(
-						default_dynamic_allocator.allocate(n*sizeof(value_type)));
-				}
-
-				/**
-				 * @brief free an allocated pointer
-				 * @param ptr the pointer to free
-				 */
-				void free(pointer ptr) {
-					default_dynamic_allocator.free(reinterpret_cast<char*>(ptr));
-				}
-
-				/**
-				 * @brief deallocate memory
-				 * @param ptr starting address of the memory to free
-				 * @param n the number of elements of type T to deallocate
-				 */
-				void deallocate(pointer ptr, size_t n) {
-					default_dynamic_allocator.deallocate(reinterpret_cast<char*>(ptr), n*sizeof(value_type));
-				}
-
-				/**
-				 * @brief construct a T at given location
-				 * @param ptr pointer to location
-				 * @param val value to initialize to
-				 */
-				void construct(pointer ptr, const_reference val) {
-					new (reinterpret_cast<void*>(ptr)) value_type(val);
-				}
-
-				/**
-				 * @brief destroy a T at given location
-				 * @param ptr pointer to location
-				 * @note this does not deallocate the storage for the element
-				 */
-				void destroy(pointer ptr) {
-					ptr->~value_type();
-				}
+		/**
+		 * @brief rebinding type
+		 */
+		template<typename U>
+		struct rebind {
+			/**
+			 * @brief Allocator of the other type
+			 */
+			using other = dynamic_allocator<U>;
 		};
 
 		/**
-		 * @brief test dynamic allocators for equality
-		 * @return always true
+		 * @brief default constructor
 		 */
-		template<typename T, typename U>
-		bool operator==(const dynamic_allocator<T>&, const dynamic_allocator<U>&) {
-			return true;
+		dynamic_allocator() {}
+
+		/**
+		 * @brief conversion constructor from other dynamic_allocator
+		 * @param other The allocator to convert from
+		 */
+		template<typename U>
+		dynamic_allocator(const dynamic_allocator<U>& other) {}
+
+		/**
+		 * @brief allocate Ts using the default dynamic allocator
+		 * @param n number of Ts to allocate
+		 * @return pointer to the allocated Ts
+		 */
+		pointer allocate(size_type n) {
+			return reinterpret_cast<pointer>(
+				default_dynamic_allocator.allocate(n*sizeof(value_type)));
 		}
 
 		/**
-		 * @brief test dynamic allocators for inequality
-		 * @return always false
+		 * @brief free an allocated pointer
+		 * @param ptr the pointer to free
 		 */
-		template<typename T, typename U>
-		bool operator!=(const dynamic_allocator<T>&, const dynamic_allocator<U>&) {
-			return false;
+		void free(pointer ptr) {
+			default_dynamic_allocator.free(reinterpret_cast<char*>(ptr));
 		}
 
-	} // namespace allocators
-
-	/**
-	 * @brief template function to construct new objects
-	 * @tparam T type to construct
-	 * @tparam APs Allocation parameters
-	 * @tparam Ps parameter types for constructor
-	 * @param ps parameters for constructor
-	 * @return pointer to newly constructed object
-	 *
-	 * The function might choose to initialize, depending on the
-	 * type constructed or the arguments provided by the user.
-	 *
-	 * -# Initialization is performed by default.
-	 * -# If the type is trivial, then no initialization is performed.
-	 * -# If the user has provided constructor arguments, then initialization is
-	 *    performed.
-	 * -# The user can explicitly override these defaults using the appropriate
-	 *    allocation parameters (@ref argo::allocation).
-	 * -# Synchronization is NOT performed at any case
-	 * -# User synchronization parameters are ignored
-	 */
-	template<typename T, allocation... APs, typename... Ps>
-	T* new_(Ps&&... ps) {
-		using aps = _internal::alloc_params<APs...>;
-		bool initialize = true;
-
-		// If the type is trivial, do not initialize
-		if (std::is_trivial<T>::value) {
-			initialize = false;
-		}
-		// If constructor arguments are given by the user, initialize
-		if (sizeof...(Ps) > 0) {
-			initialize = true;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::initialize) {
-			initialize = true;
-		} else if (aps::no_initialize) {
-			initialize = false;
+		/**
+		 * @brief deallocate memory
+		 * @param ptr starting address of the memory to free
+		 * @param n the number of elements of type T to deallocate
+		 */
+		void deallocate(pointer ptr, size_t n) {
+			default_dynamic_allocator.deallocate(reinterpret_cast<char*>(ptr), n*sizeof(value_type));
 		}
 
-		void* ptr = dynamic_alloc(sizeof(T));
-		if (initialize) {
-			new (ptr) T(std::forward<Ps>(ps)...);
+		/**
+		 * @brief construct a T at given location
+		 * @param ptr pointer to location
+		 * @param val value to initialize to
+		 */
+		void construct(pointer ptr, const_reference val) {
+			new (reinterpret_cast<void*>(ptr)) value_type(val);
 		}
-		return static_cast<T*>(ptr);
+
+		/**
+		 * @brief destroy a T at given location
+		 * @param ptr pointer to location
+		 * @note this does not deallocate the storage for the element
+		 */
+		void destroy(pointer ptr) {
+			ptr->~value_type();
+		}
+};
+
+/**
+ * @brief test dynamic allocators for equality
+ * @return always true
+ */
+template<typename T, typename U>
+bool operator==(const dynamic_allocator<T>&, const dynamic_allocator<U>&) {
+	return true;
+}
+
+/**
+ * @brief test dynamic allocators for inequality
+ * @return always false
+ */
+template<typename T, typename U>
+bool operator!=(const dynamic_allocator<T>&, const dynamic_allocator<U>&) {
+	return false;
+}
+
+}  // namespace allocators
+
+/**
+ * @brief template function to construct new objects
+ * @tparam T type to construct
+ * @tparam APs Allocation parameters
+ * @tparam Ps parameter types for constructor
+ * @param ps parameters for constructor
+ * @return pointer to newly constructed object
+ *
+ * The function might choose to initialize, depending on the
+ * type constructed or the arguments provided by the user.
+ *
+ * -# Initialization is performed by default.
+ * -# If the type is trivial, then no initialization is performed.
+ * -# If the user has provided constructor arguments, then initialization is
+ *    performed.
+ * -# The user can explicitly override these defaults using the appropriate
+ *    allocation parameters (@ref argo::allocation).
+ * -# Synchronization is NOT performed at any case
+ * -# User synchronization parameters are ignored
+ */
+template<typename T, allocation... APs, typename... Ps>
+T* new_(Ps&&... ps) {
+	using aps = _internal::alloc_params<APs...>;
+	bool initialize = true;
+
+	// If the type is trivial, do not initialize
+	if (std::is_trivial<T>::value) {
+		initialize = false;
+	}
+	// If constructor arguments are given by the user, initialize
+	if (sizeof...(Ps) > 0) {
+		initialize = true;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::initialize) {
+		initialize = true;
+	} else if (aps::no_initialize) {
+		initialize = false;
 	}
 
-	/**
-	 * @brief template function to delete objects that were allocated using dynamic_new
-	 * @tparam T type of the object to deallocate
-	 * @tparam APs deallocation parameters
-	 * @param ptr pointer to the object to deallocate
-	 * @note T can usually be inferred from the type of ptr
-	 *
-	 * This function can choose to call the destructors
-	 *
-	 * -# Deinitialization (calling the destructors) is performed by default.
-	 * -# If the type is trivially destructible, no destructors are called.
-	 * -# The user can override the default behaviour with the allocation
-	 *  parameters (@ref argo::allocation).
-	 * -# Synchronization is NOT performed at any case
-	 * -# User synchronization parameters are ignored
-	 */
-	template<typename T, allocation... APs>
-	void delete_(T* ptr) {
-		using aps = _internal::alloc_params<APs...>;
-		bool deinitialize = true;
+	void* ptr = dynamic_alloc(sizeof(T));
+	if (initialize) {
+		new (ptr) T(std::forward<Ps>(ps)...);
+	}
+	return static_cast<T*>(ptr);
+}
 
-		if (ptr == nullptr) {
-			return;
-		}
+/**
+ * @brief template function to delete objects that were allocated using dynamic_new
+ * @tparam T type of the object to deallocate
+ * @tparam APs deallocation parameters
+ * @param ptr pointer to the object to deallocate
+ * @note T can usually be inferred from the type of ptr
+ *
+ * This function can choose to call the destructors
+ *
+ * -# Deinitialization (calling the destructors) is performed by default.
+ * -# If the type is trivially destructible, no destructors are called.
+ * -# The user can override the default behaviour with the allocation
+ *  parameters (@ref argo::allocation).
+ * -# Synchronization is NOT performed at any case
+ * -# User synchronization parameters are ignored
+ */
+template<typename T, allocation... APs>
+void delete_(T* ptr) {
+	using aps = _internal::alloc_params<APs...>;
+	bool deinitialize = true;
 
-		// If the type is trivially destructible, do not deinitialize
-		if (std::is_trivially_destructible<T>::value) {
-			deinitialize = false;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::deinitialize) {
-			deinitialize = true;
-		} else if (aps::no_deinitialize) {
-			deinitialize = false;
-		}
-
-		if (deinitialize) {
-			ptr->~T();
-		}
-		dynamic_free(static_cast<void*>(ptr));
+	if (ptr == nullptr) {
+		return;
 	}
 
-	/**
-	 * @brief Construct a new array of objects in the global memory
-	 * @tparam T type to construct
-	 * @tparam APs Allocation parameters
-	 * @tparam Ps parameter types for the constructor
-	 * @param size Number of elements in the array
-	 * @return A pointer to the newly constructed object
-	 * @sa new_
-	 *
-	 * The array elements are default-initialized.
-	 */
-	template<typename T, allocation... APs>
-	T* new_array(size_t size) {
-		using aps = _internal::alloc_params<APs...>;
-		bool initialize = true;
-
-		// If the type is trivial, do not initialize
-		if (std::is_trivial<T>::value) {
-			initialize = false;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::initialize) {
-			initialize = true;
-		} else if (aps::no_initialize) {
-			initialize = false;
-		}
-
-		void* ptr = dynamic_alloc(sizeof(T) * size);
-		if (initialize) {
-			new (ptr) T[size]();
-		}
-		return static_cast<T*>(ptr);
+	// If the type is trivially destructible, do not deinitialize
+	if (std::is_trivially_destructible<T>::value) {
+		deinitialize = false;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::deinitialize) {
+		deinitialize = true;
+	} else if (aps::no_deinitialize) {
+		deinitialize = false;
 	}
 
-	/**
-	 * @brief Delete a globally allocated array of object
-	 * @tparam T Type of the array to be deleted
-	 * @tparam APs deallocation parameters
-	 * @param ptr Pointer to the array to be deleted
-	 * @sa delete_
-	 */
-	template<typename T, allocation... APs>
-	void delete_array(T* ptr) {
-		using aps = _internal::alloc_params<APs...>;
-		bool deinitialize = true;
-
-		if (ptr == nullptr) {
-			return;
-		}
-
-		// If the type is trivially destructible, do not deinitialize
-		if (std::is_trivially_destructible<T>::value) {
-			deinitialize = false;
-		}
-		// The user can explicitly override the default behaviour
-		if (aps::deinitialize) {
-			deinitialize = true;
-		} else if (aps::no_deinitialize) {
-			deinitialize = false;
-		}
-
-		if (deinitialize) {
-			auto elements =
-				argo::allocators::default_dynamic_allocator.allocated_space(
-					reinterpret_cast<char *>(ptr)) /
-				sizeof(T);
-			for (size_t i = 0; i < elements; ++i) {
-				ptr[i].~T();
-			}
-		}
-		dynamic_free(static_cast<void*>(ptr));
+	if (deinitialize) {
+		ptr->~T();
 	}
+	dynamic_free(static_cast<void*>(ptr));
+}
+
+/**
+ * @brief Construct a new array of objects in the global memory
+ * @tparam T type to construct
+ * @tparam APs Allocation parameters
+ * @tparam Ps parameter types for the constructor
+ * @param size Number of elements in the array
+ * @return A pointer to the newly constructed object
+ * @sa new_
+ *
+ * The array elements are default-initialized.
+ */
+template<typename T, allocation... APs>
+T* new_array(size_t size) {
+	using aps = _internal::alloc_params<APs...>;
+	bool initialize = true;
+
+	// If the type is trivial, do not initialize
+	if (std::is_trivial<T>::value) {
+		initialize = false;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::initialize) {
+		initialize = true;
+	} else if (aps::no_initialize) {
+		initialize = false;
+	}
+
+	void* ptr = dynamic_alloc(sizeof(T) * size);
+	if (initialize) {
+		new (ptr) T[size]();
+	}
+	return static_cast<T*>(ptr);
+}
+
+/**
+ * @brief Delete a globally allocated array of object
+ * @tparam T Type of the array to be deleted
+ * @tparam APs deallocation parameters
+ * @param ptr Pointer to the array to be deleted
+ * @sa delete_
+ */
+template<typename T, allocation... APs>
+void delete_array(T* ptr) {
+	using aps = _internal::alloc_params<APs...>;
+	bool deinitialize = true;
+
+	if (ptr == nullptr) {
+		return;
+	}
+
+	// If the type is trivially destructible, do not deinitialize
+	if (std::is_trivially_destructible<T>::value) {
+		deinitialize = false;
+	}
+	// The user can explicitly override the default behaviour
+	if (aps::deinitialize) {
+		deinitialize = true;
+	} else if (aps::no_deinitialize) {
+		deinitialize = false;
+	}
+
+	if (deinitialize) {
+		auto elements =
+			argo::allocators::default_dynamic_allocator.allocated_space(
+				reinterpret_cast<char *>(ptr)) /
+			sizeof(T);
+		for (size_t i = 0; i < elements; ++i) {
+			ptr[i].~T();
+		}
+	}
+	dynamic_free(static_cast<void*>(ptr));
+}
 
 } // namespace argo
 

--- a/src/allocators/dynamic_allocator.hpp
+++ b/src/allocators/dynamic_allocator.hpp
@@ -355,6 +355,6 @@ void delete_array(T* ptr) {
 	dynamic_free(static_cast<void*>(ptr));
 }
 
-} // namespace argo
+}  // namespace argo
 
 #endif  // ARGODSM_SRC_ALLOCATORS_DYNAMIC_ALLOCATOR_HPP_

--- a/src/allocators/generic_allocator.hpp
+++ b/src/allocators/generic_allocator.hpp
@@ -25,281 +25,280 @@
 
 namespace argo {
 
+/**
+ * @brief Enumeration class with parameters for the C++ allocation
+ * functions.
+ */
+enum class allocation {
 	/**
-	 * @brief Enumeration class with parameters for the C++ allocation
-	 * functions.
+	 * @brief Initialize the element(s) allocated
+	 *
+	 * If this parameter is given to the allocation function, then the
+	 * function will initialize the element(s) allocated. This is done by
+	 * calling a placement new expression on the memory allocated. This
+	 * option is enabled by default for non-trivial types.
 	 */
-	enum class allocation {
+	initialize,
+	/**
+	 * @brief Do not initialize the element(s) allocated
+	 *
+	 * The opposite of the ``initialize`` parameter. It is enabled by
+	 * default for trivial types.
+	 */
+	no_initialize,
+	/**
+	 * @brief Destruct (deinitialize) the element(s) deallocated
+	 *
+	 * This parameters is the equivalent of ``initialize`` for the delete
+	 * family of functions.
+	 */
+	deinitialize,
+	/**
+	 * @brief Do not destruct (deinitialize) the deallocated element(s)
+	 *
+	 * The opposite of ``deinitialize``.
+	 */
+	no_deinitialize,
+	/**
+	 * @brief Make the allocation a synchronization point
+	 *
+	 * This will cause the allocator to synchronize with the other nodes.
+	 * This is the default behaviour in the collective allocator if
+	 * ``initialize`` is also enabled.
+	 */
+	synchronize,
+	/**
+	 * @brief Do not make the allocation a synchronization point
+	 *
+	 * The opposite of ``synchronize``. Enabled by default in the collective
+	 * allocator if ``no_initialize`` is enabled, and always for the dynamic
+	 * allocator.
+	 */
+	no_synchronize
+};
+
+namespace _internal {
+/**
+ * @brief Helper struct to parse allocation parameters at compilation
+ */
+template <allocation, allocation...>
+struct alloc_param_in;
+
+template <allocation P, allocation AP, allocation... APs>
+struct alloc_param_in<P, AP, APs...>
+	: public std::conditional<P == AP, std::true_type, alloc_param_in<P, APs...>>::type {};
+
+template <allocation P>
+struct alloc_param_in<P> : public std::false_type {};
+
+/**
+ * @brief Helper struct; reduces code verbosity when using the parameters
+ */
+template <allocation... Ps>
+struct alloc_params {
+	/** @brief @ref allocation::initialize */
+	static constexpr bool initialize =
+		alloc_param_in<allocation::initialize, Ps...>::value;
+	/** @brief @ref allocation::no_initialize */
+	static constexpr bool no_initialize =
+		alloc_param_in<allocation::no_initialize, Ps...>::value;
+	/** @brief @ref allocation::deinitialize */
+	static constexpr bool deinitialize =
+		alloc_param_in<allocation::deinitialize, Ps...>::value;
+	/** @brief @ref allocation::no_deinitialize */
+	static constexpr bool no_deinitialize =
+		alloc_param_in<allocation::no_deinitialize, Ps...>::value;
+	/** @brief @ref allocation::synchronize */
+	static constexpr bool synchronize =
+		alloc_param_in<allocation::synchronize, Ps...>::value;
+	/** @brief @ref allocation::no_synchronize */
+	static constexpr bool no_synchronize =
+		alloc_param_in<allocation::no_synchronize, Ps...>::value;
+
+	// Having both of each pair enabled makes no sense
+	static_assert(!initialize || !no_initialize, "Conflicting parameters");
+	static_assert(!deinitialize || !no_deinitialize, "Conflicting parameters");
+	static_assert(!synchronize || !no_synchronize, "Conflicting parameters");
+};
+
+}  // namespace _internal
+
+namespace allocators {
+/**
+ * @brief generic template for memory allocators
+ * @tparam T type to allocate
+ * @tparam MemoryPool the type of memory pool to allocate from
+ * @tparam LockType lock type used to protect the memory pool
+ * @details This template can be used for many different kinds of
+ *          memory allocators in ArgoDSM:
+ *          The underlying memory pool is currently either a
+ *          preallocation pool or a large piece of distributed shared
+ *          memory. Locking is only required when the memory pool
+ *          otherwise would experience data races.
+ */
+template<typename T, typename MemoryPool, typename LockType>
+class generic_allocator {
+	private:
+		/** @brief Type for freelists */
+		using freelist_t = std::stack<T*>;
+
+		/** @brief The memory pool to allocate from */
+		MemoryPool* mempool;
+
+		/** @brief size of the lock in T units */
+		static constexpr std::size_t lock_size =(sizeof(LockType)+sizeof(T)-1)/sizeof(T);
+
+		/** @brief A lock to protect accesses */
+		LockType* lock;
+
+		/** @brief A map for storing the size of each allocation */
+		std::map<T*, size_t> allocation_size;
+		// another option would be std::multimap<size_t, void*>
+
+		/** @brief A map to store allocations after freeing them, according to their size */
+		std::map<size_t, freelist_t> freelist;
+
 		/**
-		 * @brief Initialize the element(s) allocated
-		 *
-		 * If this parameter is given to the allocation function, then the
-		 * function will initialize the element(s) allocated. This is done by
-		 * calling a placement new expression on the memory allocated. This
-		 * option is enabled by default for non-trivial types.
+		 * @brief helper function for deallocation
+		 * @param ptr pointer to deallocate
+		 * @param size number of elements to deallocate
+		 * @details this helper is used internally after locks have been acquired
 		 */
-		initialize,
-		/**
-		 * @brief Do not initialize the element(s) allocated
-		 *
-		 * The opposite of the ``initialize`` parameter. It is enabled by
-		 * default for trivial types.
-		 */
-		no_initialize,
-		/**
-		 * @brief Destruct (deinitialize) the element(s) deallocated
-		 *
-		 * This parameters is the equivalent of ``initialize`` for the delete
-		 * family of functions.
-		 */
-		deinitialize,
-		/**
-		 * @brief Do not destruct (deinitialize) the deallocated element(s)
-		 *
-		 * The opposite of ``deinitialize``.
-		 */
-		no_deinitialize,
-		/**
-		 * @brief Make the allocation a synchronization point
-		 *
-		 * This will cause the allocator to synchronize with the other nodes.
-		 * This is the default behaviour in the collective allocator if
-		 * ``initialize`` is also enabled.
-		 */
-		synchronize,
-		/**
-		 * @brief Do not make the allocation a synchronization point
-		 *
-		 * The opposite of ``synchronize``. Enabled by default in the collective
-		 * allocator if ``no_initialize`` is enabled, and always for the dynamic
-		 * allocator.
-		 */
-		no_synchronize
-	};
-
-	namespace _internal {
-		/**
-		 * @brief Helper struct to parse allocation parameters at compilation
-		 */
-		template <allocation, allocation...>
-		struct alloc_param_in;
-
-		template <allocation P, allocation AP, allocation... APs>
-		struct alloc_param_in<P, AP, APs...>
-			: public std::conditional<P == AP, std::true_type, alloc_param_in<P, APs...>>::type {};
-
-		template <allocation P>
-		struct alloc_param_in<P> : public std::false_type {};
+		void deallocate_nosync(T* ptr, size_t size) {
+			/* no check for initialization required:
+			 * if empty, container is default-constructed */
+			freelist[size].push(ptr);
+		}
 
 		/**
-		 * @brief Helper struct; reduces code verbosity when using the parameters
+		 * @brief helper function to align a number up to the next alignment
+		 * @param num the number to align
+		 * @param alignment the alignment to align up to
+		 * @return num aligned to the next alignment, or num if already aligned
 		 */
-		template <allocation... Ps>
-		struct alloc_params {
-			/** @brief @ref allocation::initialize */
-			static constexpr bool initialize =
-				alloc_param_in<allocation::initialize, Ps...>::value;
-			/** @brief @ref allocation::no_initialize */
-			static constexpr bool no_initialize =
-				alloc_param_in<allocation::no_initialize, Ps...>::value;
-			/** @brief @ref allocation::deinitialize */
-			static constexpr bool deinitialize =
-				alloc_param_in<allocation::deinitialize, Ps...>::value;
-			/** @brief @ref allocation::no_deinitialize */
-			static constexpr bool no_deinitialize =
-				alloc_param_in<allocation::no_deinitialize, Ps...>::value;
-			/** @brief @ref allocation::synchronize */
-			static constexpr bool synchronize =
-				alloc_param_in<allocation::synchronize, Ps...>::value;
-			/** @brief @ref allocation::no_synchronize */
-			static constexpr bool no_synchronize =
-				alloc_param_in<allocation::no_synchronize, Ps...>::value;
+		static std::size_t align_up(std::size_t num, std::size_t alignment) {
+			return ((num + alignment - 1) / alignment) * alignment;
+		}
 
-			// Having both of each pair enabled makes no sense
-			static_assert(!initialize || !no_initialize, "Conflicting parameters");
-			static_assert(!deinitialize || !no_deinitialize, "Conflicting parameters");
-			static_assert(!synchronize || !no_synchronize, "Conflicting parameters");
-		};
-
-	} // namespace _internal
-
-	namespace allocators {
+	public:
+		/**
+		 * @brief the type that is allocated
+		 */
+		using value_type = T;
 
 		/**
-		 * @brief generic template for memory allocators
-		 * @tparam T type to allocate
-		 * @tparam MemoryPool the type of memory pool to allocate from
-		 * @tparam LockType lock type used to protect the memory pool
-		 * @details This template can be used for many different kinds of
-		 *          memory allocators in ArgoDSM:
-		 *          The underlying memory pool is currently either a
-		 *          preallocation pool or a large piece of distributed shared
-		 *          memory. Locking is only required when the memory pool
-		 *          otherwise would experience data races.
+		 * @brief Default constructor: Initialize to nullptr as memory pool
+		 * @warning using the new memory pool without initializing it through
+		 *       set_mempool() is illegal
 		 */
-		template<typename T, typename MemoryPool, typename LockType>
-		class generic_allocator {
-			private:
-				/** @brief Type for freelists */
-				using freelist_t = std::stack<T*>;
+		generic_allocator()
+			: mempool(nullptr), lock(new LockType), allocation_size(), freelist() {}
+		/**
+		 * @brief Construct allocator for a memory pool
+		 * @param mp The memory pool to allocate from
+		 */
+		explicit generic_allocator(MemoryPool* mp)
+			: mempool(mp), lock(new LockType), allocation_size(), freelist() {}
 
-				/** @brief The memory pool to allocate from */
-				MemoryPool* mempool;
+		/**
+		 * @todo Documentation
+		 */
+		~generic_allocator() {
+			LockType* lock_ptr = lock;
+			lock->~LockType();
+			this->deallocate(reinterpret_cast<T*>(lock_ptr), lock_size);
+		}
 
-				/** @brief size of the lock in T units */
-				static constexpr std::size_t lock_size =(sizeof(LockType)+sizeof(T)-1)/sizeof(T);
+		/**
+		 * @brief Allocate memory
+		 * @param n The amount of Ts for which memory is allocated
+		 * @return The pointer to the allocated memory
+		 */
+		T* allocate(size_t n) {
+			/** @todo maybe detect uninitialized mempool in here? */
 
-				/** @brief A lock to protect accesses */
-				LockType* lock;
+			// Align the requested memory size in chunks of the alignment specified
+			// by max_align_t to ensure that all allocations are well aligned
+			std::size_t aligned_alloc_size = align_up(n * sizeof(T), alignof(std::max_align_t));
 
-				/** @brief A map for storing the size of each allocation */
-				std::map<T*, size_t> allocation_size;
-				// another option would be std::multimap<size_t, void*>
+			// Update the number of elements that will actually be allocated after
+			// alignment so that the freelist and allocation_size table are correct
+			std::size_t aligned_n = aligned_alloc_size / sizeof(T);
 
-				/** @brief A map to store allocations after freeing them, according to their size */
-				std::map<size_t, freelist_t> freelist;
-
-				/**
-				 * @brief helper function for deallocation
-				 * @param ptr pointer to deallocate
-				 * @param size number of elements to deallocate
-				 * @details this helper is used internally after locks have been acquired
-				 */
-				void deallocate_nosync(T* ptr, size_t size) {
-					/* no check for initialization required:
-					 * if empty, container is default-constructed */
-					freelist[size].push(ptr);
-				}
-
-				/**
-				 * @brief helper function to align a number up to the next alignment
-				 * @param num the number to align
-				 * @param alignment the alignment to align up to
-				 * @return num aligned to the next alignment, or num if already aligned
-				 */
-				static std::size_t align_up(std::size_t num, std::size_t alignment) {
-					return ((num + alignment - 1) / alignment) * alignment;
-				}
-
-
-			public:
-				/**
-				 * @brief the type that is allocated
-				 */
-				using value_type = T;
-
-				/**
-				 * @brief Default constructor: Initialize to nullptr as memory pool
-				 * @warning using the new memory pool without initializing it through
-				 *       set_mempool() is illegal
-				 */
-				generic_allocator()
-					: mempool(nullptr), lock(new LockType), allocation_size(), freelist() {}
-				/**
-				 * @brief Construct allocator for a memory pool
-				 * @param mp The memory pool to allocate from
-				 */
-				explicit generic_allocator(MemoryPool* mp)
-					: mempool(mp), lock(new LockType), allocation_size(), freelist() {}
-
-				/**
-				 * @todo Documentation
-				 */
-				~generic_allocator() {
-					LockType* lock_ptr = lock;
-					lock->~LockType();
-					this->deallocate(reinterpret_cast<T*>(lock_ptr), lock_size);
-				}
-
-				/**
-				 * @brief Allocate memory
-				 * @param n The amount of Ts for which memory is allocated
-				 * @return The pointer to the allocated memory
-				 */
-				T* allocate(size_t n) {
-					/** @todo maybe detect uninitialized mempool in here? */
-
-					// Align the requested memory size in chunks of the alignment specified
-					// by max_align_t to ensure that all allocations are well aligned
-					std::size_t aligned_alloc_size = align_up(n * sizeof(T), alignof(std::max_align_t));
-
-					// Update the number of elements that will actually be allocated after
-					// alignment so that the freelist and allocation_size table are correct
-					std::size_t aligned_n = aligned_alloc_size / sizeof(T);
-
-					lock->lock();
-					if(freelist.count(aligned_n) != 0 && !freelist[aligned_n].empty()) {
-						T* allocation = freelist[aligned_n].top();
-						freelist[aligned_n].pop();
-						lock->unlock();
-						return allocation;
-					}
-					T* allocation;
-					try {
-						allocation = static_cast<T*>(mempool->reserve(aligned_alloc_size));
-					} catch (const typename MemoryPool::bad_alloc&) {
-						auto avail = mempool->available();
-						if(avail > 0) {
-							allocation = static_cast<T*>(mempool->reserve(avail));
-							freelist[avail].push(allocation);
-							allocation_size.insert({{allocation, aligned_n}});
-						}
-						try {
-							mempool->grow(aligned_alloc_size);
-						} catch(const std::bad_alloc&) {
-							lock->unlock();
-							throw;
-						}
-						allocation = static_cast<T*>(mempool->reserve(aligned_alloc_size));
-					}
+			lock->lock();
+			if(freelist.count(aligned_n) != 0 && !freelist[aligned_n].empty()) {
+				T* allocation = freelist[aligned_n].top();
+				freelist[aligned_n].pop();
+				lock->unlock();
+				return allocation;
+			}
+			T* allocation;
+			try {
+				allocation = static_cast<T*>(mempool->reserve(aligned_alloc_size));
+			} catch (const typename MemoryPool::bad_alloc&) {
+				auto avail = mempool->available();
+				if(avail > 0) {
+					allocation = static_cast<T*>(mempool->reserve(avail));
+					freelist[avail].push(allocation);
 					allocation_size.insert({{allocation, aligned_n}});
-
+				}
+				try {
+					mempool->grow(aligned_alloc_size);
+				} catch(const std::bad_alloc&) {
 					lock->unlock();
-					return allocation;
+					throw;
 				}
+				allocation = static_cast<T*>(mempool->reserve(aligned_alloc_size));
+			}
+			allocation_size.insert({{allocation, aligned_n}});
 
-				/**
-				 * @brief free an allocated pointer
-				 * @param ptr the pointer to free
-				 */
-				void free(T* ptr) {
-					lock->lock();
-					auto size = allocation_size[ptr];
-					deallocate_nosync(ptr, size);
-					lock->unlock();
-				}
+			lock->unlock();
+			return allocation;
+		}
 
-				/**
-				 * @brief deallocate memory
-				 * @param ptr starting address of the memory to free
-				 * @param n the number of elements of type T to deallocate
-				 */
-				void deallocate(T* ptr, size_t n) {
-					std::size_t aligned_alloc_size = align_up(n * sizeof(T), alignof(std::max_align_t));
-					std::size_t aligned_n = aligned_alloc_size / sizeof(T);
-					lock->lock();
-					deallocate_nosync(ptr, aligned_n);
-					lock->unlock();
-				}
+		/**
+		 * @brief free an allocated pointer
+		 * @param ptr the pointer to free
+		 */
+		void free(T* ptr) {
+			lock->lock();
+			auto size = allocation_size[ptr];
+			deallocate_nosync(ptr, size);
+			lock->unlock();
+		}
 
-				/**
-				 * @brief set memory pool
-				 * @param mp new memory pool to feed allocations from
-				 */
-				void set_mempool(MemoryPool* mp) {
-					mempool = mp;
-				}
+		/**
+		 * @brief deallocate memory
+		 * @param ptr starting address of the memory to free
+		 * @param n the number of elements of type T to deallocate
+		 */
+		void deallocate(T* ptr, size_t n) {
+			std::size_t aligned_alloc_size = align_up(n * sizeof(T), alignof(std::max_align_t));
+			std::size_t aligned_n = aligned_alloc_size / sizeof(T);
+			lock->lock();
+			deallocate_nosync(ptr, aligned_n);
+			lock->unlock();
+		}
 
-				/**
-				 * @brief How much space has been allocated for the given chunk
-				 * @param ptr Starting address of the chunk
-				 * @return Allocated space in bytes
-				 */
-				size_t allocated_space(T* ptr) {
-					return allocation_size.at(ptr);
-				}
-		};
-	} // namespace allocators
-} // namespace argo
+		/**
+		 * @brief set memory pool
+		 * @param mp new memory pool to feed allocations from
+		 */
+		void set_mempool(MemoryPool* mp) {
+			mempool = mp;
+		}
+
+		/**
+		 * @brief How much space has been allocated for the given chunk
+		 * @param ptr Starting address of the chunk
+		 * @return Allocated space in bytes
+		 */
+		size_t allocated_space(T* ptr) {
+			return allocation_size.at(ptr);
+		}
+};
+
+}  // namespace allocators
+}  // namespace argo
 
 #endif  // ARGODSM_SRC_ALLOCATORS_GENERIC_ALLOCATOR_HPP_

--- a/src/allocators/null_lock.hpp
+++ b/src/allocators/null_lock.hpp
@@ -6,26 +6,28 @@
  * @internal
  * @details sometimes templates should be used with and without internal locking, this file provides the neccessary dummy class to allow disabling locking
  */
+
 #ifndef ARGODSM_SRC_ALLOCATORS_NULL_LOCK_HPP_
 #define ARGODSM_SRC_ALLOCATORS_NULL_LOCK_HPP_
+
 namespace argo {
-	namespace allocators {
-		/**
-		 * @internal
-		 * @brief a lock for when no locking is needed
-		 * @details This nonfunctional lock allows to instantiate templates
-		 *          that provide locking support without incurring the cost of locking.
-		 *          Correctness will not be ensured by the template and thus must be
-		 *          taken care of by the surrounding code.
-		 */
-		class null_lock {
-			public:
-				/** @brief do nothing */
-				void lock() {}
-				/** @brief do nothing */
-				void unlock() {}
-		};
-	} // namespace allocators
-} // namespace argo
+namespace allocators {
+/**
+ * @internal
+ * @brief a lock for when no locking is needed
+ * @details This nonfunctional lock allows to instantiate templates
+ *          that provide locking support without incurring the cost of locking.
+ *          Correctness will not be ensured by the template and thus must be
+ *          taken care of by the surrounding code.
+ */
+class null_lock {
+	public:
+		/** @brief do nothing */
+		void lock() {}
+		/** @brief do nothing */
+		void unlock() {}
+}; // class null_lock
+}  // namespace allocators
+}  // namespace argo
 
 #endif  // ARGODSM_SRC_ALLOCATORS_NULL_LOCK_HPP_

--- a/src/allocators/null_lock.hpp
+++ b/src/allocators/null_lock.hpp
@@ -12,6 +12,7 @@
 
 namespace argo {
 namespace allocators {
+
 /**
  * @internal
  * @brief a lock for when no locking is needed
@@ -26,7 +27,8 @@ class null_lock {
 		void lock() {}
 		/** @brief do nothing */
 		void unlock() {}
-}; // class null_lock
+};
+
 }  // namespace allocators
 }  // namespace argo
 

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -17,616 +17,614 @@
 #include "../types/types.hpp"
 
 namespace argo {
-	/**
-	 * @brief namespace for backend functionality
-	 * @details The backend functionality in ArgoDSM is all functions that
-	 *          depend inherently on the underlying communications system
-	 *          used between ArgoDSM nodes. These functions need to be
-	 *          implemented separately for each backend.
-	 */
-	namespace atomic {
-		/**
-		 * @brief Memory ordering for synchronization operations
-		 */
-		enum class memory_order {
-			relaxed, ///< No synchronization
-			// consume,
-			acquire, ///< This operation is an acquire operation
-			release, ///< This operation is a release opearation
-			acq_rel, ///< Release + Acquire
-			// seq_cst
-		};
-	} // namespace atomic
-
-	namespace backend {
-		/**
-		 * @brief Type of classification upgrade for the barrier operation
-		 */
-		enum class upgrade_type {
-			upgrade_none,	// Don't upgrade anything
-			upgrade_writers,// Upgrade all S-SW/MW to S-NW
-			upgrade_all		// Upgrade all S-NW/SW/MW to P
-		};
-
-		/**
-		 * @brief initialize backend
-		 * @param argo_size the size (in bytes) of the global memory to initialize
-		 * @param cache_size the size (in bytes) of the cache used by ArgoDSM
-		 * @warning the signature of this function may change
-		 * @todo maybe this should be tied better to the concrete memory
-		 *       allocated rather than a generic "initialize this size"
-		 *       functionality.
-		 * @todo the cache_size parameter is currently needed because cache layout
-		 *       is defined by the backend, which is wrong design-wise.
-		 */
-		void init(std::size_t argo_size, std::size_t cache_size);
-
-		/**
-		 * @brief get ArgoDSM node ID
-		 * @return local ArgoDSM node ID
-		 */
-		node_id_t node_id();
-
-		/**
-		 * @brief get total number of ArgoDSM nodes
-		 * @return total number of ArgoDSM nodes
-		 */
-		node_id_t number_of_nodes();
-
-		/**
-		 * @brief get base address of global memory
-		 * @return the pointer to the start of the global memory
-		 * @deprecated this is an implementation detail of the prototype
-		 *             implementation and should not be used in new code.
-		 */
-		char* global_base();
-
-		/**
-		 * @brief get the total amount of global memory
-		 * @return the size of the global memory
-		 * @deprecated this is an implementation detail of the prototype
-		 *             implementation and should not be used in new code.
-		 */
-		std::size_t global_size();
-
-		/**
-		 * @brief Check if a an address is cached or node local
-		 * @param addr the address to verify cache status on
-		 * @return True if the page is either cached on the node
-		 * or locally backed on the node, otherwise false.
-		 * @warning THIS IS FOR TESTING, DO NOT USE
-		 * @todo THIS SHOULD BE BAKED IN TO A CACHE CLASS
-		 */
-		bool is_cached(void* addr);
-
-		/**
-		 * @brief Resets statistics for the ArgoDSM backend in use
-		 */
-		void reset_stats();
-
-		/**
-		 * @brief global memory space address
-		 * @deprecated prototype implementation detail
-		 */
-		void finalize();
-
-		/**
-		 * @brief Resets current ArgoDSM coherence
-		 * @note Collective function which should be called only by one thread per node
-		 */
-		void reset_coherence();
-
-		/** @brief import global_ptr */
-		using argo::data_distribution::global_ptr;
-
-		/**
-		 * @brief a simple collective barrier
-		 * @param threadcount number of threads on each node that go into the barrier
-		 * @param upgrade the type of classification upgrade to perform
-		 */
-		void barrier(std::size_t threadcount = 1, upgrade_type upgrade = upgrade_type::upgrade_none);
-
-		/**
-		 * @brief broadcast-style collective synchronization
-		 * @tparam T type of synchronized object
-		 * @param source the ArgoDSM node holding the authoritative copy
-		 * @param ptr pointer to the object to synchronize
-		 */
-		template<typename T>
-		void broadcast(node_id_t source, T* ptr);
-
-		/**
-		 * @brief causes a node to self-invalidate its cache,
-		 *        and thus getting any updated values on subsequent accesses
-		 */
-		void acquire();
-
-		/**
-		 * @brief causes a node to self-downgrade its cache,
-		 *        making all previous writes to be propagated to the homenode,
-		 *        visible for nodes calling acquire (or other synchronization primitives)
-		 */
-		void release();
-
-
-		/**
-		 * The following selective coherence functions are implemented individually
-		 * by each backend
-		 */
-
-		/**
-		 * @brief backend internal type erased function for selective acquire
-		 * @param addr pointer to the start of an ArgoDSM memory region
-		 * @param size size of the region pointed to by addr
-		 * @sa    selective_acquire
-		 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-		 */
-		void _selective_acquire(void* addr, std::size_t size);
-
-		/**
-		 * @brief backend internal type erased function for selective release
-		 * @param addr pointer to the start of an ArgoDSM memory region
-		 * @param size size of the region pointed to by addr
-		 * @sa    selective_release
-		 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-		 */
-		void _selective_release(void* addr, std::size_t size);
-
-		/**
-		 * The following selective coherence functions are generic interfaces to the
-		 * actual backend implementations
-		 */
-
-		/**
-		 * @brief causes a node to self-invalidate the specified pages from its cache,
-		 *        and thus getting any updated values on subsequent accesses
-		 * @param addr pointer to the start of the memory region to self-invalidate
-		 * @param size the size of the memory region pointed to by addr. A size equal
-		 *        to zero results in that no pages are selectively acquired.
-		 * @note  Selective coherence operations do not uphold the data consistency
-		 *        semantics of regular coherence operations and should be used with
-		 *        this in mind. Specifically, write ordering with respect to writes
-		 *        outside of the selective coherence region is not upheld.
-		 */
-		template<typename T>
-		void selective_acquire(T* addr, std::size_t size) {
-			_selective_acquire(static_cast<void*>(addr), size);
-		}
-
-		/**
-		 * @brief causes a node to self-downgrade specified pages from its cache,
-		 *        making all previous writes to be propagated to the homenode,
-		 *        visible for nodes calling acquire (or other synchronization primitives)
-		 * @param addr the start of the memory region to self-invalidate
-		 * @param size the size of the memory region pointed to by addr. A size equal
-		 *        to zero results in that no pages are selectively released.
-		 * @note  Selective coherence operations do not uphold the data consistency
-		 *        semantics of regular coherence operations and should be used with
-		 *        this in mind. Specifically, write ordering with respect to writes
-		 *        outside of the selective coherence region is not upheld.
-		 */
-		template<typename T>
-		void selective_release(T* addr, std::size_t size) {
-			_selective_release(static_cast<void*>(addr), size);
-		}
-
-		namespace atomic {
-			using argo::atomic::memory_order;
-
-			/*
-			 * The following atomic functions are implemented by each backend in
-			 * their respective cpp files
-			 */
-
-			/**
-			 * @brief Backend internal type erased atomic exchange function
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param desired Pointer to the object that holds the desired value
-			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @sa exchange
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _exchange(global_ptr<void> obj, void* desired,
-				std::size_t size, void* output_buffer);
-
-			/**
-			 * @brief Backend internal type erased atomic store function
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param desired Pointer to the object that holds the desired value
-			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
-			 * @sa store
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _store(global_ptr<void> obj, void* desired, std::size_t size);
-
-			/**
-			 * @brief Backend internal type erased atomic store function
-			 * @param desired Pointer to the object that holds the desired value
-			 * @param count Number of elements from desired to store
-			 * @param size Size of each element in desired
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa store to public window section
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform stores on the owners_dir_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _store_public_owners_dir(const void* desired,
-				const std::size_t size, const std::size_t count,
-				const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic store function
-			 * @param desired The desired value to be stored
-			 * @param count Number of elements from desired to store
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa store to private window section
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform stores on the owners_dir_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _store_local_owners_dir(const std::size_t* desired,
-				const std::size_t count, const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic store function
-			 * @param desired The desired value to be stored
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa store to private window section
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform stores on the offsets_tbl_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _store_local_offsets_tbl(const std::size_t desired,
-				const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic store function
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param size sizeof(*obj) == sizeof(output_buffer)
-			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
-			 * @sa load
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _load(global_ptr<void> obj, std::size_t size, void* output_buffer);
-
-			/**
-			 * @brief Backend internal type erased atomic load function
-			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
-			 * @param size Size of an element to load
-			 * @param count Number of elements to load
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa load from public window section
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform loads on the owners_dir_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _load_public_owners_dir(void* output_buffer,
-				const std::size_t size, const std::size_t count,
-				const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic load function
-			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
-			 * @param count Number of elements to load
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa load from private window section
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform loads on the owners_dir_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _load_local_owners_dir(void* output_buffer,
-				const std::size_t count, const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic load function
-			 * @param output_buffer Pointer to the memory location where the value of the object should be stored
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa load from private window section
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform loads on the offsets_tbl_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _load_local_offsets_tbl(void* output_buffer,
-				const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic CAS function
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param desired Pointer to the object that holds the desired value
-			 * @param expected Pointer to the object that holds the expected value
-			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(*expected) == sizeof(output_buffer)
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @sa compare_exchange
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _compare_exchange(global_ptr<void> obj, void* desired,
-				std::size_t size, void* expected, void* output_buffer);
-
-			/**
-			 * @brief Backend internal type erased atomic CAS function
-			 * @param desired Pointer to the object that holds the desired value
-			 * @param expected Pointer to the object that holds the expected value
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @param size == sizeof(*desired) == sizeof(*expected) == sizeof(*output_buffer)
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa compare_exchange
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform CAS on the owners_dir_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
-				const std::size_t size, const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic CAS function
-			 * @param desired Pointer to the object that holds the desired value
-			 * @param expected Pointer to the object that holds the expected value
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @param size == sizeof(*desired) == sizeof(*expected) == sizeof(*output_buffer)
-			 * @param rank Rank of target window to which operation will be performed
-			 * @param disp Displacement from start of window to beginning of target buffer
-			 * @sa compare_exchange
-			 * @note Implementation-specific function for the first-touch data distribution.
-			 *       It is used to perform CAS on the offsets_tbl_window window.
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
-				const std::size_t size, const std::size_t rank, const std::size_t disp);
-
-			/**
-			 * @brief Backend internal type erased atomic (post)increment function for signed integers
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param value Pointer to the object that holds the desired value
-			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @sa exchange
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _fetch_add_int(global_ptr<void> obj, void* value, std::size_t size,
-				void* output_buffer);
-			/**
-			 * @brief Backend internal type erased atomic (post)increment function for unsigned integers
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param value Pointer to the object that holds the desired value
-			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @sa exchange
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _fetch_add_uint(global_ptr<void> obj, void* value, std::size_t size,
-				void* output_buffer);
-			/**
-			 * @brief Backend internal type erased atomic (post)increment function for floating point numbers
-			 * @param obj Pointer to the object whose value should be exchanged
-			 * @param value Pointer to the object that holds the desired value
-			 * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
-			 * @param output_buffer Pointer to the memory location where the old value of the object should be stored
-			 * @sa exchange
-			 * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
-			 */
-			void _fetch_add_float(global_ptr<void> obj, void* value, std::size_t size,
-				void* output_buffer);
-
-			/**
-			 * The following atomic functions are generic interfaces to the
-			 * actual backend implementations
-			 */
-
-			/**
-			 * @brief atomic swap operation on a global address
-			 * @param obj pointer to the global object to swap
-			 * @param desired the new value of the global object
-			 * @param order Memory synchronization ordering for this operation
-			 * @tparam T The type of the object to operate upon
-			 * @tparam U The type of the object to exchange with
-			 * @return the old value of the global object
-			 *
-			 * This function will atomically exchange the old value of the given
-			 * object with the new one and return the old one.
-			 */
-			template<typename T, typename U>
-			T exchange(global_ptr<T> obj, U desired, memory_order order = memory_order::acq_rel) {
-				T out_buffer;
-				static_assert(std::is_convertible<U, T>::value,
-					"It is not possible to implicitly convert \'desired\' to an"
-					" object of type T.");
-				T desired_buffer(desired);
-				static_assert(std::is_trivially_copy_assignable<T>::value,
-					"T must be trivially copy assignable");
-
-				if (order == memory_order::acq_rel || order == memory_order::release)
-					release();
-
-				_exchange(global_ptr<void>(obj), &desired_buffer, sizeof(T), &out_buffer);
-
-				if (order == memory_order::acq_rel || order == memory_order::acquire)
-					acquire();
-
-				return out_buffer;
-			}
-
-			/**
-			 * @brief Atomic store operation on a global address
-			 * @tparam T type of object to write
-			 * @param obj pointer to the object to write to
-			 * @param desired value to store in the object
-			 * @param order Memory synchronization ordering for this operation
-			 * @tparam T The type of the object to operate upon
-			 * @tparam U The type of the object to store
-			 *
-			 * This function will atomically store the given value into the
-			 * given memory location.
-			 */
-			template<typename T, typename U>
-			void store(global_ptr<T> obj, U desired, memory_order order = memory_order::release) {
-				static_assert(std::is_convertible<U, T>::value,
-					"It is not possible to implicitly convert \'desired\' to an"
-					" object of type T.");
-				T desired_buffer(desired);
-				static_assert(std::is_trivially_copy_assignable<T>::value,
-					"T must be trivially copy assignable");
-
-				if (order == memory_order::acq_rel || order == memory_order::release)
-					release();
-
-				_store(global_ptr<void>(obj), &desired_buffer, sizeof(T));
-
-				if (order == memory_order::acq_rel || order == memory_order::acquire)
-					acquire();
-			}
-
-			/**
-			 * @brief Atomic load operation on a global address
-			 * @param obj Pointer to the global object to swap
-			 * @param order Memory synchronization ordering for this operation
-			 * @tparam T The type of the object to operate upon
-			 * @return The value of the global object
-			 *
-			 * This function will atomically load the value from the given
-			 * memory location.
-			 */
-			template<typename T>
-			T load(global_ptr<T> obj, memory_order order = memory_order::acquire) {
-				T out_buffer;
-				static_assert(std::is_trivially_copy_assignable<T>::value,
-					"T must be trivially copy assignable");
-
-				if (order == memory_order::acq_rel || order == memory_order::release)
-					release();
-
-				_load(global_ptr<void>(obj), sizeof(T), &out_buffer);
-
-				if (order == memory_order::acq_rel || order == memory_order::acquire)
-					acquire();
-
-				return out_buffer;
-			}
-
-			/**
-			 * @brief Atomic CAS operation on a global address
-			 * @param obj Pointer to the global object to swap
-			 * @param expected The value to compare against
-			 * @param desired The value to set the object to
-			 * @param order Memory synchronization ordering for this operation
-			 * @tparam T The type of the object to operate upon
-			 * @tparam U The type of the expected object
-			 * @tparam U The type of the desired object
-			 * @return true if successful, false otherwise
-			 *
-			 * This function will atomically swap the old (expected) value of
-			 * the object with the new (desired) one, but only if the actual
-			 * value of the object matches the expected one.
-			 */
-			template <typename T, typename U, typename V>
-			bool compare_exchange(global_ptr<T> obj, U expected, V desired,
-				memory_order order = memory_order::acq_rel) {
-				T out_buffer;
-				static_assert(std::is_convertible<U, T>::value,
-					"It is not possible to implicitly convert \'expected\' to an"
-					" object of type T.");
-				static_assert(std::is_convertible<V, T>::value,
-					"It is not possible to implicitly convert \'desired\' to an"
-					" object of type T.");
-				T expected_buffer(expected);
-				T desired_buffer(desired);
-				static_assert(std::is_trivially_copy_assignable<T>::value,
-					"T must be trivially copy assignable");
-
-				if (order == memory_order::acq_rel || order == memory_order::release)
-					release();
-
-				//XXX: Is this strong or weak? MPI doesn't say anything
-				_compare_exchange(global_ptr<void>(obj), &desired_buffer, sizeof(T),
-					&expected_buffer, &out_buffer);
-
-				if (order == memory_order::acq_rel || order == memory_order::acquire)
-					acquire();
-
-				return out_buffer == expected_buffer;
-			}
-
-			/**
-			 * @brief Atomic fetch and add operation on a global address
-			 * @param obj Pointer to the global object to fetch and add to
-			 * @param value The value to add to the object
-			 * @param order Memory synchronization ordering for this operation
-			 * @tparam T The type of the object to operate upon
-			 * @tparam U The type of the value object
-			 * @return The value of the object BEFORE the add operation
-			 *
-			 * This function will perform an atomic (*obj)+=(*value) operation.
-			 */
-			template <typename T, typename U>
-			T fetch_add(global_ptr<T> obj, U value, memory_order order = memory_order::acq_rel) {
-				T out_buffer;
-				// We need a buffer with the same size as T
-				static_assert(std::is_convertible<U, T>::value,
-					"It is not possible to implicitly convert \'desired\' to an"
-					" object of type T.");
-				T value_buffer(value);
-				static_assert(std::is_trivially_copy_assignable<T>::value,
-					"T must be trivially copy assignable");
-
-				if (order == memory_order::acq_rel || order == memory_order::release)
-					release();
-
-				// The order is important here, as floats are signed as well
-				if (std::is_floating_point<T>::value)
-					_fetch_add_float(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
-				else if (std::is_unsigned<T>::value)
-					_fetch_add_uint(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
-				else if (std::is_signed<T>::value)
-					_fetch_add_int(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
-				else
-					throw std::invalid_argument("Invalid type V for value");
-
-				if (order == memory_order::acq_rel || order == memory_order::acquire)
-					acquire();
-
-				return out_buffer;
-			}
-
-			/**
-			 * @brief Atomic fetch and add operation for pointers on a global address
-			 * @param obj Pointer to the global object to fetch and add to
-			 * @param value The value to add to the object
-			 * @param order Memory synchronization ordering for this operation
-			 * @tparam T The type of the pointer to operate upon
-			 * @tparam U The type of the value object
-			 * @return The value of the pointer BEFORE the add operation
-			 *
-			 * This function will perform an atomic (*obj)+=(*value) operation.
-			 * This is an overload for pointer types, as pointer arithmetic
-			 * works differently than normal integer and floating point
-			 * arithmetic.
-			 */
-			template <typename T, typename U>
-			T* fetch_add(global_ptr<T*> obj, U value, memory_order order = memory_order::acq_rel) {
-				T* out_buffer;
-				// We need a buffer with the same size as the pointer
-				void *value_buffer = reinterpret_cast<char*>(value * sizeof(T));
-
-				if (order == memory_order::acq_rel || order == memory_order::release)
-					release();
-
-				// Do the operation
-				_fetch_add_uint(global_ptr<void>(obj), &value_buffer, sizeof(T*), &out_buffer);
-
-				if (order == memory_order::acq_rel || order == memory_order::acquire)
-					acquire();
-
-				return out_buffer;
-			}
-		} // namespace atomic
-	} // namespace backend
-} // namespace argo
+/**
+ * @brief namespace for backend functionality
+ * @details The backend functionality in ArgoDSM is all functions that
+ *          depend inherently on the underlying communications system
+ *          used between ArgoDSM nodes. These functions need to be
+ *          implemented separately for each backend.
+ */
+namespace atomic {
+/**
+ * @brief Memory ordering for synchronization operations
+ */
+enum class memory_order {
+	relaxed,  ///< No synchronization
+	// consume,
+	acquire,  ///< This operation is an acquire operation
+	release,  ///< This operation is a release opearation
+	acq_rel,  ///< Release + Acquire
+	// seq_cst
+};
+}  // namespace atomic
+
+namespace backend {
+/**
+ * @brief Type of classification upgrade for the barrier operation
+ */
+enum class upgrade_type {
+	upgrade_none,	  // Don't upgrade anything
+	upgrade_writers,  // Upgrade all S-SW/MW to S-NW
+	upgrade_all	  // Upgrade all S-NW/SW/MW to P
+};
+
+/**
+ * @brief initialize backend
+ * @param argo_size the size (in bytes) of the global memory to initialize
+ * @param cache_size the size (in bytes) of the cache used by ArgoDSM
+ * @warning the signature of this function may change
+ * @todo maybe this should be tied better to the concrete memory
+ *       allocated rather than a generic "initialize this size"
+ *       functionality.
+ * @todo the cache_size parameter is currently needed because cache layout
+ *       is defined by the backend, which is wrong design-wise.
+ */
+void init(std::size_t argo_size, std::size_t cache_size);
+
+/**
+ * @brief get ArgoDSM node ID
+ * @return local ArgoDSM node ID
+ */
+node_id_t node_id();
+
+/**
+ * @brief get total number of ArgoDSM nodes
+ * @return total number of ArgoDSM nodes
+ */
+node_id_t number_of_nodes();
+
+/**
+ * @brief get base address of global memory
+ * @return the pointer to the start of the global memory
+ * @deprecated this is an implementation detail of the prototype
+ *             implementation and should not be used in new code.
+ */
+char* global_base();
+
+/**
+ * @brief get the total amount of global memory
+ * @return the size of the global memory
+ * @deprecated this is an implementation detail of the prototype
+ *             implementation and should not be used in new code.
+ */
+std::size_t global_size();
+
+/**
+ * @brief Check if a an address is cached or node local
+ * @param addr the address to verify cache status on
+ * @return True if the page is either cached on the node
+ * or locally backed on the node, otherwise false.
+ * @warning THIS IS FOR TESTING, DO NOT USE
+ * @todo THIS SHOULD BE BAKED IN TO A CACHE CLASS
+ */
+bool is_cached(void* addr);
+
+/**
+ * @brief Resets statistics for the ArgoDSM backend in use
+ */
+void reset_stats();
+
+/**
+ * @brief global memory space address
+ * @deprecated prototype implementation detail
+ */
+void finalize();
+
+/**
+ * @brief Resets current ArgoDSM coherence
+ * @note Collective function which should be called only by one thread per node
+ */
+void reset_coherence();
+
+/** @brief import global_ptr */
+using argo::data_distribution::global_ptr;
+
+/**
+ * @brief a simple collective barrier
+ * @param threadcount number of threads on each node that go into the barrier
+ * @param upgrade the type of classification upgrade to perform
+ */
+void barrier(std::size_t threadcount = 1, upgrade_type upgrade = upgrade_type::upgrade_none);
+
+/**
+ * @brief broadcast-style collective synchronization
+ * @tparam T type of synchronized object
+ * @param source the ArgoDSM node holding the authoritative copy
+ * @param ptr pointer to the object to synchronize
+ */
+template<typename T>
+void broadcast(node_id_t source, T* ptr);
+
+/**
+ * @brief causes a node to self-invalidate its cache,
+ *        and thus getting any updated values on subsequent accesses
+ */
+void acquire();
+
+/**
+ * @brief causes a node to self-downgrade its cache,
+ *        making all previous writes to be propagated to the homenode,
+ *        visible for nodes calling acquire (or other synchronization primitives)
+ */
+void release();
+
+
+/**
+ * The following selective coherence functions are implemented individually
+ * by each backend
+ */
+
+/**
+ * @brief backend internal type erased function for selective acquire
+ * @param addr pointer to the start of an ArgoDSM memory region
+ * @param size size of the region pointed to by addr
+ * @sa    selective_acquire
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _selective_acquire(void* addr, std::size_t size);
+
+/**
+ * @brief backend internal type erased function for selective release
+ * @param addr pointer to the start of an ArgoDSM memory region
+ * @param size size of the region pointed to by addr
+ * @sa    selective_release
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _selective_release(void* addr, std::size_t size);
+
+/**
+ * The following selective coherence functions are generic interfaces to the
+ * actual backend implementations
+ */
+
+/**
+ * @brief causes a node to self-invalidate the specified pages from its cache,
+ *        and thus getting any updated values on subsequent accesses
+ * @param addr pointer to the start of the memory region to self-invalidate
+ * @param size the size of the memory region pointed to by addr. A size equal
+ *        to zero results in that no pages are selectively acquired.
+ * @note  Selective coherence operations do not uphold the data consistency
+ *        semantics of regular coherence operations and should be used with
+ *        this in mind. Specifically, write ordering with respect to writes
+ *        outside of the selective coherence region is not upheld.
+ */
+template<typename T>
+void selective_acquire(T* addr, std::size_t size) {
+	_selective_acquire(static_cast<void*>(addr), size);
+}
+
+/**
+ * @brief causes a node to self-downgrade specified pages from its cache,
+ *        making all previous writes to be propagated to the homenode,
+ *        visible for nodes calling acquire (or other synchronization primitives)
+ * @param addr the start of the memory region to self-invalidate
+ * @param size the size of the memory region pointed to by addr. A size equal
+ *        to zero results in that no pages are selectively released.
+ * @note  Selective coherence operations do not uphold the data consistency
+ *        semantics of regular coherence operations and should be used with
+ *        this in mind. Specifically, write ordering with respect to writes
+ *        outside of the selective coherence region is not upheld.
+ */
+template<typename T>
+void selective_release(T* addr, std::size_t size) {
+	_selective_release(static_cast<void*>(addr), size);
+}
+
+namespace atomic {
+using argo::atomic::memory_order;
+
+/*
+ * The following atomic functions are implemented by each backend in
+ * their respective cpp files
+ */
+
+/**
+ * @brief Backend internal type erased atomic exchange function
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param desired Pointer to the object that holds the desired value
+ * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @sa exchange
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _exchange(global_ptr<void> obj, void* desired, std::size_t size, void* output_buffer);
+
+/**
+ * @brief Backend internal type erased atomic store function
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param desired Pointer to the object that holds the desired value
+ * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+ * @sa store
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _store(global_ptr<void> obj, void* desired, std::size_t size);
+
+/**
+ * @brief Backend internal type erased atomic store function
+ * @param desired Pointer to the object that holds the desired value
+ * @param count Number of elements from desired to store
+ * @param size Size of each element in desired
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa store to public window section
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform stores on the owners_dir_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _store_public_owners_dir(const void* desired,
+	const std::size_t size, const std::size_t count,
+	const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic store function
+ * @param desired The desired value to be stored
+ * @param count Number of elements from desired to store
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa store to private window section
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform stores on the owners_dir_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _store_local_owners_dir(const std::size_t* desired,
+	const std::size_t count, const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic store function
+ * @param desired The desired value to be stored
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa store to private window section
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform stores on the offsets_tbl_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _store_local_offsets_tbl(const std::size_t desired,
+	const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic store function
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param size sizeof(*obj) == sizeof(output_buffer)
+ * @param output_buffer Pointer to the memory location where the value of the object should be stored
+ * @sa load
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _load(global_ptr<void> obj, std::size_t size, void* output_buffer);
+
+/**
+ * @brief Backend internal type erased atomic load function
+ * @param output_buffer Pointer to the memory location where the value of the object should be stored
+ * @param size Size of an element to load
+ * @param count Number of elements to load
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa load from public window section
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform loads on the owners_dir_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _load_public_owners_dir(void* output_buffer,
+	const std::size_t size, const std::size_t count,
+	const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic load function
+ * @param output_buffer Pointer to the memory location where the value of the object should be stored
+ * @param count Number of elements to load
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa load from private window section
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform loads on the owners_dir_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _load_local_owners_dir(void* output_buffer,
+	const std::size_t count, const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic load function
+ * @param output_buffer Pointer to the memory location where the value of the object should be stored
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa load from private window section
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform loads on the offsets_tbl_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _load_local_offsets_tbl(void* output_buffer,
+	const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic CAS function
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param desired Pointer to the object that holds the desired value
+ * @param expected Pointer to the object that holds the expected value
+ * @param size sizeof(*obj) == sizeof(*desired) == sizeof(*expected) == sizeof(output_buffer)
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @sa compare_exchange
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _compare_exchange(global_ptr<void> obj, void* desired,
+	std::size_t size, void* expected, void* output_buffer);
+
+/**
+ * @brief Backend internal type erased atomic CAS function
+ * @param desired Pointer to the object that holds the desired value
+ * @param expected Pointer to the object that holds the expected value
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @param size == sizeof(*desired) == sizeof(*expected) == sizeof(*output_buffer)
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa compare_exchange
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform CAS on the owners_dir_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
+	const std::size_t size, const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic CAS function
+ * @param desired Pointer to the object that holds the desired value
+ * @param expected Pointer to the object that holds the expected value
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @param size == sizeof(*desired) == sizeof(*expected) == sizeof(*output_buffer)
+ * @param rank Rank of target window to which operation will be performed
+ * @param disp Displacement from start of window to beginning of target buffer
+ * @sa compare_exchange
+ * @note Implementation-specific function for the first-touch data distribution.
+ *       It is used to perform CAS on the offsets_tbl_window window.
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
+	const std::size_t size, const std::size_t rank, const std::size_t disp);
+
+/**
+ * @brief Backend internal type erased atomic (post)increment function for signed integers
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param value Pointer to the object that holds the desired value
+ * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @sa exchange
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _fetch_add_int(global_ptr<void> obj, void* value, std::size_t size,
+	void* output_buffer);
+/**
+ * @brief Backend internal type erased atomic (post)increment function for unsigned integers
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param value Pointer to the object that holds the desired value
+ * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @sa exchange
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _fetch_add_uint(global_ptr<void> obj, void* value, std::size_t size,
+	void* output_buffer);
+/**
+ * @brief Backend internal type erased atomic (post)increment function for floating point numbers
+ * @param obj Pointer to the object whose value should be exchanged
+ * @param value Pointer to the object that holds the desired value
+ * @param size sizeof(*obj) == sizeof(*desired) == sizeof(output_buffer)
+ * @param output_buffer Pointer to the memory location where the old value of the object should be stored
+ * @sa exchange
+ * @warning For internal use only - DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING
+ */
+void _fetch_add_float(global_ptr<void> obj, void* value, std::size_t size,
+	void* output_buffer);
+
+/**
+ * The following atomic functions are generic interfaces to the
+ * actual backend implementations
+ */
+
+/**
+ * @brief atomic swap operation on a global address
+ * @param obj pointer to the global object to swap
+ * @param desired the new value of the global object
+ * @param order Memory synchronization ordering for this operation
+ * @tparam T The type of the object to operate upon
+ * @tparam U The type of the object to exchange with
+ * @return the old value of the global object
+ *
+ * This function will atomically exchange the old value of the given
+ * object with the new one and return the old one.
+ */
+template<typename T, typename U>
+T exchange(global_ptr<T> obj, U desired, memory_order order = memory_order::acq_rel) {
+	T out_buffer;
+	static_assert(std::is_convertible<U, T>::value,
+		"It is not possible to implicitly convert \'desired\' to an"
+		" object of type T.");
+	T desired_buffer(desired);
+	static_assert(std::is_trivially_copy_assignable<T>::value,
+		"T must be trivially copy assignable");
+
+	if (order == memory_order::acq_rel || order == memory_order::release)
+		release();
+
+	_exchange(global_ptr<void>(obj), &desired_buffer, sizeof(T), &out_buffer);
+
+	if (order == memory_order::acq_rel || order == memory_order::acquire)
+		acquire();
+
+	return out_buffer;
+}
+
+/**
+ * @brief Atomic store operation on a global address
+ * @tparam T type of object to write
+ * @param obj pointer to the object to write to
+ * @param desired value to store in the object
+ * @param order Memory synchronization ordering for this operation
+ * @tparam T The type of the object to operate upon
+ * @tparam U The type of the object to store
+ *
+ * This function will atomically store the given value into the
+ * given memory location.
+ */
+template<typename T, typename U>
+void store(global_ptr<T> obj, U desired, memory_order order = memory_order::release) {
+	static_assert(std::is_convertible<U, T>::value,
+		"It is not possible to implicitly convert \'desired\' to an"
+		" object of type T.");
+	T desired_buffer(desired);
+	static_assert(std::is_trivially_copy_assignable<T>::value,
+		"T must be trivially copy assignable");
+
+	if (order == memory_order::acq_rel || order == memory_order::release)
+		release();
+
+	_store(global_ptr<void>(obj), &desired_buffer, sizeof(T));
+
+	if (order == memory_order::acq_rel || order == memory_order::acquire)
+		acquire();
+}
+
+/**
+ * @brief Atomic load operation on a global address
+ * @param obj Pointer to the global object to swap
+ * @param order Memory synchronization ordering for this operation
+ * @tparam T The type of the object to operate upon
+ * @return The value of the global object
+ *
+ * This function will atomically load the value from the given memory location.
+ */
+template<typename T>
+T load(global_ptr<T> obj, memory_order order = memory_order::acquire) {
+	T out_buffer;
+	static_assert(std::is_trivially_copy_assignable<T>::value,
+		"T must be trivially copy assignable");
+
+	if (order == memory_order::acq_rel || order == memory_order::release)
+		release();
+
+	_load(global_ptr<void>(obj), sizeof(T), &out_buffer);
+
+	if (order == memory_order::acq_rel || order == memory_order::acquire)
+		acquire();
+
+	return out_buffer;
+}
+
+/**
+ * @brief Atomic CAS operation on a global address
+ * @param obj Pointer to the global object to swap
+ * @param expected The value to compare against
+ * @param desired The value to set the object to
+ * @param order Memory synchronization ordering for this operation
+ * @tparam T The type of the object to operate upon
+ * @tparam U The type of the expected object
+ * @tparam U The type of the desired object
+ * @return true if successful, false otherwise
+ *
+ * This function will atomically swap the old (expected) value of
+ * the object with the new (desired) one, but only if the actual
+ * value of the object matches the expected one.
+ */
+template <typename T, typename U, typename V>
+bool compare_exchange(global_ptr<T> obj, U expected, V desired,
+	memory_order order = memory_order::acq_rel) {
+	T out_buffer;
+	static_assert(std::is_convertible<U, T>::value,
+		"It is not possible to implicitly convert \'expected\' to an"
+		" object of type T.");
+	static_assert(std::is_convertible<V, T>::value,
+		"It is not possible to implicitly convert \'desired\' to an"
+		" object of type T.");
+	T expected_buffer(expected);
+	T desired_buffer(desired);
+	static_assert(std::is_trivially_copy_assignable<T>::value,
+		"T must be trivially copy assignable");
+
+	if (order == memory_order::acq_rel || order == memory_order::release)
+		release();
+
+	// XXX: Is this strong or weak? MPI doesn't say anything
+	_compare_exchange(global_ptr<void>(obj), &desired_buffer, sizeof(T),
+		&expected_buffer, &out_buffer);
+
+	if (order == memory_order::acq_rel || order == memory_order::acquire)
+		acquire();
+
+	return out_buffer == expected_buffer;
+}
+
+/**
+ * @brief Atomic fetch and add operation on a global address
+ * @param obj Pointer to the global object to fetch and add to
+ * @param value The value to add to the object
+ * @param order Memory synchronization ordering for this operation
+ * @tparam T The type of the object to operate upon
+ * @tparam U The type of the value object
+ * @return The value of the object BEFORE the add operation
+ *
+ * This function will perform an atomic (*obj)+=(*value) operation.
+ */
+template <typename T, typename U>
+T fetch_add(global_ptr<T> obj, U value, memory_order order = memory_order::acq_rel) {
+	T out_buffer;
+	// We need a buffer with the same size as T
+	static_assert(std::is_convertible<U, T>::value,
+		"It is not possible to implicitly convert \'desired\' to an"
+		" object of type T.");
+	T value_buffer(value);
+	static_assert(std::is_trivially_copy_assignable<T>::value,
+		"T must be trivially copy assignable");
+
+	if (order == memory_order::acq_rel || order == memory_order::release)
+		release();
+
+	// The order is important here, as floats are signed as well
+	if (std::is_floating_point<T>::value)
+		_fetch_add_float(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
+	else if (std::is_unsigned<T>::value)
+		_fetch_add_uint(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
+	else if (std::is_signed<T>::value)
+		_fetch_add_int(global_ptr<void>(obj), &value_buffer, sizeof(T), &out_buffer);
+	else
+		throw std::invalid_argument("Invalid type V for value");
+
+	if (order == memory_order::acq_rel || order == memory_order::acquire)
+		acquire();
+
+	return out_buffer;
+}
+
+/**
+ * @brief Atomic fetch and add operation for pointers on a global address
+ * @param obj Pointer to the global object to fetch and add to
+ * @param value The value to add to the object
+ * @param order Memory synchronization ordering for this operation
+ * @tparam T The type of the pointer to operate upon
+ * @tparam U The type of the value object
+ * @return The value of the pointer BEFORE the add operation
+ *
+ * This function will perform an atomic (*obj)+=(*value) operation.
+ * This is an overload for pointer types, as pointer arithmetic
+ * works differently than normal integer and floating point arithmetic.
+ */
+template <typename T, typename U>
+T* fetch_add(global_ptr<T*> obj, U value, memory_order order = memory_order::acq_rel) {
+	T* out_buffer;
+	// We need a buffer with the same size as the pointer
+	void *value_buffer = reinterpret_cast<char*>(value * sizeof(T));
+
+	if (order == memory_order::acq_rel || order == memory_order::release)
+		release();
+
+	// Do the operation
+	_fetch_add_uint(global_ptr<void>(obj), &value_buffer, sizeof(T*), &out_buffer);
+
+	if (order == memory_order::acq_rel || order == memory_order::acquire)
+		acquire();
+
+	return out_buffer;
+}
+
+}  // namespace atomic
+}  // namespace backend
+}  // namespace argo
 
 #endif  // ARGODSM_SRC_BACKEND_BACKEND_HPP_

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -52,7 +52,7 @@ void _selective_acquire(void *addr, std::size_t size) {
 
 		// If the page is dirty, downgrade it
 		if(cacheControl[cache_index].dirty == DIRTY) {
-			mprotect((char*)start_address + page_address, block_size, PROT_READ);
+			mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_READ);
 			for(int i = 0; i <CACHELINE; i++) {
 				storepageDIFF(cache_index+i, page_address+page_size*i);
 			}
@@ -80,7 +80,7 @@ void _selective_acquire(void *addr, std::size_t size) {
 			cacheControl[cache_index].dirty = CLEAN;
 			cacheControl[cache_index].state = INVALID;
 			touchedcache[cache_index] = 0;
-			mprotect((char*)start_address + page_address, block_size, PROT_NONE);
+			mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_NONE);
 		}
 		cache_locks[cache_index].unlock();
 	}

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -46,77 +46,9 @@ void _selective_acquire(void *addr, std::size_t size) {
 			continue;
 		}
 
-<<<<<<< HEAD
-			const std::size_t block_size = page_size*CACHELINE;
-			const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
-			const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
-			std::size_t argo_address =
-				((reinterpret_cast<std::size_t>(addr)-start_address)/block_size)*block_size;
-			const node_id_t node_id = argo::backend::node_id();
-			const std::size_t node_id_bit = static_cast<std::size_t>(1) << node_id;
-
-			// Lock relevant mutexes. Start statistics timekeeping
-			double t1 = MPI_Wtime();
-			std::shared_lock lock(sync_lock);
-
-			// Iterate over all pages to selectively invalidate
-			for(std::size_t page_address = argo_address;
-					page_address < argo_address + page_misalignment + size;
-					page_address += block_size) {
-				const node_id_t homenode_id = peek_homenode(page_address);
-				// This page should be skipped in the following cases
-				// 1. The page is node local so no acquire is necessary
-				// 2. The page has not yet been first-touched and trying
-				// to perform an acquire would first-touch the page
-				if(	homenode_id == node_id ||
-					homenode_id == argo::data_distribution::invalid_node_id) {
-					continue;
-				}
-
-				const std::size_t cache_index = getCacheIndex(page_address);
-				const std::size_t classification_index = get_classification_index(page_address);
-				cache_locks[cache_index].lock();
-
-				// If the page is dirty, downgrade it
-				if(cacheControl[cache_index].dirty == DIRTY) {
-					mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_READ);
-					for(int i = 0; i < CACHELINE; i++) {
-						storepageDIFF(cache_index+i, page_address+page_size*i);
-					}
-					argo_write_buffer->erase(cache_index);
-					cacheControl[cache_index].dirty = CLEAN;
-				}
-
-				std::size_t win_index = get_sharer_win_index(classification_index);
-				// Optimization to keep pages in cache if they do not
-				// need to be invalidated.
-				mpi_lock_sharer[win_index][node_id].lock(MPI_LOCK_SHARED, node_id, sharer_windows[win_index][node_id]);
-				if(
-						// node is single writer
-						(globalSharers[classification_index+1] == node_id_bit)
-						||
-						// No writer and assert that the node is a sharer
-						((globalSharers[classification_index+1] == 0) &&
-						 ((globalSharers[classification_index] & node_id_bit) == node_id_bit))
-				  ) {
-					mpi_lock_sharer[win_index][node_id].unlock(node_id, sharer_windows[win_index][node_id]);
-					touchedcache[cache_index] = 1;
-					// nothing - we keep the pages, SD is done in flushWB
-				} else { // multiple writer or SO, invalidate the page
-					mpi_lock_sharer[win_index][node_id].unlock(node_id, sharer_windows[win_index][node_id]);
-					cacheControl[cache_index].dirty = CLEAN;
-					cacheControl[cache_index].state = INVALID;
-					touchedcache[cache_index] = 0;
-					mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_NONE);
-				}
-				cache_locks[cache_index].unlock();
-			}
-			double t2 = MPI_Wtime();
-=======
 		const std::size_t cache_index = getCacheIndex(page_address);
 		const std::size_t classification_index = get_classification_index(page_address);
 		cache_locks[cache_index].lock();
->>>>>>> 4d1dc86 (Do not indent inside namespaces)
 
 		// If the page is dirty, downgrade it
 		if(cacheControl[cache_index].dirty == DIRTY) {

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -12,13 +12,41 @@
 #include "virtual_memory/virtual_memory.hpp"
 
 namespace argo {
-	namespace backend {
-		void _selective_acquire(void *addr, std::size_t size) {
-			// Skip selective acquire if the size of the region is 0
-			if(size == 0) {
-				return;
-			}
+namespace backend {
 
+void _selective_acquire(void *addr, std::size_t size) {
+	// Skip selective acquire if the size of the region is 0
+	if(size == 0) {
+		return;
+	}
+
+	const std::size_t block_size = page_size*CACHELINE;
+	const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
+	const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
+	std::size_t argo_address =
+		((reinterpret_cast<std::size_t>(addr)-start_address)/block_size)*block_size;
+	const node_id_t node_id = argo::backend::node_id();
+	const std::size_t node_id_bit = static_cast<std::size_t>(1) << node_id;
+
+	// Lock relevant mutexes. Start statistics timekeeping
+	double t1 = MPI_Wtime();
+	std::shared_lock lock(sync_lock);
+
+	// Iterate over all pages to selectively invalidate
+	for(std::size_t page_address = argo_address;
+			page_address < argo_address + page_misalignment + size;
+			page_address += block_size) {
+		const node_id_t homenode_id = peek_homenode(page_address);
+		// This page should be skipped in the following cases
+		// 1. The page is node local so no acquire is necessary
+		// 2. The page has not yet been first-touched and trying
+		// to perform an acquire would first-touch the page
+		if(	homenode_id == node_id ||
+			homenode_id == argo::data_distribution::invalid_node_id) {
+			continue;
+		}
+
+<<<<<<< HEAD
 			const std::size_t block_size = page_size*CACHELINE;
 			const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
 			const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
@@ -84,68 +112,110 @@ namespace argo {
 				cache_locks[cache_index].unlock();
 			}
 			double t2 = MPI_Wtime();
+=======
+		const std::size_t cache_index = getCacheIndex(page_address);
+		const std::size_t classification_index = get_classification_index(page_address);
+		cache_locks[cache_index].lock();
+>>>>>>> 4d1dc86 (Do not indent inside namespaces)
 
-			// Poke the MPI system to force progress
-			int flag;
-			MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
-
-			std::lock_guard<std::mutex> ssi_time_lock(stats.ssi_time_mutex);
-			stats.ssi_time += t2-t1;
+		// If the page is dirty, downgrade it
+		if(cacheControl[cache_index].dirty == DIRTY) {
+			mprotect((char*)start_address + page_address, block_size, PROT_READ);
+			for(int i = 0; i <CACHELINE; i++) {
+				storepageDIFF(cache_index+i, page_address+page_size*i);
+			}
+			argo_write_buffer->erase(cache_index);
+			cacheControl[cache_index].dirty = CLEAN;
 		}
 
-		void _selective_release(void *addr, std::size_t size) {
-			// Skip selective release if the size of the region is 0
-			if(size == 0) {
-				return;
-			}
-
-			const std::size_t block_size = page_size*CACHELINE;
-			const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
-			const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
-			std::size_t argo_address =
-				((reinterpret_cast<std::size_t>(addr)-start_address)/block_size)*block_size;
-			const node_id_t node_id = argo::backend::node_id();
-
-			// Lock relevant mutexes. Start statistics timekeeping
-			double t1 = MPI_Wtime();
-			std::shared_lock lock(sync_lock);
-
-			// Iterate over all pages to selectively downgrade
-			for(std::size_t page_address = argo_address;
-					page_address < argo_address + page_misalignment + size;
-					page_address += block_size) {
-				const node_id_t homenode_id = peek_homenode(page_address);
-				// selective_release should be skipped in the following cases
-				// 1. The page is node local so no release is necessary
-				// 2. The page has not yet been first-touched and trying
-				// to perform a release would first-touch the page
-				if(	homenode_id == node_id ||
-					homenode_id == argo::data_distribution::invalid_node_id) {
-					continue;
-				}
-
-				const std::size_t cache_index = getCacheIndex(page_address);
-				cache_locks[cache_index].lock();
-
-				// If the page is dirty, downgrade it
-				if(cacheControl[cache_index].dirty == DIRTY) {
-					mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_READ);
-					for(int i = 0; i <CACHELINE; i++) {
-						storepageDIFF(cache_index+i, page_address+page_size*i);
-					}
-					argo_write_buffer->erase(cache_index);
-					cacheControl[cache_index].dirty = CLEAN;
-				}
-				cache_locks[cache_index].unlock();
-			}
-			double t2 = MPI_Wtime();
-
-			// Poke the MPI system to force progress
-			int flag;
-			MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
-
-			std::lock_guard<std::mutex> ssd_time_lock(stats.ssd_time_mutex);
-			stats.ssd_time += t2-t1;
+		std::size_t win_index = get_sharer_win_index(classification_index);
+		// Optimization to keep pages in cache if they do not
+		// need to be invalidated.
+		mpi_lock_sharer[win_index][node_id].lock(MPI_LOCK_SHARED, node_id, sharer_windows[win_index][node_id]);
+		if(
+				// node is single writer
+				(globalSharers[classification_index+1] == node_id_bit)
+				||
+				// No writer and assert that the node is a sharer
+				((globalSharers[classification_index+1] == 0) &&
+				 ((globalSharers[classification_index] & node_id_bit) == node_id_bit))
+		  ) {
+			mpi_lock_sharer[win_index][node_id].unlock(node_id, sharer_windows[win_index][node_id]);
+			touchedcache[cache_index] = 1;
+			// nothing - we keep the pages, SD is done in flushWB
+		} else { // multiple writer or SO, invalidate the page
+			mpi_lock_sharer[win_index][node_id].unlock(node_id, sharer_windows[win_index][node_id]);
+			cacheControl[cache_index].dirty = CLEAN;
+			cacheControl[cache_index].state = INVALID;
+			touchedcache[cache_index] = 0;
+			mprotect((char*)start_address + page_address, block_size, PROT_NONE);
 		}
-	} //namespace backend
-} //namespace argo
+		cache_locks[cache_index].unlock();
+	}
+	double t2 = MPI_Wtime();
+
+	// Poke the MPI system to force progress
+	int flag;
+	MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
+
+	std::lock_guard<std::mutex> ssi_time_lock(stats.ssi_time_mutex);
+	stats.ssi_time += t2-t1;
+}
+
+void _selective_release(void *addr, std::size_t size) {
+	// Skip selective release if the size of the region is 0
+	if(size == 0) {
+		return;
+	}
+
+	const std::size_t block_size = page_size*CACHELINE;
+	const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
+	const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
+	std::size_t argo_address =
+		((reinterpret_cast<std::size_t>(addr)-start_address)/block_size)*block_size;
+	const node_id_t node_id = argo::backend::node_id();
+
+	// Lock relevant mutexes. Start statistics timekeeping
+	double t1 = MPI_Wtime();
+	std::shared_lock lock(sync_lock);
+
+	// Iterate over all pages to selectively downgrade
+	for(std::size_t page_address = argo_address;
+			page_address < argo_address + page_misalignment + size;
+			page_address += block_size) {
+		const node_id_t homenode_id = peek_homenode(page_address);
+		// selective_release should be skipped in the following cases
+		// 1. The page is node local so no release is necessary
+		// 2. The page has not yet been first-touched and trying
+		// to perform a release would first-touch the page
+		if(	homenode_id == node_id ||
+			homenode_id == argo::data_distribution::invalid_node_id) {
+			continue;
+		}
+
+		const std::size_t cache_index = getCacheIndex(page_address);
+		cache_locks[cache_index].lock();
+
+		// If the page is dirty, downgrade it
+		if(cacheControl[cache_index].dirty == DIRTY) {
+			mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_READ);
+			for(int i = 0; i <CACHELINE; i++) {
+				storepageDIFF(cache_index+i, page_address+page_size*i);
+			}
+			argo_write_buffer->erase(cache_index);
+			cacheControl[cache_index].dirty = CLEAN;
+		}
+		cache_locks[cache_index].unlock();
+	}
+	double t2 = MPI_Wtime();
+
+	// Poke the MPI system to force progress
+	int flag;
+	MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, workcomm, &flag, MPI_STATUS_IGNORE);
+
+	std::lock_guard<std::mutex> ssd_time_lock(stats.ssd_time_mutex);
+	stats.ssd_time += t2-t1;
+}
+
+}  // namespace backend
+}  // namespace argo

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -116,219 +116,222 @@ static MPI_Datatype fitting_mpi_float(std::size_t size) {
 }
 
 namespace argo {
-	namespace backend {
-		void init(std::size_t argo_size, std::size_t cache_size) {
-			argo_initialize(argo_size, cache_size);
-		}
+namespace backend {
 
-		node_id_t node_id() {
-			return argo_get_nid();
-		}
+void init(std::size_t argo_size, std::size_t cache_size) {
+	argo_initialize(argo_size, cache_size);
+}
 
-		node_id_t number_of_nodes() {
-			return argo_get_nodes();
-		}
+node_id_t node_id() {
+	return argo_get_nid();
+}
 
-		char* global_base() {
-			return static_cast<char*>(argo_get_global_base());
-		}
+node_id_t number_of_nodes() {
+	return argo_get_nodes();
+}
 
-		std::size_t global_size() {
-			return argo_get_global_size();
-		}
+char* global_base() {
+	return static_cast<char*>(argo_get_global_base());
+}
 
-		bool is_cached(void* addr) {
-			return _is_cached(reinterpret_cast<std::size_t>(addr));
-		}
+std::size_t global_size() {
+	return argo_get_global_size();
+}
 
-		void reset_stats() {
-			argo_reset_stats();
-		}
+bool is_cached(void* addr) {
+	return _is_cached(reinterpret_cast<std::size_t>(addr));
+}
 
-		void finalize() {
-			argo_finalize();
-		}
+void reset_stats() {
+	argo_reset_stats();
+}
 
-		void reset_coherence() {
-			argo_reset_coherence();
-		}
+void finalize() {
+	argo_finalize();
+}
 
-		void barrier(std::size_t tc, upgrade_type upgrade) {
-			swdsm_argo_barrier(tc, upgrade);
-		}
+void reset_coherence() {
+	argo_reset_coherence();
+}
 
-		template<typename T>
-		void broadcast(node_id_t source, T* ptr) {
-			MPI_Bcast(static_cast<void*>(ptr), sizeof(T), MPI_BYTE, source, workcomm);
-		}
+void barrier(std::size_t tc, upgrade_type upgrade) {
+	swdsm_argo_barrier(tc, upgrade);
+}
 
-		void acquire() {
-			argo_acquire();
-			std::atomic_thread_fence(std::memory_order_acquire);
-		}
-		void release() {
-			std::atomic_thread_fence(std::memory_order_release);
-			argo_release();
-		}
+template<typename T>
+void broadcast(node_id_t source, T* ptr) {
+	MPI_Bcast(static_cast<void*>(ptr), sizeof(T), MPI_BYTE, source, workcomm);
+}
+
+void acquire() {
+	argo_acquire();
+	std::atomic_thread_fence(std::memory_order_acquire);
+}
+
+void release() {
+	std::atomic_thread_fence(std::memory_order_release);
+	argo_release();
+}
 
 #include "../explicit_instantiations.inc.cpp"
 
-		namespace atomic {
-			void _exchange(global_ptr<void> obj, void* desired,
-					std::size_t size, void* output_buffer) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the exchange operation
-				std::size_t win_index = get_data_win_index(obj.offset());
-				std::size_t win_offset = get_data_win_offset(obj.offset());
-				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
-				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-			}
+namespace atomic {
+	void _exchange(global_ptr<void> obj, void* desired,
+			std::size_t size, void* output_buffer) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the exchange operation
+		std::size_t win_index = get_data_win_index(obj.offset());
+		std::size_t win_offset = get_data_win_offset(obj.offset());
+		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+		MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
+		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+	}
 
-			void _store(global_ptr<void> obj, void* desired, std::size_t size) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the store operation
-				std::size_t win_index = get_data_win_index(obj.offset());
-				std::size_t win_offset = get_data_win_offset(obj.offset());
-				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Put(desired, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
-				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-			}
+	void _store(global_ptr<void> obj, void* desired, std::size_t size) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the store operation
+		std::size_t win_index = get_data_win_index(obj.offset());
+		std::size_t win_offset = get_data_win_offset(obj.offset());
+		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+		MPI_Put(desired, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
+		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+	}
 
-			void _store_public_owners_dir(const void* desired,
-					const std::size_t size, const std::size_t count,
-					const std::size_t rank, const std::size_t disp) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the store operation
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-				MPI_Put(desired, count, t_type, rank, disp, count, t_type, owners_dir_window);
-				MPI_Win_unlock(rank, owners_dir_window);
-			}
+	void _store_public_owners_dir(const void* desired,
+			const std::size_t size, const std::size_t count,
+			const std::size_t rank, const std::size_t disp) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the store operation
+		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
+		MPI_Put(desired, count, t_type, rank, disp, count, t_type, owners_dir_window);
+		MPI_Win_unlock(rank, owners_dir_window);
+	}
 
-			void _store_local_owners_dir(const std::size_t* desired,
-					const std::size_t count, const std::size_t rank, const std::size_t disp) {
-				// Perform the store operation
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-				std::copy(desired, desired + count, &global_owners_dir[disp]);
-				MPI_Win_unlock(rank, owners_dir_window);
-			}
+	void _store_local_owners_dir(const std::size_t* desired,
+			const std::size_t count, const std::size_t rank, const std::size_t disp) {
+		// Perform the store operation
+		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
+		std::copy(desired, desired + count, &global_owners_dir[disp]);
+		MPI_Win_unlock(rank, owners_dir_window);
+	}
 
-			void _store_local_offsets_tbl(const std::size_t desired,
-					const std::size_t rank, const std::size_t disp) {
-				// Perform the store operation
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
-				global_offsets_tbl[disp] = desired;
-				MPI_Win_unlock(rank, offsets_tbl_window);
-			}
+	void _store_local_offsets_tbl(const std::size_t desired,
+			const std::size_t rank, const std::size_t disp) {
+		// Perform the store operation
+		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
+		global_offsets_tbl[disp] = desired;
+		MPI_Win_unlock(rank, offsets_tbl_window);
+	}
 
-			void _load(global_ptr<void> obj, std::size_t size,
-					void* output_buffer) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the store operation
-				std::size_t win_index = get_data_win_index(obj.offset());
-				std::size_t win_offset = get_data_win_offset(obj.offset());
-				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
-				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-			}
+	void _load(global_ptr<void> obj, std::size_t size,
+			void* output_buffer) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the store operation
+		std::size_t win_index = get_data_win_index(obj.offset());
+		std::size_t win_offset = get_data_win_offset(obj.offset());
+		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
+		MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
+		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+	}
 
-			void _load_public_owners_dir(void* output_buffer,
-					const std::size_t size, const std::size_t count,
-					const std::size_t rank, const std::size_t disp) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the load operation
-				MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
-				MPI_Get(output_buffer, count, t_type, rank, disp, count, t_type, owners_dir_window);
-				MPI_Win_unlock(rank, owners_dir_window);
-			}
+	void _load_public_owners_dir(void* output_buffer,
+			const std::size_t size, const std::size_t count,
+			const std::size_t rank, const std::size_t disp) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the load operation
+		MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
+		MPI_Get(output_buffer, count, t_type, rank, disp, count, t_type, owners_dir_window);
+		MPI_Win_unlock(rank, owners_dir_window);
+	}
 
-			void _load_local_owners_dir(void* output_buffer,
-					const std::size_t count, const std::size_t rank, const std::size_t disp) {
-				// Perform the load operation
-				MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
-				std::copy(&global_owners_dir[disp],
-						&global_owners_dir[disp+count],
-						static_cast<std::size_t*>(output_buffer));
-				MPI_Win_unlock(rank, owners_dir_window);
-			}
+	void _load_local_owners_dir(void* output_buffer,
+			const std::size_t count, const std::size_t rank, const std::size_t disp) {
+		// Perform the load operation
+		MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
+		std::copy(&global_owners_dir[disp],
+				&global_owners_dir[disp+count],
+				static_cast<std::size_t*>(output_buffer));
+		MPI_Win_unlock(rank, owners_dir_window);
+	}
 
-			void _load_local_offsets_tbl(void* output_buffer,
-					const std::size_t rank, const std::size_t disp) {
-				// Perform the load operation
-				MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, offsets_tbl_window);
-				*(static_cast<std::size_t*>(output_buffer)) = global_offsets_tbl[disp];
-				MPI_Win_unlock(rank, offsets_tbl_window);
-			}
+	void _load_local_offsets_tbl(void* output_buffer,
+			const std::size_t rank, const std::size_t disp) {
+		// Perform the load operation
+		MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, offsets_tbl_window);
+		*(static_cast<std::size_t*>(output_buffer)) = global_offsets_tbl[disp];
+		MPI_Win_unlock(rank, offsets_tbl_window);
+	}
 
-			void _compare_exchange(global_ptr<void> obj, void* desired,
-					std::size_t size, void* expected, void* output_buffer) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the store operation
-				std::size_t win_index = get_data_win_index(obj.offset());
-				std::size_t win_offset = get_data_win_offset(obj.offset());
-				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
-				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-			}
+	void _compare_exchange(global_ptr<void> obj, void* desired,
+			std::size_t size, void* expected, void* output_buffer) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the store operation
+		std::size_t win_index = get_data_win_index(obj.offset());
+		std::size_t win_offset = get_data_win_offset(obj.offset());
+		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+		MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
+		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+	}
 
-			void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the compare-and-swap operation
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, owners_dir_window);
-				MPI_Win_unlock(rank, owners_dir_window);
-			}
+	void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
+			const std::size_t size, const std::size_t rank, const std::size_t disp) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the compare-and-swap operation
+		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
+		MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, owners_dir_window);
+		MPI_Win_unlock(rank, owners_dir_window);
+	}
 
-			void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				// Perform the compare-and-swap operation
-				MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
-				MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, offsets_tbl_window);
-				MPI_Win_unlock(rank, offsets_tbl_window);
-			}
+	void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
+			const std::size_t size, const std::size_t rank, const std::size_t disp) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		// Perform the compare-and-swap operation
+		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
+		MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, offsets_tbl_window);
+		MPI_Win_unlock(rank, offsets_tbl_window);
+	}
 
-			/**
-			 * @brief Atomic fetch&add for the MPI backend (for internal usage)
-			 *
-			 * This function requires the correct MPI type to work. Usually, you
-			 * want to use the three _fetch_add_{int,uint,float} functions
-			 * instead, which determine the correct type themselves and then
-			 * call this function
-			 *
-			 * @param obj The pointer to the memory location to modify
-			 * @param value Pointer to the value to add
-			 * @param t_type MPI type of the object, value, and output buffer
-			 * @param output_buffer Location to store the return value
-			 */
-			void _fetch_add(global_ptr<void> obj, void* value,
-					MPI_Datatype t_type, void* output_buffer) {
-				// Perform the exchange operation
-				std::size_t win_index = get_data_win_index(obj.offset());
-				std::size_t win_offset = get_data_win_offset(obj.offset());
-				mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-				MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
-				mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-			}
+	/**
+	 * @brief Atomic fetch&add for the MPI backend (for internal usage)
+	 *
+	 * This function requires the correct MPI type to work. Usually, you
+	 * want to use the three _fetch_add_{int,uint,float} functions
+	 * instead, which determine the correct type themselves and then
+	 * call this function
+	 *
+	 * @param obj The pointer to the memory location to modify
+	 * @param value Pointer to the value to add
+	 * @param t_type MPI type of the object, value, and output buffer
+	 * @param output_buffer Location to store the return value
+	 */
+	void _fetch_add(global_ptr<void> obj, void* value,
+			MPI_Datatype t_type, void* output_buffer) {
+		// Perform the exchange operation
+		std::size_t win_index = get_data_win_index(obj.offset());
+		std::size_t win_offset = get_data_win_offset(obj.offset());
+		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+		MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
+		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+	}
 
-			void _fetch_add_int(global_ptr<void> obj, void* value,
-					std::size_t size, void* output_buffer) {
-				MPI_Datatype t_type = fitting_mpi_int(size);
-				_fetch_add(obj, value, t_type, output_buffer);
-			}
+	void _fetch_add_int(global_ptr<void> obj, void* value,
+			std::size_t size, void* output_buffer) {
+		MPI_Datatype t_type = fitting_mpi_int(size);
+		_fetch_add(obj, value, t_type, output_buffer);
+	}
 
-			void _fetch_add_uint(global_ptr<void> obj, void* value,
-					std::size_t size, void* output_buffer) {
-				MPI_Datatype t_type = fitting_mpi_uint(size);
-				_fetch_add(obj, value, t_type, output_buffer);
-			}
+	void _fetch_add_uint(global_ptr<void> obj, void* value,
+			std::size_t size, void* output_buffer) {
+		MPI_Datatype t_type = fitting_mpi_uint(size);
+		_fetch_add(obj, value, t_type, output_buffer);
+	}
 
-			void _fetch_add_float(global_ptr<void> obj, void* value,
-					std::size_t size, void* output_buffer) {
-				MPI_Datatype t_type = fitting_mpi_float(size);
-				_fetch_add(obj, value, t_type, output_buffer);
-			}
-		} // namespace atomic
-	} // namespace backend
-} // namespace argo
+	void _fetch_add_float(global_ptr<void> obj, void* value,
+			std::size_t size, void* output_buffer) {
+		MPI_Datatype t_type = fitting_mpi_float(size);
+		_fetch_add(obj, value, t_type, output_buffer);
+	}
+
+}  // namespace atomic
+}  // namespace backend
+}  // namespace argo

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -176,161 +176,161 @@ void release() {
 #include "../explicit_instantiations.inc.cpp"
 
 namespace atomic {
-	void _exchange(global_ptr<void> obj, void* desired,
-			std::size_t size, void* output_buffer) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the exchange operation
-		std::size_t win_index = get_data_win_index(obj.offset());
-		std::size_t win_offset = get_data_win_offset(obj.offset());
-		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-		MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
-		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-	}
 
-	void _store(global_ptr<void> obj, void* desired, std::size_t size) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the store operation
-		std::size_t win_index = get_data_win_index(obj.offset());
-		std::size_t win_offset = get_data_win_offset(obj.offset());
-		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-		MPI_Put(desired, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
-		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-	}
+void _exchange(global_ptr<void> obj, void* desired,
+		std::size_t size, void* output_buffer) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the exchange operation
+	std::size_t win_index = get_data_win_index(obj.offset());
+	std::size_t win_offset = get_data_win_offset(obj.offset());
+	mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+	MPI_Fetch_and_op(desired, output_buffer, t_type, obj.node(), win_offset, MPI_REPLACE, data_windows[win_index][obj.node()]);
+	mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+}
 
-	void _store_public_owners_dir(const void* desired,
-			const std::size_t size, const std::size_t count,
-			const std::size_t rank, const std::size_t disp) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the store operation
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-		MPI_Put(desired, count, t_type, rank, disp, count, t_type, owners_dir_window);
-		MPI_Win_unlock(rank, owners_dir_window);
-	}
+void _store(global_ptr<void> obj, void* desired, std::size_t size) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the store operation
+	std::size_t win_index = get_data_win_index(obj.offset());
+	std::size_t win_offset = get_data_win_offset(obj.offset());
+	mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+	MPI_Put(desired, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
+	mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+}
 
-	void _store_local_owners_dir(const std::size_t* desired,
-			const std::size_t count, const std::size_t rank, const std::size_t disp) {
-		// Perform the store operation
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-		std::copy(desired, desired + count, &global_owners_dir[disp]);
-		MPI_Win_unlock(rank, owners_dir_window);
-	}
+void _store_public_owners_dir(const void* desired,
+		const std::size_t size, const std::size_t count,
+		const std::size_t rank, const std::size_t disp) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the store operation
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
+	MPI_Put(desired, count, t_type, rank, disp, count, t_type, owners_dir_window);
+	MPI_Win_unlock(rank, owners_dir_window);
+}
 
-	void _store_local_offsets_tbl(const std::size_t desired,
-			const std::size_t rank, const std::size_t disp) {
-		// Perform the store operation
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
-		global_offsets_tbl[disp] = desired;
-		MPI_Win_unlock(rank, offsets_tbl_window);
-	}
+void _store_local_owners_dir(const std::size_t* desired,
+		const std::size_t count, const std::size_t rank, const std::size_t disp) {
+	// Perform the store operation
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
+	std::copy(desired, desired + count, &global_owners_dir[disp]);
+	MPI_Win_unlock(rank, owners_dir_window);
+}
 
-	void _load(global_ptr<void> obj, std::size_t size,
-			void* output_buffer) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the store operation
-		std::size_t win_index = get_data_win_index(obj.offset());
-		std::size_t win_offset = get_data_win_offset(obj.offset());
-		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
-		MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
-		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-	}
+void _store_local_offsets_tbl(const std::size_t desired,
+		const std::size_t rank, const std::size_t disp) {
+	// Perform the store operation
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
+	global_offsets_tbl[disp] = desired;
+	MPI_Win_unlock(rank, offsets_tbl_window);
+}
 
-	void _load_public_owners_dir(void* output_buffer,
-			const std::size_t size, const std::size_t count,
-			const std::size_t rank, const std::size_t disp) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the load operation
-		MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
-		MPI_Get(output_buffer, count, t_type, rank, disp, count, t_type, owners_dir_window);
-		MPI_Win_unlock(rank, owners_dir_window);
-	}
+void _load(global_ptr<void> obj, std::size_t size, void* output_buffer) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the store operation
+	std::size_t win_index = get_data_win_index(obj.offset());
+	std::size_t win_offset = get_data_win_offset(obj.offset());
+	mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_SHARED, obj.node(), data_windows[win_index][obj.node()]);
+	MPI_Get(output_buffer, 1, t_type, obj.node(), win_offset, 1, t_type, data_windows[win_index][obj.node()]);
+	mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+}
 
-	void _load_local_owners_dir(void* output_buffer,
-			const std::size_t count, const std::size_t rank, const std::size_t disp) {
-		// Perform the load operation
-		MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
-		std::copy(&global_owners_dir[disp],
-				&global_owners_dir[disp+count],
-				static_cast<std::size_t*>(output_buffer));
-		MPI_Win_unlock(rank, owners_dir_window);
-	}
+void _load_public_owners_dir(void* output_buffer,
+		const std::size_t size, const std::size_t count,
+		const std::size_t rank, const std::size_t disp) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the load operation
+	MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
+	MPI_Get(output_buffer, count, t_type, rank, disp, count, t_type, owners_dir_window);
+	MPI_Win_unlock(rank, owners_dir_window);
+}
 
-	void _load_local_offsets_tbl(void* output_buffer,
-			const std::size_t rank, const std::size_t disp) {
-		// Perform the load operation
-		MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, offsets_tbl_window);
-		*(static_cast<std::size_t*>(output_buffer)) = global_offsets_tbl[disp];
-		MPI_Win_unlock(rank, offsets_tbl_window);
-	}
+void _load_local_owners_dir(void* output_buffer,
+		const std::size_t count, const std::size_t rank, const std::size_t disp) {
+	// Perform the load operation
+	MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, owners_dir_window);
+	std::copy(&global_owners_dir[disp],
+			&global_owners_dir[disp+count],
+			static_cast<std::size_t*>(output_buffer));
+	MPI_Win_unlock(rank, owners_dir_window);
+}
 
-	void _compare_exchange(global_ptr<void> obj, void* desired,
-			std::size_t size, void* expected, void* output_buffer) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the store operation
-		std::size_t win_index = get_data_win_index(obj.offset());
-		std::size_t win_offset = get_data_win_offset(obj.offset());
-		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-		MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
-		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-	}
+void _load_local_offsets_tbl(void* output_buffer,
+		const std::size_t rank, const std::size_t disp) {
+	// Perform the load operation
+	MPI_Win_lock(MPI_LOCK_SHARED, rank, 0, offsets_tbl_window);
+	*(static_cast<std::size_t*>(output_buffer)) = global_offsets_tbl[disp];
+	MPI_Win_unlock(rank, offsets_tbl_window);
+}
 
-	void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
-			const std::size_t size, const std::size_t rank, const std::size_t disp) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the compare-and-swap operation
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
-		MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, owners_dir_window);
-		MPI_Win_unlock(rank, owners_dir_window);
-	}
+void _compare_exchange(global_ptr<void> obj, void* desired,
+		std::size_t size, void* expected, void* output_buffer) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the store operation
+	std::size_t win_index = get_data_win_index(obj.offset());
+	std::size_t win_offset = get_data_win_offset(obj.offset());
+	mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+	MPI_Compare_and_swap(desired, expected, output_buffer, t_type, obj.node(), win_offset, data_windows[win_index][obj.node()]);
+	mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+}
 
-	void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
-			const std::size_t size, const std::size_t rank, const std::size_t disp) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		// Perform the compare-and-swap operation
-		MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
-		MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, offsets_tbl_window);
-		MPI_Win_unlock(rank, offsets_tbl_window);
-	}
+void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
+		const std::size_t size, const std::size_t rank, const std::size_t disp) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the compare-and-swap operation
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, owners_dir_window);
+	MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, owners_dir_window);
+	MPI_Win_unlock(rank, owners_dir_window);
+}
 
-	/**
-	 * @brief Atomic fetch&add for the MPI backend (for internal usage)
-	 *
-	 * This function requires the correct MPI type to work. Usually, you
-	 * want to use the three _fetch_add_{int,uint,float} functions
-	 * instead, which determine the correct type themselves and then
-	 * call this function
-	 *
-	 * @param obj The pointer to the memory location to modify
-	 * @param value Pointer to the value to add
-	 * @param t_type MPI type of the object, value, and output buffer
-	 * @param output_buffer Location to store the return value
-	 */
-	void _fetch_add(global_ptr<void> obj, void* value,
-			MPI_Datatype t_type, void* output_buffer) {
-		// Perform the exchange operation
-		std::size_t win_index = get_data_win_index(obj.offset());
-		std::size_t win_offset = get_data_win_offset(obj.offset());
-		mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
-		MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
-		mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
-	}
+void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
+		const std::size_t size, const std::size_t rank, const std::size_t disp) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	// Perform the compare-and-swap operation
+	MPI_Win_lock(MPI_LOCK_EXCLUSIVE, rank, 0, offsets_tbl_window);
+	MPI_Compare_and_swap(desired, expected, output_buffer, t_type, rank, disp, offsets_tbl_window);
+	MPI_Win_unlock(rank, offsets_tbl_window);
+}
 
-	void _fetch_add_int(global_ptr<void> obj, void* value,
-			std::size_t size, void* output_buffer) {
-		MPI_Datatype t_type = fitting_mpi_int(size);
-		_fetch_add(obj, value, t_type, output_buffer);
-	}
+/**
+ * @brief Atomic fetch&add for the MPI backend (for internal usage)
+ *
+ * This function requires the correct MPI type to work. Usually, you
+ * want to use the three _fetch_add_{int,uint,float} functions
+ * instead, which determine the correct type themselves and then
+ * call this function
+ *
+ * @param obj The pointer to the memory location to modify
+ * @param value Pointer to the value to add
+ * @param t_type MPI type of the object, value, and output buffer
+ * @param output_buffer Location to store the return value
+ */
+void _fetch_add(global_ptr<void> obj, void* value,
+		MPI_Datatype t_type, void* output_buffer) {
+	// Perform the exchange operation
+	std::size_t win_index = get_data_win_index(obj.offset());
+	std::size_t win_offset = get_data_win_offset(obj.offset());
+	mpi_lock_data[win_index][obj.node()].lock(MPI_LOCK_EXCLUSIVE, obj.node(), data_windows[win_index][obj.node()]);
+	MPI_Fetch_and_op(value, output_buffer, t_type, obj.node(), win_offset, MPI_SUM, data_windows[win_index][obj.node()]);
+	mpi_lock_data[win_index][obj.node()].unlock(obj.node(), data_windows[win_index][obj.node()]);
+}
 
-	void _fetch_add_uint(global_ptr<void> obj, void* value,
-			std::size_t size, void* output_buffer) {
-		MPI_Datatype t_type = fitting_mpi_uint(size);
-		_fetch_add(obj, value, t_type, output_buffer);
-	}
+void _fetch_add_int(global_ptr<void> obj, void* value,
+		std::size_t size, void* output_buffer) {
+	MPI_Datatype t_type = fitting_mpi_int(size);
+	_fetch_add(obj, value, t_type, output_buffer);
+}
 
-	void _fetch_add_float(global_ptr<void> obj, void* value,
-			std::size_t size, void* output_buffer) {
-		MPI_Datatype t_type = fitting_mpi_float(size);
-		_fetch_add(obj, value, t_type, output_buffer);
-	}
+void _fetch_add_uint(global_ptr<void> obj, void* value,
+		std::size_t size, void* output_buffer) {
+	MPI_Datatype t_type = fitting_mpi_uint(size);
+	_fetch_add(obj, value, t_type, output_buffer);
+}
+
+void _fetch_add_float(global_ptr<void> obj, void* value,
+		std::size_t size, void* output_buffer) {
+	MPI_Datatype t_type = fitting_mpi_float(size);
+	_fetch_add(obj, value, t_type, output_buffer);
+}
 
 }  // namespace atomic
 }  // namespace backend

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -77,348 +77,351 @@ void singlenode_handler(int sig, siginfo_t*, void*) {
 }
 
 namespace argo {
-	namespace backend {
-		void init(std::size_t argo_size, std::size_t cache_size) {
-			/** @todo the cache_size parameter is not needed
-			 *        and should not be part of the backend interface */
-			(void)(cache_size);
-			memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
-			memory_size = argo_size;
-			using namespace data_distribution;
-			base_distribution<0>::set_memory_space(nodes, memory, argo_size);
-			sig::signal_handler<SIGSEGV>::install_argo_handler(&singlenode_handler);
-			/** @note first-touch needs a directory for fetching
-			 *        the homenode and offset for an address */
-			if (is_first_touch_policy()) {
-				/* calculate the directory size and allocate memory */
-				std::size_t owners_dir_size = 3*(argo_size/4096UL);
-				std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
-				owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / 4096UL))*4096UL;
-				global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(4096UL, owners_dir_size_bytes));
-				/* hardcode first-touch directory values so
-				   that we perform only load operations */
-				for(std::size_t j = 0; j < owners_dir_size; j += 3) {
-					global_owners_dir[j] = 0;
-					global_owners_dir[j+1] = j/3 * 4096UL;
-					global_owners_dir[j+2] = 0;
-				}
-			}
+namespace backend {
+
+void init(std::size_t argo_size, std::size_t cache_size) {
+	/** @todo the cache_size parameter is not needed
+	 *        and should not be part of the backend interface */
+	(void)(cache_size);
+	memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
+	memory_size = argo_size;
+	using namespace data_distribution;
+	base_distribution<0>::set_memory_space(nodes, memory, argo_size);
+	sig::signal_handler<SIGSEGV>::install_argo_handler(&singlenode_handler);
+	/** @note first-touch needs a directory for fetching
+	 *        the homenode and offset for an address */
+	if (is_first_touch_policy()) {
+		/* calculate the directory size and allocate memory */
+		std::size_t owners_dir_size = 3*(argo_size/4096UL);
+		std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
+		owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / 4096UL))*4096UL;
+		global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(4096UL, owners_dir_size_bytes));
+		/* hardcode first-touch directory values so
+		   that we perform only load operations */
+		for(std::size_t j = 0; j < owners_dir_size; j += 3) {
+			global_owners_dir[j] = 0;
+			global_owners_dir[j+1] = j/3 * 4096UL;
+			global_owners_dir[j+2] = 0;
 		}
+	}
+}
 
-		node_id_t node_id() {
-			return my_node_id;
+node_id_t node_id() {
+	return my_node_id;
+}
+
+node_id_t number_of_nodes() {
+	return nodes;
+}
+
+char* global_base() {
+	return memory;
+}
+
+std::size_t global_size() {
+	return memory_size;
+}
+
+bool is_cached(void* addr) {
+	(void)addr;
+	return true;
+}
+
+void reset_stats() {}
+
+void finalize() {}
+
+void reset_coherence() {
+	using namespace data_distribution;
+	/** @note first-touch needs a directory for fetching
+	 *        the homenode and offset for an address */
+	if (is_first_touch_policy()) {
+		/* calculate the directory size and allocate memory */
+		std::size_t owners_dir_size = 3*(memory_size/4096UL);
+		std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
+		owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / 4096UL))*4096UL;
+		global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(4096UL, owners_dir_size_bytes));
+		/* hardcode first-touch directory values so
+		   that we perform only load operations */
+		for(std::size_t j = 0; j < owners_dir_size; j += 3) {
+			global_owners_dir[j] = 0;
+			global_owners_dir[j+1] = j/3 * 4096UL;
+			global_owners_dir[j+2] = 0;
 		}
+	}
+}
 
-		node_id_t number_of_nodes() {
-			return nodes;
-		}
+void barrier(std::size_t threadcount, upgrade_type upgrade) {
+	(void)upgrade;
+	/* initially: flag = false */
+	std::unique_lock<std::mutex> barrier_lock(barrier_mutex);
+	barrier_counter++;
+	if(barrier_counter == threadcount) {
+		/* avoid progress if some thread is still stuck in the previous barrier */
+		barrier_cv.wait(barrier_lock, []{ return !barrier_flag.load(); });
+		/* all threads in this barrier now,
+		 * flip flag to avoid progress in next barrier */
+		barrier_flag = true;
+		barrier_cv.notify_all();
+	}
 
-		char* global_base() {
-			return memory;
-		}
+	/* wait for flag to flip to ensure all threads have reached this barrier */
+	barrier_cv.wait(barrier_lock, []{ return barrier_flag.load(); });
 
-		std::size_t global_size() {
-			return memory_size;
-		}
+	/* all threads synchronized here. cleanup needed. */
 
-		bool is_cached(void* addr) {
-			(void)addr;
-			return true;
-		}
+	barrier_counter--;
+	if(barrier_counter == 0) {
+		/* all threads successfully left the wait call, allow next barrier */
+		barrier_flag = false;
+		barrier_cv.notify_all(); // other threads + unstick next barrier's final thread
+	}
 
-		void reset_stats() {}
+	/** @bug there is a race here when the next barrier does not require
+	 *       a thread stuck in this particular wait, which can then be
+	 *       delayed until the end of that other barrier call
+	 */
+	barrier_cv.wait(barrier_lock, []{ return !barrier_flag; });
+}
 
-		void finalize() {
-		}
+template<typename T>
+void broadcast(node_id_t source, T* ptr) {
+	(void)source; // source is always node 0
+	(void)ptr; // synchronization with self is a no-op
+}
 
-		void reset_coherence() {
-			using namespace data_distribution;
-			/** @note first-touch needs a directory for fetching
-			 *        the homenode and offset for an address */
-			if (is_first_touch_policy()) {
-				/* calculate the directory size and allocate memory */
-				std::size_t owners_dir_size = 3*(memory_size/4096UL);
-				std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
-				owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / 4096UL))*4096UL;
-				global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(4096UL, owners_dir_size_bytes));
-				/* hardcode first-touch directory values so
-				   that we perform only load operations */
-				for(std::size_t j = 0; j < owners_dir_size; j += 3) {
-					global_owners_dir[j] = 0;
-					global_owners_dir[j+1] = j/3 * 4096UL;
-					global_owners_dir[j+2] = 0;
-				}
+#include "../explicit_instantiations.inc.cpp"
+
+void acquire() {
+	std::atomic_thread_fence(std::memory_order_acquire);
+}
+
+void release() {
+	std::atomic_thread_fence(std::memory_order_release);
+}
+
+void _selective_acquire(void* addr, std::size_t size) {
+	(void)addr;
+	(void)size;
+	acquire();	// Selective acquire not actually possible here
+}
+
+void _selective_release(void* addr, std::size_t size) {
+	(void)addr;
+	(void)size;
+	release();	// Selective release not actually possible here
+}
+
+namespace atomic {
+
+void _exchange(global_ptr<void> obj, void* desired,
+		std::size_t size, void* output_buffer) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(output_buffer, obj.get(), size);
+	memcpy(obj.get(), desired, size);
+}
+
+void _store(global_ptr<void> obj, void* desired, std::size_t size) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(obj.get(), desired, size);
+}
+
+void _store_public_owners_dir(const void* desired,
+		const std::size_t size, const std::size_t count,
+		const std::size_t rank, const std::size_t disp) {
+	(void)desired;
+	(void)size;
+	(void)count;
+	(void)rank;
+	(void)disp;
+}
+
+void _store_local_owners_dir(const std::size_t* desired,
+		const std::size_t count, const std::size_t rank,
+		const std::size_t disp) {
+	(void)desired;
+	(void)count;
+	(void)rank;
+	(void)disp;
+}
+
+void _store_local_offsets_tbl(const std::size_t desired,
+		const std::size_t rank, const std::size_t disp) {
+	(void)desired;
+	(void)rank;
+	(void)disp;
+}
+
+void _load(global_ptr<void> obj, std::size_t size, void* output_buffer) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(output_buffer, obj.get(), size);
+}
+
+void _load_public_owners_dir(void* output_buffer,
+		const std::size_t size, const std::size_t count,
+		const std::size_t rank, const std::size_t disp) {
+	(void)output_buffer;
+	(void)size;
+	(void)count;
+	(void)rank;
+	(void)disp;
+}
+
+/**
+ * @note only load operations are performed on the first-touch
+ *       directory, since the values are hardcoded in the init call
+ */
+void _load_local_owners_dir(void* output_buffer,
+		const std::size_t count, const std::size_t rank,
+		const std::size_t disp) {
+	(void)rank;
+	std::copy(&global_owners_dir[disp],
+			&global_owners_dir[disp+count],
+			static_cast<std::size_t*>(output_buffer));
+}
+
+void _load_local_offsets_tbl(void* output_buffer,
+		const std::size_t rank, const std::size_t disp) {
+	(void)output_buffer;
+	(void)rank;
+	(void)disp;
+}
+
+void _compare_exchange(global_ptr<void> obj, void* desired,
+		std::size_t size, void* expected, void* output_buffer) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(output_buffer, obj.get(), size);
+	if (memcmp(obj.get(), expected, size) == 0) {
+		memcpy(obj.get(), desired, size);
+	}
+}
+
+void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
+		const std::size_t size, const std::size_t rank, const std::size_t disp) {
+	(void)desired;
+	(void)expected;
+	(void)output_buffer;
+	(void)size;
+	(void)rank;
+	(void)disp;
+}
+
+void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
+		const std::size_t size, const std::size_t rank, const std::size_t disp) {
+	(void)desired;
+	(void)expected;
+	(void)output_buffer;
+	(void)size;
+	(void)rank;
+	(void)disp;
+}
+
+void _fetch_add_int(global_ptr<void> obj, void* value,
+		std::size_t size, void* output_buffer) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(output_buffer, obj.get(), size);
+	// ewwww...
+	switch (size) {
+		case 1: {
+				char *ptr = static_cast<char*>(obj.get());
+				char *val = static_cast<char*>(value);
+				*ptr += *val;
+				break;
 			}
-		}
-
-		void barrier(std::size_t threadcount, upgrade_type upgrade) {
-			(void)upgrade;
-			/* initially: flag = false */
-			std::unique_lock<std::mutex> barrier_lock(barrier_mutex);
-			barrier_counter++;
-			if(barrier_counter == threadcount) {
-				/* avoid progress if some thread is still stuck in the previous barrier */
-				barrier_cv.wait(barrier_lock, []{ return !barrier_flag.load(); });
-				/* all threads in this barrier now,
-				 * flip flag to avoid progress in next barrier */
-				barrier_flag = true;
-				barrier_cv.notify_all();
+		case 2: {
+				int16_t *ptr = static_cast<int16_t*>(obj.get());
+				int16_t *val = static_cast<int16_t*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			/* wait for flag to flip to ensure all threads have reached this barrier */
-			barrier_cv.wait(barrier_lock, []{ return barrier_flag.load(); });
-
-			/* all threads synchronized here. cleanup needed. */
-
-			barrier_counter--;
-			if(barrier_counter == 0) {
-				/* all threads successfully left the wait call, allow next barrier */
-				barrier_flag = false;
-				barrier_cv.notify_all(); // other threads + unstick next barrier's final thread
+		case 4: {
+				int32_t *ptr = static_cast<int32_t*>(obj.get());
+				int32_t *val = static_cast<int32_t*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			/** @bug there is a race here when the next barrier does not require
-			 *       a thread stuck in this particular wait, which can then be
-			 *       delayed until the end of that other barrier call
-			 */
-			barrier_cv.wait(barrier_lock, []{ return !barrier_flag; });
-		}
-
-		template<typename T>
-		void broadcast(node_id_t source, T* ptr) {
-			(void)source; // source is always node 0
-			(void)ptr; // synchronization with self is a no-op
-		}
-
-#		include "../explicit_instantiations.inc.cpp"
-
-		void acquire() {
-			std::atomic_thread_fence(std::memory_order_acquire);
-		}
-		void release() {
-			std::atomic_thread_fence(std::memory_order_release);
-		}
-		void _selective_acquire(void* addr, std::size_t size) {
-			(void)addr;
-			(void)size;
-			acquire();	// Selective acquire not actually possible here
-		}
-		void _selective_release(void* addr, std::size_t size) {
-			(void)addr;
-			(void)size;
-			release();	// Selective release not actually possible here
-		}
-
-		namespace atomic {
-			void _exchange(global_ptr<void> obj, void* desired,
-					std::size_t size, void* output_buffer) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(output_buffer, obj.get(), size);
-				memcpy(obj.get(), desired, size);
+		case 8: {
+				int64_t *ptr = static_cast<int64_t*>(obj.get());
+				int64_t *val = static_cast<int64_t*>(value);
+				*ptr += *val;
+				break;
 			}
+		default:
+			throw std::invalid_argument(
+				"Invalid size (must be power either 1, 2, 4 or 8)");
+			break;
+	}
+}
 
-			void _store(global_ptr<void> obj, void* desired, std::size_t size) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(obj.get(), desired, size);
+void _fetch_add_uint(global_ptr<void> obj, void* value,
+		std::size_t size, void* output_buffer) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(output_buffer, obj.get(), size);
+	// ewwww...
+	switch (size) {
+		case 1: {
+				unsigned char *ptr = static_cast<unsigned char*>(obj.get());
+				unsigned char *val = static_cast<unsigned char*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			void _store_public_owners_dir(const void* desired,
-					const std::size_t size, const std::size_t count,
-					const std::size_t rank, const std::size_t disp) {
-				(void)desired;
-				(void)size;
-				(void)count;
-				(void)rank;
-				(void)disp;
+		case 2: {
+				uint16_t *ptr = static_cast<uint16_t*>(obj.get());
+				uint16_t *val = static_cast<uint16_t*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			void _store_local_owners_dir(const std::size_t* desired,
-					const std::size_t count, const std::size_t rank,
-					const std::size_t disp) {
-				(void)desired;
-				(void)count;
-				(void)rank;
-				(void)disp;
+		case 4: {
+				uint32_t *ptr = static_cast<uint32_t*>(obj.get());
+				uint32_t *val = static_cast<uint32_t*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			void _store_local_offsets_tbl(const std::size_t desired,
-					const std::size_t rank, const std::size_t disp) {
-				(void)desired;
-				(void)rank;
-				(void)disp;
+		case 8: {
+				uint64_t *ptr = static_cast<uint64_t*>(obj.get());
+				uint64_t *val = static_cast<uint64_t*>(value);
+				*ptr += *val;
+				break;
 			}
+		default:
+			throw std::invalid_argument(
+				"Invalid size (must be power either 1, 2, 4 or 8)");
+			break;
+	}
+}
 
-			void _load(
-					global_ptr<void> obj, std::size_t size, void* output_buffer) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(output_buffer, obj.get(), size);
+void _fetch_add_float(global_ptr<void> obj, void* value,
+		std::size_t size, void* output_buffer) {
+	lock_guard lock(atomic_op_mutex);
+	memcpy(output_buffer, obj.get(), size);
+	// ewwww...
+	switch (size) {
+		case sizeof(float): {
+				float *ptr = static_cast<float*>(obj.get());
+				float *val = static_cast<float*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			void _load_public_owners_dir(void* output_buffer,
-					const std::size_t size, const std::size_t count,
-					const std::size_t rank, const std::size_t disp) {
-				(void)output_buffer;
-				(void)size;
-				(void)count;
-				(void)rank;
-				(void)disp;
+		case sizeof(double): {
+				double *ptr = static_cast<double*>(obj.get());
+				double *val = static_cast<double*>(value);
+				*ptr += *val;
+				break;
 			}
-
-			/**
-			 * @note only load operations are performed on the first-touch
-			 *       directory, since the values are hardcoded in the init call
-			 */
-			void _load_local_owners_dir(void* output_buffer,
-					const std::size_t count, const std::size_t rank,
-					const std::size_t disp) {
-				(void)rank;
-				std::copy(&global_owners_dir[disp],
-						&global_owners_dir[disp+count],
-						static_cast<std::size_t*>(output_buffer));
+		case sizeof(long double): {
+				long double *ptr = static_cast<long double*>(obj.get());
+				long double *val = static_cast<long double*>(value);
+				*ptr += *val;
+				break;
 			}
+		default:
+			throw std::invalid_argument(
+				"Invalid size (must be power either 1, 2, 4 or 8)");
+			break;
+	}
+}
 
-			void _load_local_offsets_tbl(void* output_buffer,
-					const std::size_t rank, const std::size_t disp) {
-				(void)output_buffer;
-				(void)rank;
-				(void)disp;
-			}
-
-			void _compare_exchange(global_ptr<void> obj, void* desired,
-					std::size_t size, void* expected, void* output_buffer) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(output_buffer, obj.get(), size);
-				if (memcmp(obj.get(), expected, size) == 0) {
-					memcpy(obj.get(), desired, size);
-				}
-			}
-
-			void _compare_exchange_owners_dir(const void* desired, const void* expected, void* output_buffer,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
-				(void)desired;
-				(void)expected;
-				(void)output_buffer;
-				(void)size;
-				(void)rank;
-				(void)disp;
-			}
-
-			void _compare_exchange_offsets_tbl(const void* desired, const void* expected, void* output_buffer,
-					const std::size_t size, const std::size_t rank, const std::size_t disp) {
-				(void)desired;
-				(void)expected;
-				(void)output_buffer;
-				(void)size;
-				(void)rank;
-				(void)disp;
-			}
-
-			void _fetch_add_int(global_ptr<void> obj, void* value,
-					std::size_t size, void* output_buffer) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(output_buffer, obj.get(), size);
-				// ewwww...
-				switch (size) {
-					case 1: {
-							char *ptr = static_cast<char*>(obj.get());
-							char *val = static_cast<char*>(value);
-							*ptr += *val;
-							break;
-						}
-					case 2: {
-							int16_t *ptr = static_cast<int16_t*>(obj.get());
-							int16_t *val = static_cast<int16_t*>(value);
-							*ptr += *val;
-							break;
-						}
-					case 4: {
-							int32_t *ptr = static_cast<int32_t*>(obj.get());
-							int32_t *val = static_cast<int32_t*>(value);
-							*ptr += *val;
-							break;
-						}
-					case 8: {
-							int64_t *ptr = static_cast<int64_t*>(obj.get());
-							int64_t *val = static_cast<int64_t*>(value);
-							*ptr += *val;
-							break;
-						}
-					default:
-						throw std::invalid_argument(
-							"Invalid size (must be power either 1, 2, 4 or 8)");
-						break;
-				}
-			}
-
-			void _fetch_add_uint(global_ptr<void> obj, void* value,
-					std::size_t size, void* output_buffer) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(output_buffer, obj.get(), size);
-				// ewwww...
-				switch (size) {
-					case 1: {
-							unsigned char *ptr = static_cast<unsigned char*>(obj.get());
-							unsigned char *val = static_cast<unsigned char*>(value);
-							*ptr += *val;
-							break;
-						}
-					case 2: {
-							uint16_t *ptr = static_cast<uint16_t*>(obj.get());
-							uint16_t *val = static_cast<uint16_t*>(value);
-							*ptr += *val;
-							break;
-						}
-					case 4: {
-							uint32_t *ptr = static_cast<uint32_t*>(obj.get());
-							uint32_t *val = static_cast<uint32_t*>(value);
-							*ptr += *val;
-							break;
-						}
-					case 8: {
-							uint64_t *ptr = static_cast<uint64_t*>(obj.get());
-							uint64_t *val = static_cast<uint64_t*>(value);
-							*ptr += *val;
-							break;
-						}
-					default:
-						throw std::invalid_argument(
-							"Invalid size (must be power either 1, 2, 4 or 8)");
-						break;
-				}
-			}
-
-			void _fetch_add_float(global_ptr<void> obj, void* value,
-					std::size_t size, void* output_buffer) {
-				lock_guard lock(atomic_op_mutex);
-				memcpy(output_buffer, obj.get(), size);
-				// ewwww...
-				switch (size) {
-					case sizeof(float): {
-							float *ptr = static_cast<float*>(obj.get());
-							float *val = static_cast<float*>(value);
-							*ptr += *val;
-							break;
-						}
-					case sizeof(double): {
-							double *ptr = static_cast<double*>(obj.get());
-							double *val = static_cast<double*>(value);
-							*ptr += *val;
-							break;
-						}
-					case sizeof(long double): {
-							long double *ptr = static_cast<long double*>(obj.get());
-							long double *val = static_cast<long double*>(value);
-							*ptr += *val;
-							break;
-						}
-					default:
-						throw std::invalid_argument(
-							"Invalid size (must be power either 1, 2, 4 or 8)");
-						break;
-				}
-			}
-		} // namespace atomic
-
-	} // namespace backend
-} // namespace argo
+}  // namespace atomic
+}  // namespace backend
+}  // namespace argo
 

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -70,8 +70,7 @@ std::uintptr_t *global_owners_dir;
  */
 void singlenode_handler(int sig, siginfo_t*, void*) {
 	printf("A segfault was encountered in ArgoDSM memory. "
-		"This should never happen, as the singlenode backend is in use.\n"
-	);
+		"This should never happen, as the singlenode backend is in use.\n");
 	std::signal(sig, SIG_DFL);
 	std::raise(sig);
 }

--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -14,132 +14,133 @@
 #include "../types/types.hpp"
 
 namespace argo {
-	namespace data_distribution {
+namespace data_distribution {
 
-		/** @brief This constant is used to represent an invalid node id */
-		constexpr argo::node_id_t invalid_node_id = -1;
+/** @brief This constant is used to represent an invalid node id */
+constexpr argo::node_id_t invalid_node_id = -1;
 
-		/** @brief This constant is used to represent an invalid offset */
-		constexpr std::size_t invalid_offset = SIZE_MAX;
+/** @brief This constant is used to represent an invalid offset */
+constexpr std::size_t invalid_offset = SIZE_MAX;
 
-		/** @brief page size for the implementations */
-		static constexpr std::size_t granularity = 0x1000UL;
+/** @brief page size for the implementations */
+static constexpr std::size_t granularity = 0x1000UL;
 
-		/** @brief error message string for the implementations */
-		static const std::string msg_fetch_homenode_fail = "ArgoDSM failed to fetch a valid backing node. Please report a bug.";
-		/** @brief error message string for the implementations */
-		static const std::string msg_fetch_offset_fail = "ArgoDSM failed to fetch a valid backing offset. Please report a bug.";
+/** @brief error message string for the implementations */
+static const std::string msg_fetch_homenode_fail = "ArgoDSM failed to fetch a valid backing node. Please report a bug.";
+/** @brief error message string for the implementations */
+static const std::string msg_fetch_offset_fail = "ArgoDSM failed to fetch a valid backing offset. Please report a bug.";
+
+/**
+ * @brief the base data distribution class
+ * @details this is the parent class from which all the memory policies
+ *          inherit in order to implement their own homenode and
+ *          local_offset functions.
+ * @tparam instance used to statically allow for multiple instances
+ * @note all functions are defined on char* only, as this guarantees a
+ *       fixed memory base unit of size 1.
+ */
+template<int instance>
+class base_distribution {
+	protected:
+		/** @brief number of ArgoDSM nodes */
+		static node_id_t nodes;
+
+		/** @brief starting address of the memory space */
+		static char* start_address;
+
+		/** @brief size of the memory space */
+		static std::size_t total_size;
+
+		/** @brief one node's share of the memory space */
+		static std::size_t size_per_node;
+
+	public:
+		/**
+		 * @brief set runtime parameters for global memory space
+		 * @param n numer of ArgoDSM nodes
+		 * @param start pointer to the memory space
+		 * @param size size of the memory space
+		 */
+		static void set_memory_space(const node_id_t n, char* const start, const std::size_t size) {
+			nodes = n;
+			start_address = start;
+			total_size = size;
+			size_per_node = size / n;
+		}
 
 		/**
-		 * @brief the base data distribution class
-		 * @details this is the parent class from which all the memory policies
-		 *          inherit in order to implement their own homenode and
-		 *          local_offset functions.
-		 * @tparam instance used to statically allow for multiple instances
-		 * @note all functions are defined on char* only, as this guarantees a
-		 *       fixed memory base unit of size 1.
+		 * @brief get the backing store size per node
+		 * @return the value of size_per_node
 		 */
-		template<int instance>
-		class base_distribution {
-			protected:
-				/** @brief number of ArgoDSM nodes */
-				static node_id_t nodes;
+		static std::size_t get_size_per_node() {
+			return size_per_node;
+		}
 
-				/** @brief starting address of the memory space */
-				static char* start_address;
+		/**
+		 * @brief compute home node of an address
+		 * @param ptr address to find homenode of
+		 * @return the computed home node
+		 */
+		virtual node_id_t homenode(char* const ptr) {
+			(void)ptr;
+			return invalid_node_id;
+		}
 
-				/** @brief size of the memory space */
-				static std::size_t total_size;
+		/**
+		 * @brief compute home node of an address
+		 * @param ptr address to find homenode of
+		 * @return the computed home node, or ::invalid_node_id if
+		 * ptr has not yet been first-touched
+		 * @note this version shall not perform first-touch on an
+		 * address that has not yet been first touched
+		 */
+		virtual node_id_t peek_homenode(char* const ptr) {
+			(void)ptr;
+			return invalid_node_id;
+		}
 
-				/** @brief one node's share of the memory space */
-				static std::size_t size_per_node;
+		/**
+		 * @brief compute the offset of ptr in the backing store
+		 * on ptr's homenode
+		 * @param ptr address to find offset of
+		 * @return the backing store offset
+		 */
+		virtual std::size_t local_offset(char* const ptr) {
+			(void)ptr;
+			return invalid_offset;
+		}
 
-			public:
-				/**
-				 * @brief set runtime parameters for global memory space
-				 * @param n numer of ArgoDSM nodes
-				 * @param start pointer to the memory space
-				 * @param size size of the memory space
-				 */
-				static void set_memory_space(const node_id_t n, char* const start, const std::size_t size) {
-					nodes = n;
-					start_address = start;
-					total_size = size;
-					size_per_node = size / n;
-				}
+		/**
+		 * @brief compute the offset of ptr in the backing store
+		 * on ptr's homenode
+		 * @param ptr address to find offset of
+		 * does not have a valid offset
+		 * @return the backing store offset, or ::invalid_offset if
+		 * ptr has not yet been first-touched
+		 * @note this version shall not perform first-touch on an
+		 * address that has not yet been first touched
+		 */
+		virtual std::size_t peek_local_offset(char* const ptr) {
+			(void)ptr;
+			return invalid_offset;
+		}
 
-				/**
-				 * @brief get the backing store size per node
-				 * @return the value of size_per_node
-				 */
-				static std::size_t get_size_per_node() {
-					return size_per_node;
-				}
+		/**
+		 * @brief compute a pointer value
+		 * @param homenode the adress's home node
+		 * @param offset the offset in the home node's memory share
+		 * @return a pointer to the requested address
+		 */
+		static char* get_ptr(const node_id_t homenode, const std::size_t offset) {
+			return start_address + homenode*size_per_node + offset;
+		}
+};
+template<int i> node_id_t base_distribution<i>::nodes;
+template<int i> char* base_distribution<i>::start_address;
+template<int i> std::size_t base_distribution<i>::total_size;
+template<int i> std::size_t base_distribution<i>::size_per_node;
 
-				/**
-				 * @brief compute home node of an address
-				 * @param ptr address to find homenode of
-				 * @return the computed home node
-				 */
-				virtual node_id_t homenode(char* const ptr) {
-					(void)ptr;
-					return invalid_node_id;
-				}
-
-				/**
-				 * @brief compute home node of an address
-				 * @param ptr address to find homenode of
-				 * @return the computed home node, or ::invalid_node_id if
-				 * ptr has not yet been first-touched
-				 * @note this version shall not perform first-touch on an
-				 * address that has not yet been first touched
-				 */
-				virtual node_id_t peek_homenode(char* const ptr) {
-					(void)ptr;
-					return invalid_node_id;
-				}
-
-				/**
-				 * @brief compute the offset of ptr in the backing store
-				 * on ptr's homenode
-				 * @param ptr address to find offset of
-				 * @return the backing store offset
-				 */
-				virtual std::size_t local_offset(char* const ptr) {
-					(void)ptr;
-					return invalid_offset;
-				}
-
-				/**
-				 * @brief compute the offset of ptr in the backing store
-				 * on ptr's homenode
-				 * @param ptr address to find offset of
-				 * does not have a valid offset
-				 * @return the backing store offset, or ::invalid_offset if
-				 * ptr has not yet been first-touched
-				 * @note this version shall not perform first-touch on an
-				 * address that has not yet been first touched
-				 */
-				virtual std::size_t peek_local_offset(char* const ptr) {
-					(void)ptr;
-					return invalid_offset;
-				}
-
-				/**
-				 * @brief compute a pointer value
-				 * @param homenode the adress's home node
-				 * @param offset the offset in the home node's memory share
-				 * @return a pointer to the requested address
-				 */
-				static char* get_ptr(const node_id_t homenode, const std::size_t offset) {
-					return start_address + homenode*size_per_node + offset;
-				}
-		};
-		template<int i> node_id_t base_distribution<i>::nodes;
-		template<int i> char* base_distribution<i>::start_address;
-		template<int i> std::size_t base_distribution<i>::total_size;
-		template<int i> std::size_t base_distribution<i>::size_per_node;
-	} // namespace data_distribution
-} // namespace argo
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_BASE_DISTRIBUTION_HPP_

--- a/src/data_distribution/cyclic_distribution.hpp
+++ b/src/data_distribution/cyclic_distribution.hpp
@@ -10,52 +10,54 @@
 #include "base_distribution.hpp"
 
 namespace argo {
-	namespace data_distribution {
-		/**
-		 * @brief the cyclic data distribution
-		 * @details linearly distributes a block of pages per round in a round-robin fashion.
-		 */
-		template<int instance>
-		class cyclic_distribution : public base_distribution<instance> {
-			public:
-				virtual node_id_t homenode(char* const ptr) {
-					static const std::size_t pageblock = env::allocation_block_size() * granularity;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t pagenum = addr / pageblock;
-					const node_id_t homenode = pagenum % base_distribution<instance>::nodes;
+namespace data_distribution {
 
-					if(homenode >= base_distribution<instance>::nodes) {
-						std::cerr << msg_fetch_homenode_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-						exit(EXIT_FAILURE);
-					}
-					return homenode;
-				}
+/**
+ * @brief the cyclic data distribution
+ * @details linearly distributes a block of pages per round in a round-robin fashion.
+ */
+template<int instance>
+class cyclic_distribution : public base_distribution<instance> {
+	public:
+		virtual node_id_t homenode(char* const ptr) {
+			static const std::size_t pageblock = env::allocation_block_size() * granularity;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t pagenum = addr / pageblock;
+			const node_id_t homenode = pagenum % base_distribution<instance>::nodes;
 
-				virtual node_id_t peek_homenode(char* const ptr) {
-					return homenode(ptr);
-				}
+			if(homenode >= base_distribution<instance>::nodes) {
+				std::cerr << msg_fetch_homenode_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
+				exit(EXIT_FAILURE);
+			}
+			return homenode;
+		}
 
-				virtual std::size_t local_offset(char* const ptr) {
-					static const std::size_t pageblock = env::allocation_block_size() * granularity;
-					const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t pagenum = addr / pageblock;
-					const std::size_t offset = pagenum / base_distribution<instance>::nodes * pageblock + addr % pageblock + drift;
+		virtual node_id_t peek_homenode(char* const ptr) {
+			return homenode(ptr);
+		}
 
-					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
-						std::cerr << msg_fetch_offset_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-						exit(EXIT_FAILURE);
-					}
-					return offset;
-				}
+		virtual std::size_t local_offset(char* const ptr) {
+			static const std::size_t pageblock = env::allocation_block_size() * granularity;
+			const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t pagenum = addr / pageblock;
+			const std::size_t offset = pagenum / base_distribution<instance>::nodes * pageblock + addr % pageblock + drift;
 
-				virtual std::size_t peek_local_offset(char* const ptr) {
-					return local_offset(ptr);
-				}
-		};
-	} // namespace data_distribution
-} // namespace argo
+			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+				std::cerr << msg_fetch_offset_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
+				exit(EXIT_FAILURE);
+			}
+			return offset;
+		}
+
+		virtual std::size_t peek_local_offset(char* const ptr) {
+			return local_offset(ptr);
+		}
+};
+
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_CYCLIC_DISTRIBUTION_HPP_

--- a/src/data_distribution/data_distribution.hpp
+++ b/src/data_distribution/data_distribution.hpp
@@ -21,128 +21,119 @@
  *       backend definitions, and that is why we need to forward here.
  */
 namespace argo {
-	/* forward argo::backend function declarations */
-	namespace backend {
-		node_id_t number_of_nodes();
-	} // namespace backend
-} // namespace argo
+/* forward argo::backend function declarations */
+namespace backend {
+	node_id_t number_of_nodes();
+}  // namespace backend
+}  // namespace argo
 
 namespace argo {
-	namespace data_distribution {
-		/**
-		 * @brief Enumeration for the available distributions
-		 */
-		enum memory_policy {
-			/**
-			 * @brief the naive distribution scheme
-			 * @note distributes data at the default
-			 *       page granularity level (4KB).
-			 * @see naive_distribution.hpp
-			 * @see @ref ARGO_ALLOCATION_POLICY
-			 */
-			naive,
-			/**
-			 * @brief the cyclic policy
-			 * @note distributes data at a configu-
-			 *       rable page granularity level.
-			 * @see cyclic_distribution.hpp
-			 * @see @ref ARGO_ALLOCATION_POLICY
-			 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
-			 */
-			cyclic,
-			/**
-			 * @brief the skew-mapp policy
-			 * @note distributes data at a configu-
-			 *       rable page granularity level.
-			 * @see skew_mapp_distribution.hpp
-			 * @see @ref ARGO_ALLOCATION_POLICY
-			 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
-			 */
-			skew_mapp,
-			/**
-			 * @brief the prime-mapp policy
-			 * @note distributes data at a configu-
-			 *       rable page granularity level.
-			 * @see prime_mapp_distribution.hpp
-			 * @see @ref ARGO_ALLOCATION_POLICY
-			 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
-			 */
-			prime_mapp,
-			/**
-			 * @brief the first-touch policy
-			 * @note distributes data at the default
-			 *       page granularity level (4KB).
-			 * @see first_touch_distribution.hpp
-			 * @see @ref ARGO_ALLOCATION_POLICY
-			 */
-			first_touch
-		};
+namespace data_distribution {
 
-		/**
-		 * @brief identifies if we distribute data using
-		 *        a cyclic memory policy
-		 * @return true if we utilize a cyclic policy
-		 *         false if we don't utilize a cyclic policy
-		 */
-		static inline bool is_cyclic_policy() {
-			std::size_t policy = env::allocation_policy();
-			switch (policy) {
-				case cyclic	: return true;
-				case skew_mapp	: return true;
-				case prime_mapp	: return true;
-				default		: return false;
-			}
-		}
+/**
+ * @brief Enumeration for the available distributions
+ */
+enum memory_policy {
+	/**
+	 * @brief the naive distribution scheme
+	 * @note distributes data at the default
+	 *       page granularity level (4KB).
+	 * @see naive_distribution.hpp
+	 * @see @ref ARGO_ALLOCATION_POLICY
+	 */
+	naive,
+	/**
+	 * @brief the cyclic policy
+	 * @note distributes data at a configurable page granularity level.
+	 * @see cyclic_distribution.hpp
+	 * @see @ref ARGO_ALLOCATION_POLICY
+	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
+	 */
+	cyclic,
+	/**
+	 * @brief the skew-mapp policy
+	 * @note distributes data at a configurable page granularity level.
+	 * @see skew_mapp_distribution.hpp
+	 * @see @ref ARGO_ALLOCATION_POLICY
+	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
+	 */
+	skew_mapp,
+	/**
+	 * @brief the prime-mapp policy
+	 * @note distributes data at a configurable page granularity level.
+	 * @see prime_mapp_distribution.hpp
+	 * @see @ref ARGO_ALLOCATION_POLICY
+	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
+	 */
+	prime_mapp,
+	/**
+	 * @brief the first-touch policy
+	 * @note distributes data at the default page granularity level (4KB).
+	 * @see first_touch_distribution.hpp
+	 * @see @ref ARGO_ALLOCATION_POLICY
+	 */
+	first_touch
+};
 
-		/**
-		 * @brief identifies if we distribute data using
-		 *        the prime-mapp memory policy
-		 * @return true if we utilize the prime-mapp policy
-		 *         false if we don't utilize prime-mapp policy
-		 */
-		static inline bool is_prime_policy() {
-			std::size_t policy = env::allocation_policy();
-			return (policy == prime_mapp) ? true : false;
-		}
+/**
+ * @brief identifies if we distribute data using a cyclic memory policy
+ * @return true if we utilize a cyclic policy
+ *         false if we don't utilize a cyclic policy
+ */
+static inline bool is_cyclic_policy() {
+	std::size_t policy = env::allocation_policy();
+	switch (policy) {
+		case cyclic	: return true;
+		case skew_mapp	: return true;
+		case prime_mapp	: return true;
+		default		: return false;
+	}
+}
 
-		/**
-		 * @brief identifies if we distribute data using
-		 *        the first-touch memory policy
-		 * @return true if we utilize the first-touch policy
-		 *         false if we don't utilize first-touch policy
-		 */
-		static inline bool is_first_touch_policy() {
-			std::size_t policy = env::allocation_policy();
-			return (policy == first_touch) ? true : false;
-		}
+/**
+ * @brief identifies if we distribute data using the prime-mapp memory policy
+ * @return true if we utilize the prime-mapp policy
+ *         false if we don't utilize prime-mapp policy
+ */
+static inline bool is_prime_mapp_policy() {
+	return env::allocation_policy() == prime_mapp;
+}
 
-		/**
-		 * @brief based on the chosen policy, gets the required
-		 *        size we need to add to the standardisation of
-		 *        the ArgoDSM global memory space
-		 * @return the padding size based on the chosen policy
-		 */
-		static inline std::size_t policy_padding() {
-			std::size_t padding = (is_cyclic_policy()) ? env::allocation_block_size() : 1;
-			padding *= (is_prime_policy()) ? ((3 * argo::backend::number_of_nodes()) / 2) : 1;
-			return padding;
-		}
+/**
+ * @brief identifies if we distribute data using the first-touch memory policy
+ * @return true if we utilize the first-touch policy
+ *         false if we don't utilize first-touch policy
+ */
+static inline bool is_first_touch_policy() {
+	return env::allocation_policy() == first_touch;
+}
 
-		/**
-		 * @brief based on the chosen policy, gets the policy
-		 * 		  block size
-		 * @return The requested block size for all cyclical policies,
-		 * 		   the size of a page for the first-touch policy or the chunk
-		 * 		   size per node for the naive policy
-		 */
-		static inline std::size_t policy_block_size() {
-			if(is_cyclic_policy()) {
-				std::size_t requested_block_size = env::allocation_block_size();
-				return requested_block_size*granularity;
-			}
-			return is_first_touch_policy() ? granularity : base_distribution<0>::get_size_per_node();
-		}
-	} // namespace data_distribution
-} // namespace argo
+/**
+ * @brief based on the chosen policy, gets the required size we need to
+ *        add to the standardisation of the ArgoDSM global memory space
+ * @return the padding size based on the chosen policy
+ */
+static inline std::size_t policy_padding() {
+	std::size_t padding = (is_cyclic_policy()) ? env::allocation_block_size() : 1;
+	padding *= (is_prime_mapp_policy()) ? ((3 * argo::backend::number_of_nodes()) / 2) : 1;
+	return padding;
+}
+
+/**
+ * @brief based on the chosen policy, gets the policy block size
+ * @return The requested block size for all cyclical policies,
+ * 	   the size of a page for the first-touch policy or the chunk
+ * 	   size per node for the naive policy
+ */
+static inline std::size_t policy_block_size() {
+	if(is_cyclic_policy()) {
+		std::size_t requested_block_size = env::allocation_block_size();
+		return requested_block_size*granularity;
+	}
+	return is_first_touch_policy() ? granularity : base_distribution<0>::get_size_per_node();
+}
+
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_DATA_DISTRIBUTION_HPP_

--- a/src/data_distribution/first_touch_distribution.hpp
+++ b/src/data_distribution/first_touch_distribution.hpp
@@ -33,38 +33,42 @@ constexpr std::size_t page_info_size = single_entry_size * 3;
  *       backend definitions, and that is why we need to forward here.
  */
 namespace argo {
-	/* forward argo::backend function declarations */
-	namespace backend {
-		node_id_t node_id();
-		/* forward argo::backend::atomic function declarations */
-		namespace atomic {
-			void _store_public_owners_dir(const void* desired,
-				const std::size_t size, const std::size_t count,
-				const std::size_t rank, const std::size_t disp);
-			void _store_local_owners_dir(const std::size_t* desired,
-				const std::size_t count, const std::size_t rank,
-				const std::size_t disp);
-			void _store_local_offsets_tbl(const std::size_t desired,
-				const std::size_t rank, const std::size_t disp);
-			void _load_public_owners_dir(void* output_buffer,
-				const std::size_t size, const std::size_t count,
-				const std::size_t rank, const std::size_t disp);
-			void _load_local_owners_dir(void* output_buffer,
-				const std::size_t count, const std::size_t rank,
-				const std::size_t disp);
-			void _load_local_offsets_tbl(void* output_buffer,
-				const std::size_t rank, const std::size_t disp);
-			void _compare_exchange_owners_dir(const void* desired,
-				const void* expected, void* output_buffer,
-				const std::size_t size, const std::size_t rank,
-				const std::size_t disp);
-			void _compare_exchange_offsets_tbl(const void* desired,
-				const void* expected, void* output_buffer,
-				const std::size_t size, const std::size_t rank,
-				const std::size_t disp);
-		} // namespace atomic
-	} // namespace backend
-} // namespace argo
+/* forward argo::backend function declarations */
+namespace backend {
+
+node_id_t node_id();
+
+/* forward argo::backend::atomic function declarations */
+namespace atomic {
+
+void _store_public_owners_dir(const void* desired,
+	const std::size_t size, const std::size_t count,
+	const std::size_t rank, const std::size_t disp);
+void _store_local_owners_dir(const std::size_t* desired,
+	const std::size_t count, const std::size_t rank,
+	const std::size_t disp);
+void _store_local_offsets_tbl(const std::size_t desired,
+	const std::size_t rank, const std::size_t disp);
+void _load_public_owners_dir(void* output_buffer,
+	const std::size_t size, const std::size_t count,
+	const std::size_t rank, const std::size_t disp);
+void _load_local_owners_dir(void* output_buffer,
+	const std::size_t count, const std::size_t rank,
+	const std::size_t disp);
+void _load_local_offsets_tbl(void* output_buffer,
+	const std::size_t rank, const std::size_t disp);
+void _compare_exchange_owners_dir(const void* desired,
+	const void* expected, void* output_buffer,
+	const std::size_t size, const std::size_t rank,
+	const std::size_t disp);
+void _compare_exchange_offsets_tbl(const void* desired,
+	const void* expected, void* output_buffer,
+	const std::size_t size, const std::size_t rank,
+	const std::size_t disp);
+
+}  // namespace atomic
+}  // namespace backend
+}  // namespace argo
 
 /** @brief tiny macro to find if all the values of `page_info` are equal to a specific value */
 #define is_all_equal_to(arr, val) (((arr[0] == val) && (arr[1] == val) && (arr[2] == val)) ? 1 : 0)
@@ -75,251 +79,252 @@ namespace argo {
 static const std::string msg_first_touch_fail = "ArgoDSM failed to find a backing node. Please report a bug.";
 
 namespace argo {
-	namespace data_distribution {
+namespace data_distribution {
+/**
+ * @brief the first-touch data distribution
+ * @details gives ownership of a page to the node that first touched it.
+ * @note if a node's backing store size is not sufficient, it passes the
+ *       ownership of the page to a node that can host it.
+ */
+template<int instance>
+class first_touch_distribution : public base_distribution<instance> {
+	private:
 		/**
-		 * @brief the first-touch data distribution
-		 * @details gives ownership of a page to the node that first touched it.
-		 * @note if a node's backing store size is not sufficient, it passes the
-		 *       ownership of the page to a node that can host it.
+		 * @brief try and claim ownership of a page
+		 * @param addr address in the global address space
 		 */
-		template<int instance>
-		class first_touch_distribution : public base_distribution<instance> {
-			private:
-				/**
-				 * @brief try and claim ownership of a page
-				 * @param addr address in the global address space
-				 */
-				static void first_touch(const std::size_t& addr);
-				/**
-				 * @brief perform the necessary directory actions
-				 * @param addr address in the global address space
-				 * @param do_first_touch attempt to first touch if true
-				 */
-				static void update_dirs(const std::size_t& addr, bool do_first_touch = true);
-				/** @brief protects the owners directory */
-				std::mutex owners_mutex;
+		static void first_touch(const std::size_t& addr);
+		/**
+		 * @brief perform the necessary directory actions
+		 * @param addr address in the global address space
+		 * @param do_first_touch attempt to first touch if true
+		 */
+		static void update_dirs(const std::size_t& addr, bool do_first_touch = true);
+		/** @brief protects the owners directory */
+		std::mutex owners_mutex;
 
-			public:
-				virtual node_id_t peek_homenode(char* const ptr) {
-					std::size_t page_info[page_info_size];
-					node_id_t homenode = invalid_node_id;
-					static const std::size_t rank = argo::backend::node_id();
-					static const std::size_t global_null = base_distribution<instance>::total_size + 1;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
-
-					std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
-					def_lock.lock();
-					/* handle all the necessary directory actions for the global address */
-					update_dirs(addr, false);
-					/* spin in case the values other than `ownership` have not been reflected to the local window */
-					do {
-						argo::backend::atomic::_load_local_owners_dir(&page_info, page_info_size, rank, owners_dir_window_index);
-					} while (page_info[2] != global_null && page_info[0] == global_null);
-					def_lock.unlock();
-
-					/* Update the homenode if we found one */
-					if(page_info[0] != global_null) {
-						homenode = page_info[0];
-					}
-
-					if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
-						std::cerr << msg_fetch_homenode_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-						exit(EXIT_FAILURE);
-					}
-					return homenode;
-				}
-
-				virtual node_id_t homenode(char* const ptr) {
-					node_id_t homenode = invalid_node_id;
-					static const std::size_t rank = argo::backend::node_id();
-					static const std::size_t global_null = base_distribution<instance>::total_size + 1;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
-
-					std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
-					def_lock.lock();
-					/* handle all the necessary directory actions for the global address */
-					update_dirs(addr);
-					/* spin in case the values other than `ownership` have not been reflected to the local window */
-					do {
-						argo::backend::atomic::_load_local_owners_dir(&homenode,
-								single_entry_size, rank, owners_dir_window_index);
-					} while (homenode == static_cast<node_id_t>(global_null));
-					def_lock.unlock();
-
-					if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
-						std::cerr << msg_fetch_homenode_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-						exit(EXIT_FAILURE);
-					}
-					return homenode;
-				}
-
-				virtual std::size_t peek_local_offset(char* const ptr) {
-					std::size_t page_info[page_info_size];
-					std::size_t offset = invalid_offset;
-					static const std::size_t rank = argo::backend::node_id();
-					static const std::size_t global_null = base_distribution<instance>::total_size + 1;
-					const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
-
-					std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
-					def_lock.lock();
-					/* handle all the necessary directory actions for the global address */
-					update_dirs(addr, false);
-					/* spin in case the values other than `ownership` have not been reflected to the local window */
-					do {
-						argo::backend::atomic::_load_local_owners_dir(&page_info, page_info_size, rank, owners_dir_window_index);
-					} while (page_info[2] != global_null && page_info[1] == global_null);
-					def_lock.unlock();
-
-					/* Update the offset if we found one */
-					if(page_info[1] != global_null) {
-						offset = page_info[1] + drift;
-					}
-					if(offset != invalid_offset &&
-						offset >= base_distribution<instance>::size_per_node) {
-						std::cerr << msg_fetch_offset_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-						exit(EXIT_FAILURE);
-					}
-					return offset;
-				}
-
-				virtual std::size_t local_offset(char* const ptr) {
-					std::size_t offset = invalid_offset;
-					static const std::size_t rank = argo::backend::node_id();
-					static const std::size_t global_null = base_distribution<instance>::total_size + 1;
-					const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
-
-					std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
-					def_lock.lock();
-					/* handle all the necessary directory actions for the global address */
-					update_dirs(addr);
-					/* spin in case the values other than `ownership` have not been reflected to the local window */
-					do {
-						argo::backend::atomic::_load_local_owners_dir(&offset,
-								single_entry_size, rank, owners_dir_window_index+1);
-					} while (offset == global_null);
-					def_lock.unlock();
-					offset += drift;
-
-					if(offset >= base_distribution<instance>::size_per_node) {
-						std::cerr << msg_fetch_offset_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-						exit(EXIT_FAILURE);
-					}
-					return offset;
-				}
-		};
-
-		template<int instance>
-		void first_touch_distribution<instance>::update_dirs(const std::size_t& addr,
-				const bool do_first_touch) {
-			std::size_t ownership;
+	public:
+		virtual node_id_t peek_homenode(char* const ptr) {
+			std::size_t page_info[page_info_size];
+			node_id_t homenode = invalid_node_id;
 			static const std::size_t rank = argo::backend::node_id();
 			static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
 			const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
-			const std::size_t cas_node = (addr / granularity) % base_distribution<instance>::nodes;
 
-			/* fetch the ownership value for the page from the local window */
-			argo::backend::atomic::_load_local_owners_dir(&ownership,
-					single_entry_size, rank, owners_dir_window_index+2);
-			/* check if no info is found locally regarding the page */
-			if (ownership == global_null) {
-				/* load page info from the public cas_node window */
-				std::size_t page_info[page_info_size];
-				argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
-				/* check if any page info is found on the cas_node window */
-				if (!is_all_equal_to(page_info, global_null)) {
-					/* make sure that all the remote values are read correctly */
-					if (rank != cas_node) {
-						while (is_one_equal_to(page_info, global_null)) {
-							argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
-						}
-						/* store page info in the local window */
-						argo::backend::atomic::_store_local_owners_dir(page_info, page_info_size, rank, owners_dir_window_index);
-					}
-				} else {
-					if(do_first_touch) {
-						/* try to claim ownership of that page */
-						first_touch(addr);
-					}
-				}
+			std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
+			def_lock.lock();
+			/* handle all the necessary directory actions for the global address */
+			update_dirs(addr, false);
+			/* spin in case the values other than `ownership` have not been reflected to the local window */
+			do {
+				argo::backend::atomic::_load_local_owners_dir(&page_info, page_info_size, rank, owners_dir_window_index);
+			} while (page_info[2] != global_null && page_info[0] == global_null);
+			def_lock.unlock();
+
+			/* Update the homenode if we found one */
+			if(page_info[0] != global_null) {
+				homenode = page_info[0];
 			}
+
+			if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
+				std::cerr << msg_fetch_homenode_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
+				exit(EXIT_FAILURE);
+			}
+			return homenode;
 		}
 
-		template<int instance>
-		void first_touch_distribution<instance>::first_touch(const std::size_t& addr) {
-			/* variables for CAS */
-			std::size_t offset, homenode, result;
+		virtual node_id_t homenode(char* const ptr) {
+			node_id_t homenode = invalid_node_id;
 			static const std::size_t rank = argo::backend::node_id();
 			static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
 			const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
-			/* decentralize CAS */
-			const std::size_t cas_node = (addr / granularity) % base_distribution<instance>::nodes;
 
-			/* check/try to acquire ownership of the page with CAS to process' cas_node index */
-			argo::backend::atomic::_compare_exchange_owners_dir(&rank, &global_null, &result, sizeof(std::size_t), cas_node, owners_dir_window_index+2);
+			std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
+			def_lock.lock();
+			/* handle all the necessary directory actions for the global address */
+			update_dirs(addr);
+			/* spin in case the values other than `ownership` have not been reflected to the local window */
+			do {
+				argo::backend::atomic::_load_local_owners_dir(&homenode,
+						single_entry_size, rank, owners_dir_window_index);
+			} while (homenode == static_cast<node_id_t>(global_null));
+			def_lock.unlock();
 
-			/* this process was the first one to deposit its rank */
-			if (result == global_null) {
-				/* iterate through the nodes to find a valid offset for the page, starting from the currently running one */
-				bool succeeded = false;
-				std::size_t n, searched;
-				for(n = rank, searched = 0; searched < static_cast<std::size_t>(base_distribution<instance>::nodes);
-						n = (n + 1) % base_distribution<instance>::nodes, searched++) {
-					/* load backing offset for the node from the offsets table */
-					argo::backend::atomic::_load_local_offsets_tbl(&offset, rank, n);
-					/* check if the backing store size of this node is sufficient */
-					while (offset < base_distribution<instance>::size_per_node) {
-						/* try to claim a valid offset */
-						const std::size_t incr_offset = offset + granularity;
-						argo::backend::atomic::_compare_exchange_offsets_tbl(&incr_offset, &offset, &result, sizeof(std::size_t), n, n);
-						if (result == offset) { succeeded = true; homenode = n; break; }
-						offset = result;
-					}
-					/* cache the offset returned from a remote CAS operation */
-					if (n != rank) {
-						argo::backend::atomic::_store_local_offsets_tbl(offset, rank, n);
-					}
-					/* succeeded, leave */
-					if (succeeded) break;
+			if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
+				std::cerr << msg_fetch_homenode_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
+				exit(EXIT_FAILURE);
+			}
+			return homenode;
+		}
+
+		virtual std::size_t peek_local_offset(char* const ptr) {
+			std::size_t page_info[page_info_size];
+			std::size_t offset = invalid_offset;
+			static const std::size_t rank = argo::backend::node_id();
+			static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+			const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
+
+			std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
+			def_lock.lock();
+			/* handle all the necessary directory actions for the global address */
+			update_dirs(addr, false);
+			/* spin in case the values other than `ownership` have not been reflected to the local window */
+			do {
+				argo::backend::atomic::_load_local_owners_dir(&page_info, page_info_size, rank, owners_dir_window_index);
+			} while (page_info[2] != global_null && page_info[1] == global_null);
+			def_lock.unlock();
+
+			/* Update the offset if we found one */
+			if(page_info[1] != global_null) {
+				offset = page_info[1] + drift;
+			}
+			if(offset != invalid_offset &&
+				offset >= base_distribution<instance>::size_per_node) {
+				std::cerr << msg_fetch_offset_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
+				exit(EXIT_FAILURE);
+			}
+			return offset;
+		}
+
+		virtual std::size_t local_offset(char* const ptr) {
+			std::size_t offset = invalid_offset;
+			static const std::size_t rank = argo::backend::node_id();
+			static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+			const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
+
+			std::unique_lock<std::mutex> def_lock(owners_mutex, std::defer_lock);
+			def_lock.lock();
+			/* handle all the necessary directory actions for the global address */
+			update_dirs(addr);
+			/* spin in case the values other than `ownership` have not been reflected to the local window */
+			do {
+				argo::backend::atomic::_load_local_owners_dir(&offset,
+						single_entry_size, rank, owners_dir_window_index+1);
+			} while (offset == global_null);
+			def_lock.unlock();
+			offset += drift;
+
+			if(offset >= base_distribution<instance>::size_per_node) {
+				std::cerr << msg_fetch_offset_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
+				exit(EXIT_FAILURE);
+			}
+			return offset;
+		}
+};
+
+template<int instance>
+void first_touch_distribution<instance>::update_dirs(const std::size_t& addr,
+		const bool do_first_touch) {
+	std::size_t ownership;
+	static const std::size_t rank = argo::backend::node_id();
+	static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+	const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
+	const std::size_t cas_node = (addr / granularity) % base_distribution<instance>::nodes;
+
+	/* fetch the ownership value for the page from the local window */
+	argo::backend::atomic::_load_local_owners_dir(&ownership,
+			single_entry_size, rank, owners_dir_window_index+2);
+	/* check if no info is found locally regarding the page */
+	if (ownership == global_null) {
+		/* load page info from the public cas_node window */
+		std::size_t page_info[page_info_size];
+		argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
+		/* check if any page info is found on the cas_node window */
+		if (!is_all_equal_to(page_info, global_null)) {
+			/* make sure that all the remote values are read correctly */
+			if (rank != cas_node) {
+				while (is_one_equal_to(page_info, global_null)) {
+					argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
 				}
-
-				/* this should never happen */
-				if (!succeeded) {
-					std::cerr << msg_first_touch_fail << std::endl;
-					throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_first_touch_fail);
-					exit(EXIT_FAILURE);
-				}
-
 				/* store page info in the local window */
-				std::size_t page_info[page_info_size] = {homenode, offset, rank};
 				argo::backend::atomic::_store_local_owners_dir(page_info, page_info_size, rank, owners_dir_window_index);
-
-				/* store page info in the remote public cas_node window */
-				if (rank != cas_node) {
-					argo::backend::atomic::_store_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
-				}
-			} else {
-				/* load page info from the remote public cas_node window */
-				if (rank != cas_node) {
-					std::size_t page_info[page_info_size];
-					do {
-						argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
-					} while (is_one_equal_to(page_info, global_null));
-					/* store page info in the local window */
-					argo::backend::atomic::_store_local_owners_dir(page_info, page_info_size, rank, owners_dir_window_index);
-				}
+			}
+		} else {
+			if(do_first_touch) {
+				/* try to claim ownership of that page */
+				first_touch(addr);
 			}
 		}
-	} // namespace data_distribution
-} // namespace argo
+	}
+}
+
+template<int instance>
+void first_touch_distribution<instance>::first_touch(const std::size_t& addr) {
+	/* variables for CAS */
+	std::size_t offset, homenode, result;
+	static const std::size_t rank = argo::backend::node_id();
+	static const std::size_t global_null = base_distribution<instance>::total_size + 1;
+	const std::size_t owners_dir_window_index = page_info_size * (addr / granularity);
+	/* decentralize CAS */
+	const std::size_t cas_node = (addr / granularity) % base_distribution<instance>::nodes;
+
+	/* check/try to acquire ownership of the page with CAS to process' cas_node index */
+	argo::backend::atomic::_compare_exchange_owners_dir(&rank, &global_null, &result, sizeof(std::size_t), cas_node, owners_dir_window_index+2);
+
+	/* this process was the first one to deposit its rank */
+	if (result == global_null) {
+		/* iterate through the nodes to find a valid offset for the page, starting from the currently running one */
+		bool succeeded = false;
+		std::size_t n, searched;
+		for(n = rank, searched = 0; searched < static_cast<std::size_t>(base_distribution<instance>::nodes);
+				n = (n + 1) % base_distribution<instance>::nodes, searched++) {
+			/* load backing offset for the node from the offsets table */
+			argo::backend::atomic::_load_local_offsets_tbl(&offset, rank, n);
+			/* check if the backing store size of this node is sufficient */
+			while (offset < base_distribution<instance>::size_per_node) {
+				/* try to claim a valid offset */
+				const std::size_t incr_offset = offset + granularity;
+				argo::backend::atomic::_compare_exchange_offsets_tbl(&incr_offset, &offset, &result, sizeof(std::size_t), n, n);
+				if (result == offset) { succeeded = true; homenode = n; break; }
+				offset = result;
+			}
+			/* cache the offset returned from a remote CAS operation */
+			if (n != rank) {
+				argo::backend::atomic::_store_local_offsets_tbl(offset, rank, n);
+			}
+			/* succeeded, leave */
+			if (succeeded) break;
+		}
+
+		/* this should never happen */
+		if (!succeeded) {
+			std::cerr << msg_first_touch_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_first_touch_fail);
+			exit(EXIT_FAILURE);
+		}
+
+		/* store page info in the local window */
+		std::size_t page_info[page_info_size] = {homenode, offset, rank};
+		argo::backend::atomic::_store_local_owners_dir(page_info, page_info_size, rank, owners_dir_window_index);
+
+		/* store page info in the remote public cas_node window */
+		if (rank != cas_node) {
+			argo::backend::atomic::_store_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
+		}
+	} else {
+		/* load page info from the remote public cas_node window */
+		if (rank != cas_node) {
+			std::size_t page_info[page_info_size];
+			do {
+				argo::backend::atomic::_load_public_owners_dir(page_info, sizeof(std::size_t), page_info_size, cas_node, owners_dir_window_index);
+			} while (is_one_equal_to(page_info, global_null));
+			/* store page info in the local window */
+			argo::backend::atomic::_store_local_owners_dir(page_info, page_info_size, rank, owners_dir_window_index);
+		}
+	}
+}
+
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_FIRST_TOUCH_DISTRIBUTION_HPP_

--- a/src/data_distribution/global_ptr.hpp
+++ b/src/data_distribution/global_ptr.hpp
@@ -13,161 +13,160 @@
 #include "data_distribution.hpp"
 
 namespace argo {
-	namespace data_distribution {
+namespace data_distribution {
+
+/**
+ * @brief smart pointers for global memory addresses
+ * @tparam T pointer to T
+ */
+template<typename T, class Dist = base_distribution<0>>
+class global_ptr {
+	private:
+		/** @brief the ArgoDSM node this pointer is pointing to */
+		node_id_t homenode;
+
+		/** @brief local offset in the ArgoDSM node's local share of the global memory */
+		std::size_t local_offset;
+
+		/** @brief pointer to the object in global memory this smart pointer is pointing to */
+		T* access_ptr;
+
+		/** @brief array holding an instance of each available policy */
+		static Dist* policies[5];
+
+	public:
+		/** @brief construct nullptr */
+		global_ptr() : homenode(invalid_node_id), local_offset(invalid_offset) {}
+
 		/**
-		 * @brief smart pointers for global memory addresses
-		 * @tparam T pointer to T
+		 * @brief construct from virtual address pointer
+		 * @param ptr pointer to construct from
+		 * @param compute_homenode If true, compute the homenode in constructor
+		 * @param compute_offset If true, compute local offset in constructor
 		 */
-		template<typename T, class Dist = base_distribution<0>>
-		class global_ptr {
-			private:
-				/** @brief the ArgoDSM node this pointer is pointing to */
-				node_id_t homenode;
+		global_ptr(T* ptr, const bool compute_homenode = true,
+							const bool compute_offset = true)
+				: homenode(invalid_node_id), local_offset(invalid_offset), access_ptr(ptr) {
+			if(compute_homenode) {
+				homenode = policy()->homenode(reinterpret_cast<char*>(ptr));
+			}
+			if(compute_offset) {
+				local_offset = policy()->local_offset(reinterpret_cast<char*>(ptr));
+			}
+		}
 
-				/** @brief local offset in the ArgoDSM node's local share of the global memory */
-				std::size_t local_offset;
+		/**
+		 * @brief Copy constructor between different pointer types
+		 * @param other The pointer to copy from
+		 */
+		template<typename U>
+		explicit global_ptr(global_ptr<U> other)
+			: homenode(other.node()), local_offset(other.offset()), access_ptr(other.get()) {}
 
-				/** @brief pointer to the object in global memory this smart pointer is pointing to */
-				T* access_ptr;
+		/**
+		 * @brief get standard pointer
+		 * @return pointer to object this smart pointer is pointing to
+		 * @todo implement
+		 */
+		T* get() const {
+			/**
+			 * @note the get_ptr invocation is kept here to re-
+			 *       member where and for what it was used for.
+			 */
+			// return reinterpret_cast<T*>(get_ptr(homenode, local_offset));
+			return access_ptr;
+		}
 
-				/** @brief array holding an instance of each available policy */
-				static Dist* policies[5];
+		/**
+		 * @brief dereference smart pointer
+		 * @return dereferenced object
+		 */
+		typename std::add_lvalue_reference<T>::type operator*() const {
+			return *this->get();
+		}
 
-			public:
-				/** @brief construct nullptr */
-				global_ptr() : homenode(invalid_node_id), local_offset(invalid_offset) {}
-
-				/**
-				 * @brief construct from virtual address pointer
-				 * @param ptr pointer to construct from
-				 * @param compute_homenode If true, compute the homenode in constructor
-				 * @param compute_offset If true, compute local offset in constructor
-				 */
-				global_ptr(T* ptr, const bool compute_homenode = true,
-									const bool compute_offset = true)
-						: homenode(invalid_node_id), local_offset(invalid_offset), access_ptr(ptr) {
-					if(compute_homenode) {
-						homenode = policy()->homenode(reinterpret_cast<char*>(ptr));
-					}
-					if(compute_offset) {
-						local_offset = policy()->local_offset(reinterpret_cast<char*>(ptr));
-					}
+		/**
+		 * @brief return the home node of the value pointed to
+		 * @return home node id
+		 */
+		node_id_t node() {
+			// If homenode is not yet calculated we need to find it
+			if(homenode == invalid_node_id) {
+				homenode = policy()->homenode(reinterpret_cast<char*>(access_ptr));
+			}
+			return homenode;
 				}
 
-				/**
-				 * @brief Copy constructor between different pointer types
-				 * @param other The pointer to copy from
-				 */
-				template<typename U>
-				explicit global_ptr(global_ptr<U> other)
-					: homenode(other.node()), local_offset(other.offset()), access_ptr(other.get()) {}
-
-				/**
-				 * @brief get standard pointer
-				 * @return pointer to object this smart pointer is pointing to
-				 * @todo implement
-				 */
-				T* get() const {
-					/**
-					 * @note the get_ptr invocation is kept here to re-
-					 *       member where and for what it was used for.
-					 */
-					// return reinterpret_cast<T*>(get_ptr(homenode, local_offset));
-					return access_ptr;
+		/**
+		 * @brief return the home node of the value pointed to, or a
+		 * default value if the page has not yet been first-touched
+		 * under first-touch allocation.
+		 * @return home node id, or argo::data_distribution::invalid_node_id
+		 * if access_ptr has not been first-touched yet under the
+		 * first-touch allocation policy
+		 */
+		node_id_t peek_node() {
+			// If homenode is not yet calculated we need to find it
+			if(homenode == invalid_node_id) {
+				// Avoid invoking first-touch
+				node_id_t new_node = policy()->peek_homenode(reinterpret_cast<char*>(access_ptr));
+				if(new_node != invalid_node_id) {
+					homenode = new_node;
 				}
+			}
+			return homenode;
+		}
 
-				/**
-				 * @brief dereference smart pointer
-				 * @return dereferenced object
-				 */
-				typename std::add_lvalue_reference<T>::type operator*() const {
-					return *this->get();
-				}
+		/**
+		 * @brief return the offset on the home node's local memory share
+		 * @return local offset
+		 */
+		std::size_t offset() {
+			if(local_offset == invalid_offset) {
+				local_offset = policy()->local_offset(reinterpret_cast<char*>(access_ptr));
+			}
+			return local_offset;
+		}
 
-				/**
-				 * @brief return the home node of the value pointed to
-				 * @return home node id
-				 */
-				node_id_t node() {
-					// If homenode is not yet calculated we need to find it
-					if(homenode == invalid_node_id) {
-						homenode = policy()->homenode(
-								reinterpret_cast<char*>(access_ptr));
-					}
-					return homenode;
+		/**
+		 * @brief return the offset on the home node's local memory share
+		 * or a default value if the page has not yet been first-touched
+		 * under first-touch allocation.
+		 * @return local offset, or argo::data_distribution::invalid_offset
+		 * if access_ptr has not been first-touched yet under the
+		 * first-touch allocation policy
+		 */
+		std::size_t peek_offset() {
+			// If homenode is not yet calculated we need to find it
+			if(local_offset == invalid_offset) {
+				// Avoid invoking first-touch
+				std::size_t new_offset = policy()->peek_local_offset(reinterpret_cast<char*>(access_ptr));
+				if(new_offset != invalid_offset) {
+					local_offset = new_offset;
 				}
+			}
+			return local_offset;
+		}
 
-				/**
-				 * @brief return the home node of the value pointed to, or a
-				 * default value if the page has not yet been first-touched
-				 * under first-touch allocation.
-				 * @return home node id, or argo::data_distribution::invalid_node_id
-				 * if access_ptr has not been first-touched yet under the
-				 * first-touch allocation policy
-				 */
-				node_id_t peek_node() {
-					// If homenode is not yet calculated we need to find it
-					if(homenode == invalid_node_id) {
-						// Avoid invoking first-touch
-						node_id_t new_node = policy()->peek_homenode(
-								reinterpret_cast<char*>(access_ptr));
-						if(new_node != invalid_node_id) {
-							homenode = new_node;
-						}
-					}
-					return homenode;
-				}
+		/**
+		 * @brief return a pointer to the selected allocation policy
+		 * @return enabled policy
+		 */
+		Dist* policy() {
+			return policies[env::allocation_policy()];
+		}
+};
 
-				/**
-				 * @brief return the offset on the home node's local memory share
-				 * @return local offset
-				 */
-				std::size_t offset() {
-					if(local_offset == invalid_offset) {
-						local_offset = policy()->local_offset(
-								reinterpret_cast<char*>(access_ptr));
-					}
-					return local_offset;
-				}
+template<typename T, class Dist>
+Dist* global_ptr<T, Dist>::policies[] = {
+	new naive_distribution<0>,
+	new cyclic_distribution<0>,
+	new skew_mapp_distribution<0>,
+	new prime_mapp_distribution<0>,
+	new first_touch_distribution<0>
+};
 
-				/**
-				 * @brief return the offset on the home node's local memory share
-				 * or a default value if the page has not yet been first-touched
-				 * under first-touch allocation.
-				 * @return local offset, or argo::data_distribution::invalid_offset
-				 * if access_ptr has not been first-touched yet under the
-				 * first-touch allocation policy
-				 */
-				std::size_t peek_offset() {
-					// If homenode is not yet calculated we need to find it
-					if(local_offset == invalid_offset) {
-						// Avoid invoking first-touch
-						std::size_t new_offset = policy()->peek_local_offset(
-								reinterpret_cast<char*>(access_ptr));
-						if(new_offset != invalid_offset) {
-							local_offset = new_offset;
-						}
-					}
-					return local_offset;
-				}
-
-				/**
-				 * @brief return a pointer to the selected allocation policy
-				 * @return enabled policy
-				 */
-				Dist* policy() {
-					return policies[env::allocation_policy()];
-				}
-		};
-		template<typename T, class Dist>
-		Dist* global_ptr<T, Dist>::policies[] = {
-			new naive_distribution<0>,
-			new cyclic_distribution<0>,
-			new skew_mapp_distribution<0>,
-			new prime_mapp_distribution<0>,
-			new first_touch_distribution<0>
-		};
-	} // namespace data_distribution
+} // namespace data_distribution
 } // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_GLOBAL_PTR_HPP_

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -10,49 +10,51 @@
 #include "base_distribution.hpp"
 
 namespace argo {
-	namespace data_distribution {
-		/**
-		 * @brief the naive data distribution
-		 * @details each ArgoDSM node provides an equally-sized chunk of global
-		 *          memory, and these chunks are simply concatenated in order or
-		 *          ArgoDSM ids to form the global address space.
-		 */
-		template<int instance>
-		class naive_distribution : public base_distribution<instance> {
-			public:
-				virtual node_id_t homenode(char* const ptr) {
-					const std::size_t addr = ptr - base_distribution<instance>::start_address;
-					node_id_t homenode = addr / base_distribution<instance>::size_per_node;
+namespace data_distribution {
 
-					if(homenode >= base_distribution<instance>::nodes) {
-						std::cerr << msg_fetch_homenode_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-						exit(EXIT_FAILURE);
-					}
-					return homenode;
-				}
+/**
+ * @brief the naive data distribution
+ * @details each ArgoDSM node provides an equally-sized chunk of global
+ *          memory, and these chunks are simply concatenated in order or
+ *          ArgoDSM ids to form the global address space.
+ */
+template<int instance>
+class naive_distribution : public base_distribution<instance> {
+	public:
+		virtual node_id_t homenode(char* const ptr) {
+			const std::size_t addr = ptr - base_distribution<instance>::start_address;
+			node_id_t homenode = addr / base_distribution<instance>::size_per_node;
 
-				virtual node_id_t peek_homenode(char* const ptr) {
-					return homenode(ptr);
-				}
+			if(homenode >= base_distribution<instance>::nodes) {
+				std::cerr << msg_fetch_homenode_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
+				exit(EXIT_FAILURE);
+			}
+			return homenode;
+		}
 
-				virtual std::size_t local_offset(char* const ptr) {
-					const std::size_t addr = ptr - base_distribution<instance>::start_address;
-					std::size_t offset = addr - (homenode(ptr)) * base_distribution<instance>::size_per_node;
+		virtual node_id_t peek_homenode(char* const ptr) {
+			return homenode(ptr);
+		}
 
-					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
-						std::cerr << msg_fetch_offset_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-						exit(EXIT_FAILURE);
-					}
-					return offset;
-				}
+		virtual std::size_t local_offset(char* const ptr) {
+			const std::size_t addr = ptr - base_distribution<instance>::start_address;
+			std::size_t offset = addr - (homenode(ptr)) * base_distribution<instance>::size_per_node;
 
-				virtual std::size_t peek_local_offset(char* const ptr) {
-					return local_offset(ptr);
-				}
-		};
-	} // namespace data_distribution
-} // namespace argo
+			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+				std::cerr << msg_fetch_offset_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
+				exit(EXIT_FAILURE);
+			}
+			return offset;
+		}
+
+		virtual std::size_t peek_local_offset(char* const ptr) {
+			return local_offset(ptr);
+		}
+};
+
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_NAIVE_DISTRIBUTION_HPP_

--- a/src/data_distribution/prime_mapp_distribution.hpp
+++ b/src/data_distribution/prime_mapp_distribution.hpp
@@ -10,73 +10,74 @@
 #include "base_distribution.hpp"
 
 namespace argo {
-	namespace data_distribution {
-		/**
-		 * @brief the prime-mapp data distribution
-		 * @details distributes blocks of pages using a two-phase round-robin strategy.
-		 */
-		template<int instance>
-		class prime_mapp_distribution : public base_distribution<instance> {
-			public:
-				virtual node_id_t homenode(char* const ptr) {
-					static const std::size_t pageblock = env::allocation_block_size() * granularity;
-					static const std::size_t prime = (3 * base_distribution<instance>::nodes) / 2;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t pagenum = addr / pageblock;
-					const node_id_t homenode = ((pagenum % prime) >= static_cast<std::size_t>(base_distribution<instance>::nodes))
-					? ((pagenum / prime) * (prime - base_distribution<instance>::nodes) + ((pagenum % prime) - base_distribution<instance>::nodes)) % base_distribution<instance>::nodes
-					: pagenum % prime;
+namespace data_distribution {
+/**
+ * @brief the prime-mapp data distribution
+ * @details distributes blocks of pages using a two-phase round-robin strategy.
+ */
+template<int instance>
+class prime_mapp_distribution : public base_distribution<instance> {
+	public:
+		virtual node_id_t homenode(char* const ptr) {
+			static const std::size_t pageblock = env::allocation_block_size() * granularity;
+			static const std::size_t prime = (3 * base_distribution<instance>::nodes) / 2;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t pagenum = addr / pageblock;
+			const node_id_t homenode = ((pagenum % prime) >= static_cast<std::size_t>(base_distribution<instance>::nodes))
+			? ((pagenum / prime) * (prime - base_distribution<instance>::nodes) + ((pagenum % prime) - base_distribution<instance>::nodes)) % base_distribution<instance>::nodes
+			: pagenum % prime;
 
-					if(homenode >= base_distribution<instance>::nodes) {
-						std::cerr << msg_fetch_homenode_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-						exit(EXIT_FAILURE);
+			if(homenode >= base_distribution<instance>::nodes) {
+				std::cerr << msg_fetch_homenode_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
+				exit(EXIT_FAILURE);
+			}
+			return homenode;
+		}
+
+		virtual node_id_t peek_homenode(char* const ptr) {
+			return homenode(ptr);
+		}
+
+		virtual std::size_t local_offset(char* const ptr) {
+			static const std::size_t pageblock = env::allocation_block_size() * granularity;
+			static const std::size_t prime = (3 * base_distribution<instance>::nodes) / 2;
+			const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
+			std::size_t offset, addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			std::size_t pagenum = addr / pageblock;
+			if ((addr <= (base_distribution<instance>::nodes * pageblock)) || ((pagenum % prime) >= static_cast<std::size_t>(base_distribution<instance>::nodes))) {
+				offset = (pagenum / base_distribution<instance>::nodes) * pageblock + addr % pageblock + drift;
+			} else {
+				node_id_t currhome;
+				std::size_t homecounter = 0;
+				const node_id_t realhome = homenode(ptr);
+				for (addr -= pageblock; ; addr -= pageblock) {
+					pagenum = addr / pageblock;
+					currhome = homenode(static_cast<char*>(base_distribution<instance>::start_address) + addr);
+					homecounter += (currhome == realhome) ? 1 : 0;
+					if (((addr <= (base_distribution<instance>::nodes * pageblock)) && (currhome == realhome)) ||
+							(((pagenum % prime) >= static_cast<std::size_t>(base_distribution<instance>::nodes)) && (currhome == realhome))) {
+						offset = (pagenum / base_distribution<instance>::nodes) * pageblock + addr % pageblock;
+						offset += homecounter * pageblock + drift;
+						break;
 					}
-					return homenode;
 				}
+			}
 
-				virtual node_id_t peek_homenode(char* const ptr) {
-					return homenode(ptr);
-				}
+			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+				std::cerr << msg_fetch_offset_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
+				exit(EXIT_FAILURE);
+			}
+			return offset;
+		}
 
-				virtual std::size_t local_offset(char* const ptr) {
-					static const std::size_t pageblock = env::allocation_block_size() * granularity;
-					static const std::size_t prime = (3 * base_distribution<instance>::nodes) / 2;
-					const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
-					std::size_t offset, addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					std::size_t pagenum = addr / pageblock;
-					if ((addr <= (base_distribution<instance>::nodes * pageblock)) || ((pagenum % prime) >= static_cast<std::size_t>(base_distribution<instance>::nodes))) {
-						offset = (pagenum / base_distribution<instance>::nodes) * pageblock + addr % pageblock + drift;
-					} else {
-						node_id_t currhome;
-						std::size_t homecounter = 0;
-						const node_id_t realhome = homenode(ptr);
-						for (addr -= pageblock; ; addr -= pageblock) {
-							pagenum = addr / pageblock;
-							currhome = homenode(static_cast<char*>(base_distribution<instance>::start_address) + addr);
-							homecounter += (currhome == realhome) ? 1 : 0;
-							if (((addr <= (base_distribution<instance>::nodes * pageblock)) && (currhome == realhome)) ||
-									(((pagenum % prime) >= static_cast<std::size_t>(base_distribution<instance>::nodes)) && (currhome == realhome))) {
-								offset = (pagenum / base_distribution<instance>::nodes) * pageblock + addr % pageblock;
-								offset += homecounter * pageblock + drift;
-								break;
-							}
-						}
-					}
+		virtual std::size_t peek_local_offset(char* const ptr) {
+			return local_offset(ptr);
+		}
+};
 
-					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
-						std::cerr << msg_fetch_offset_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-						exit(EXIT_FAILURE);
-					}
-					return offset;
-				}
-
-				virtual std::size_t peek_local_offset(char* const ptr) {
-					return local_offset(ptr);
-				}
-		};
-	} // namespace data_distribution
-} // namespace argo
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_PRIME_MAPP_DISTRIBUTION_HPP_

--- a/src/data_distribution/prime_mapp_distribution.hpp
+++ b/src/data_distribution/prime_mapp_distribution.hpp
@@ -11,6 +11,7 @@
 
 namespace argo {
 namespace data_distribution {
+
 /**
  * @brief the prime-mapp data distribution
  * @details distributes blocks of pages using a two-phase round-robin strategy.

--- a/src/data_distribution/skew_mapp_distribution.hpp
+++ b/src/data_distribution/skew_mapp_distribution.hpp
@@ -10,53 +10,55 @@
 #include "base_distribution.hpp"
 
 namespace argo {
-	namespace data_distribution {
-		/**
-		 * @brief the skew-mapp data distribution
-		 * @details cyclically distributes a block of pages per round but skips
-		 *          a node for every N (number of nodes used) pages allocated.
-		 */
-		template<int instance>
-		class skew_mapp_distribution : public base_distribution<instance> {
-			public:
-				virtual node_id_t homenode(char* const ptr) {
-					static const std::size_t pageblock = env::allocation_block_size() * granularity;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t pagenum = addr / pageblock;
-					const node_id_t homenode = (pagenum + pagenum / base_distribution<instance>::nodes + 1) % base_distribution<instance>::nodes;
+namespace data_distribution {
 
-					if(homenode >= base_distribution<instance>::nodes) {
-						std::cerr << msg_fetch_homenode_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-						exit(EXIT_FAILURE);
-					}
-					return homenode;
-				}
+/**
+ * @brief the skew-mapp data distribution
+ * @details cyclically distributes a block of pages per round but skips
+ *          a node for every N (number of nodes used) pages allocated.
+ */
+template<int instance>
+class skew_mapp_distribution : public base_distribution<instance> {
+	public:
+		virtual node_id_t homenode(char* const ptr) {
+			static const std::size_t pageblock = env::allocation_block_size() * granularity;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t pagenum = addr / pageblock;
+			const node_id_t homenode = (pagenum + pagenum / base_distribution<instance>::nodes + 1) % base_distribution<instance>::nodes;
 
-				virtual node_id_t peek_homenode(char* const ptr) {
-					return homenode(ptr);
-				}
+			if(homenode >= base_distribution<instance>::nodes) {
+				std::cerr << msg_fetch_homenode_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
+				exit(EXIT_FAILURE);
+			}
+			return homenode;
+		}
 
-				virtual std::size_t local_offset(char* const ptr) {
-					static const std::size_t pageblock = env::allocation_block_size() * granularity;
-					const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
-					const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
-					const std::size_t pagenum = addr / pageblock;
-					const std::size_t offset = pagenum / base_distribution<instance>::nodes * pageblock + addr % pageblock + drift;
+		virtual node_id_t peek_homenode(char* const ptr) {
+			return homenode(ptr);
+		}
 
-					if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
-						std::cerr << msg_fetch_offset_fail << std::endl;
-						throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-						exit(EXIT_FAILURE);
-					}
-					return offset;
-				}
+		virtual std::size_t local_offset(char* const ptr) {
+			static const std::size_t pageblock = env::allocation_block_size() * granularity;
+			const std::size_t drift = (ptr - base_distribution<instance>::start_address) % granularity;
+			const std::size_t addr = (ptr - base_distribution<instance>::start_address) / granularity * granularity;
+			const std::size_t pagenum = addr / pageblock;
+			const std::size_t offset = pagenum / base_distribution<instance>::nodes * pageblock + addr % pageblock + drift;
 
-				virtual std::size_t peek_local_offset(char* const ptr) {
-					return local_offset(ptr);
-				}
-		};
-	} // namespace data_distribution
-} // namespace argo
+			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
+				std::cerr << msg_fetch_offset_fail << std::endl;
+				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
+				exit(EXIT_FAILURE);
+			}
+			return offset;
+		}
+
+		virtual std::size_t peek_local_offset(char* const ptr) {
+			return local_offset(ptr);
+		}
+};
+
+}  // namespace data_distribution
+}  // namespace argo
 
 #endif // ARGODSM_SRC_DATA_DISTRIBUTION_SKEW_MAPP_DISTRIBUTION_HPP_

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -222,73 +222,75 @@ namespace {
 } // unnamed namespace
 
 namespace argo {
-	namespace env {
-		void init() {
-			value_memory_size = parse_env<std::size_t>(env_memory_size, default_memory_size).second;
-			value_cache_size = parse_env<std::size_t>(env_cache_size, default_cache_size).second;
-			value_write_buffer_size = parse_env<std::size_t>(
-					env_write_buffer_size,
-					default_write_buffer_size).second;
-			value_write_buffer_write_back_size = parse_env<std::size_t>(
-					env_write_buffer_write_back_size,
-					default_write_buffer_write_back_size).second;
-			// Limit the write buffer write back size to the write buffer size
-			if(value_write_buffer_write_back_size > value_write_buffer_size) {
-				value_write_buffer_write_back_size = value_write_buffer_size;
-			}
+namespace env {
 
-			value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
-			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
-			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
-			value_mpi_windows_per_node = parse_env<std::size_t>(env_mpi_windows_per_node, default_mpi_windows_per_node).second;
-			value_print_statistics = parse_env<std::size_t>(env_print_statistics, default_print_statistics).second;
+void init() {
+	value_memory_size = parse_env<std::size_t>(env_memory_size, default_memory_size).second;
+	value_cache_size = parse_env<std::size_t>(env_cache_size, default_cache_size).second;
+	value_write_buffer_size = parse_env<std::size_t>(
+			env_write_buffer_size,
+			default_write_buffer_size).second;
+	value_write_buffer_write_back_size = parse_env<std::size_t>(
+			env_write_buffer_write_back_size,
+			default_write_buffer_write_back_size).second;
+	// Limit the write buffer write back size to the write buffer size
+	if(value_write_buffer_write_back_size > value_write_buffer_size) {
+		value_write_buffer_write_back_size = value_write_buffer_size;
+	}
 
-			is_initialized = true;
-		}
+	value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
+	value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
+	value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
+	value_mpi_windows_per_node = parse_env<std::size_t>(env_mpi_windows_per_node, default_mpi_windows_per_node).second;
+	value_print_statistics = parse_env<std::size_t>(env_print_statistics, default_print_statistics).second;
 
-		std::size_t memory_size() {
-			assert_initialized();
-			return value_memory_size;
-		}
+	is_initialized = true;
+}
 
-		std::size_t cache_size() {
-			assert_initialized();
-			return value_cache_size;
-		}
+std::size_t memory_size() {
+	assert_initialized();
+	return value_memory_size;
+}
 
-		std::size_t write_buffer_size() {
-			assert_initialized();
-			return value_write_buffer_size;
-		}
+std::size_t cache_size() {
+	assert_initialized();
+	return value_cache_size;
+}
 
-		std::size_t write_buffer_write_back_size() {
-			assert_initialized();
-			return value_write_buffer_write_back_size;
-		}
+std::size_t write_buffer_size() {
+	assert_initialized();
+	return value_write_buffer_size;
+}
 
-		std::size_t allocation_policy() {
-			assert_initialized();
-			return value_allocation_policy;
-		}
+std::size_t write_buffer_write_back_size() {
+	assert_initialized();
+	return value_write_buffer_write_back_size;
+}
 
-		std::size_t allocation_block_size() {
-			assert_initialized();
-			return value_allocation_block_size;
-		}
+std::size_t allocation_policy() {
+	assert_initialized();
+	return value_allocation_policy;
+}
 
-		std::size_t load_size() {
-			assert_initialized();
-			return value_load_size;
-		}
+std::size_t allocation_block_size() {
+	assert_initialized();
+	return value_allocation_block_size;
+}
 
-		std::size_t mpi_windows_per_node() {
-			assert_initialized();
-			return value_mpi_windows_per_node;
-		}
+std::size_t load_size() {
+	assert_initialized();
+	return value_load_size;
+}
 
-		std::size_t print_statistics() {
-			assert_initialized();
-			return value_print_statistics;
-		}
-	} // namespace env
-} // namespace argo
+std::size_t mpi_windows_per_node() {
+	assert_initialized();
+	return value_mpi_windows_per_node;
+}
+
+std::size_t print_statistics() {
+	assert_initialized();
+	return value_print_statistics;
+}
+
+}  // namespace env
+}  // namespace argo

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -14,212 +14,212 @@
 #include "env.hpp"
 
 namespace {
-	/* file constants */
-	/**
-	 * @brief default requested memory size (if environment variable is unset)
-	 * @see @ref ARGO_MEMORY_SIZE
-	 */
-	const std::size_t default_memory_size = 8ul*(1ul<<30); // default: 8GB
+/* file constants */
+/**
+ * @brief default requested memory size (if environment variable is unset)
+ * @see @ref ARGO_MEMORY_SIZE
+ */
+const std::size_t default_memory_size = 8ul*(1ul<<30); // default: 8GB
 
-	/**
-	 * @brief default requested cache size (if environment variable is unset)
-	 * @see @ref ARGO_CACHE_SIZE
-	 */
-	const std::size_t default_cache_size = 1ul<<30; // default: 1GB
+/**
+ * @brief default requested cache size (if environment variable is unset)
+ * @see @ref ARGO_CACHE_SIZE
+ */
+const std::size_t default_cache_size = 1ul<<30; // default: 1GB
 
-	/**
-	 * @brief default requested write buffer size (if environment variable is unset)
-	 * @see @ref ARGO_WRITE_BUFFER_SIZE
-	 */
-	const std::size_t default_write_buffer_size = 512; // default: 512 cache blocks
+/**
+ * @brief default requested write buffer size (if environment variable is unset)
+ * @see @ref ARGO_WRITE_BUFFER_SIZE
+ */
+const std::size_t default_write_buffer_size = 512; // default: 512 cache blocks
 
-	/**
-	 * @brief default requested write buffer write back size (if environment variable is unset)
-	 * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
-	 */
-	const std::size_t default_write_buffer_write_back_size = 32; // default: 32 pages
+/**
+ * @brief default requested write buffer write back size (if environment variable is unset)
+ * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+ */
+const std::size_t default_write_buffer_write_back_size = 32; // default: 32 pages
 
-	/**
-	 * @brief default requested allocation policy (if environment variable is unset)
-	 * @see @ref ARGO_ALLOCATION_POLICY
-	 */
-	const std::size_t default_allocation_policy = 0; // default: naive
+/**
+ * @brief default requested allocation policy (if environment variable is unset)
+ * @see @ref ARGO_ALLOCATION_POLICY
+ */
+const std::size_t default_allocation_policy = 0; // default: naive
 
-	/**
-	 * @brief default requested allocation block size (if environment variable is unset)
-	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
-	 */
-	const std::size_t default_allocation_block_size = 1ul<<4; // default: 16
+/**
+ * @brief default requested allocation block size (if environment variable is unset)
+ * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
+ */
+const std::size_t default_allocation_block_size = 1ul<<4; // default: 16
 
-	/**
-	 * @brief default requested load size (if environment variable is unset)
-	 * @see @ref ARGO_LOAD_SIZE
-	 */
-	const std::size_t default_load_size = 8;
+/**
+ * @brief default requested load size (if environment variable is unset)
+ * @see @ref ARGO_LOAD_SIZE
+ */
+const std::size_t default_load_size = 8;
 
-	/**
-	 * @brief default number of MPI windows (if environment variable is unset)
-	 * @see @ref ARGO_MPI_WINDOWS_PER_NODE
-	 */
-	const std::size_t default_mpi_windows_per_node = 4;
+/**
+ * @brief default number of MPI windows (if environment variable is unset)
+ * @see @ref ARGO_MPI_WINDOWS_PER_NODE
+ */
+const std::size_t default_mpi_windows_per_node = 4;
 
-	/**
-	 * @brief default requested statistics level (if environment variable is unset)
-	 * @see @ref ARGO_PRINT_STATISTICS
-	 */
-	const std::size_t default_print_statistics = 2; // default 2 is basic node statistics
+/**
+ * @brief default requested statistics level (if environment variable is unset)
+ * @see @ref ARGO_PRINT_STATISTICS
+ */
+const std::size_t default_print_statistics = 2; // default 2 is basic node statistics
 
-	/**
-	 * @brief environment variable used for requesting memory size
-	 * @see @ref ARGO_MEMORY_SIZE
-	 */
-	const std::string env_memory_size = "ARGO_MEMORY_SIZE";
+/**
+ * @brief environment variable used for requesting memory size
+ * @see @ref ARGO_MEMORY_SIZE
+ */
+const std::string env_memory_size = "ARGO_MEMORY_SIZE";
 
-	/**
-	 * @brief environment variable used for requesting cache size
-	 * @see @ref ARGO_CACHE_SIZE
-	 */
-	const std::string env_cache_size = "ARGO_CACHE_SIZE";
+/**
+ * @brief environment variable used for requesting cache size
+ * @see @ref ARGO_CACHE_SIZE
+ */
+const std::string env_cache_size = "ARGO_CACHE_SIZE";
 
-	/**
-	 * @brief environment variable used for requesting write buffer size
-	 * @see @ref ARGO_WRITE_BUFFER_SIZE
-	 */
-	const std::string env_write_buffer_size = "ARGO_WRITE_BUFFER_SIZE";
+/**
+ * @brief environment variable used for requesting write buffer size
+ * @see @ref ARGO_WRITE_BUFFER_SIZE
+ */
+const std::string env_write_buffer_size = "ARGO_WRITE_BUFFER_SIZE";
 
-	/**
-	 * @brief environment variable used for requesting write buffer write back size
-	 * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
-	 */
-	const std::string env_write_buffer_write_back_size = "ARGO_WRITE_BUFFER_WRITE_BACK_SIZE";
+/**
+ * @brief environment variable used for requesting write buffer write back size
+ * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+ */
+const std::string env_write_buffer_write_back_size = "ARGO_WRITE_BUFFER_WRITE_BACK_SIZE";
 
-	/**
-	 * @brief environment variable used for requesting allocation policy
-	 * @see @ref ARGO_ALLOCATION_POLICY
-	 */
-	const std::string env_allocation_policy = "ARGO_ALLOCATION_POLICY";
+/**
+ * @brief environment variable used for requesting allocation policy
+ * @see @ref ARGO_ALLOCATION_POLICY
+ */
+const std::string env_allocation_policy = "ARGO_ALLOCATION_POLICY";
 
-	/**
-	 * @brief environment variable used for requesting allocation block size
-	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
-	 */
-	const std::string env_allocation_block_size = "ARGO_ALLOCATION_BLOCK_SIZE";
+/**
+ * @brief environment variable used for requesting allocation block size
+ * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
+ */
+const std::string env_allocation_block_size = "ARGO_ALLOCATION_BLOCK_SIZE";
 
-	/**
-	 * @brief environment variable used for requesting load size
-	 * @see @ref ARGO_LOAD_SIZE
-	 */
-	const std::string env_load_size = "ARGO_LOAD_SIZE";
+/**
+ * @brief environment variable used for requesting load size
+ * @see @ref ARGO_LOAD_SIZE
+ */
+const std::string env_load_size = "ARGO_LOAD_SIZE";
 
-	/**
-	 * @brief environment variable used for requesting the number of MPI windows
-	 * @see @ref ARGO_MPI_WINDOWS_PER_NODE
-	 */
-	const std::string env_mpi_windows_per_node = "ARGO_MPI_WINDOWS_PER_NODE";
+/**
+ * @brief environment variable used for requesting the number of MPI windows
+ * @see @ref ARGO_MPI_WINDOWS_PER_NODE
+ */
+const std::string env_mpi_windows_per_node = "ARGO_MPI_WINDOWS_PER_NODE";
 
-	/**
-	 * @brief environment variable used for requesting statistics level
-	 * @see @ref ARGO_PRINT_STATISTICS
-	 */
-	const std::string env_print_statistics = "ARGO_PRINT_STATISTICS";
+/**
+ * @brief environment variable used for requesting statistics level
+ * @see @ref ARGO_PRINT_STATISTICS
+ */
+const std::string env_print_statistics = "ARGO_PRINT_STATISTICS";
 
-	/** @brief error message string */
-	const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
-	/** @brief error message string */
-	const std::string msg_illegal_format = "An environment variable could not be converted to a number: ";
-	/** @brief error message string */
-	const std::string msg_out_of_range = "An environment variable contains a number outside the possible range: ";
+/** @brief error message string */
+const std::string msg_uninitialized = "argo::env::init() must be called before accessing environment values";
+/** @brief error message string */
+const std::string msg_illegal_format = "An environment variable could not be converted to a number: ";
+/** @brief error message string */
+const std::string msg_out_of_range = "An environment variable contains a number outside the possible range: ";
 
-	/* file variables */
-	/**
-	 * @brief memory size requested through the environment variable @ref ARGO_MEMORY_SIZE
-	 */
-	std::size_t value_memory_size;
+/* file variables */
+/**
+ * @brief memory size requested through the environment variable @ref ARGO_MEMORY_SIZE
+ */
+std::size_t value_memory_size;
 
-	/**
-	 * @brief cache size requested through the environment variable @ref ARGO_CACHE_SIZE
-	 */
-	std::size_t value_cache_size;
+/**
+ * @brief cache size requested through the environment variable @ref ARGO_CACHE_SIZE
+ */
+std::size_t value_cache_size;
 
-	/**
-	 * @brief write buffer size requested through the environment variable @ref ARGO_WRITE_BUFFER_SIZE
-	 */
-	std::size_t value_write_buffer_size;
+/**
+ * @brief write buffer size requested through the environment variable @ref ARGO_WRITE_BUFFER_SIZE
+ */
+std::size_t value_write_buffer_size;
 
-	/**
-	 * @brief write buffer write back size requested through the environment variable @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
-	 */
-	std::size_t value_write_buffer_write_back_size;
+/**
+ * @brief write buffer write back size requested through the environment variable @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+ */
+std::size_t value_write_buffer_write_back_size;
 
-	/**
-	 * @brief allocation policy requested through the environment variable @ref ARGO_ALLOCATION_POLICY
-	 */
-	std::size_t value_allocation_policy;
+/**
+ * @brief allocation policy requested through the environment variable @ref ARGO_ALLOCATION_POLICY
+ */
+std::size_t value_allocation_policy;
 
-	/**
-	 * @brief allocation block size requested through the environment variable @ref ARGO_ALLOCATION_BLOCK_SIZE
-	 */
-	std::size_t value_allocation_block_size;
+/**
+ * @brief allocation block size requested through the environment variable @ref ARGO_ALLOCATION_BLOCK_SIZE
+ */
+std::size_t value_allocation_block_size;
 
-	/**
-	 * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
-	 */
-	std::size_t value_load_size;
+/**
+ * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
+ */
+std::size_t value_load_size;
 
-	/**
-	 * @brief number of MPI windows requested through the environment variable @ref ARGO_MPI_WINDOWS_PER_NODE
-	 */
-	std::size_t value_mpi_windows_per_node;
+/**
+ * @brief number of MPI windows requested through the environment variable @ref ARGO_MPI_WINDOWS_PER_NODE
+ */
+std::size_t value_mpi_windows_per_node;
 
-	/**
-	 * @brief statistics output level requested through the environment variable @ref ARGO_PRINT_STATISTICS
-	 */
-	std::size_t value_print_statistics;
+/**
+ * @brief statistics output level requested through the environment variable @ref ARGO_PRINT_STATISTICS
+ */
+std::size_t value_print_statistics;
 
-	/** @brief flag to allow checking that environment variables have been read before accessing their values */
-	bool is_initialized = false;
+/** @brief flag to allow checking that environment variables have been read before accessing their values */
+bool is_initialized = false;
 
-	/* helper functions */
-	/** @brief throw an exception if argo::env::init() has not yet been called */
-	void assert_initialized() {
-		if(!is_initialized) {
-			throw std::logic_error(msg_uninitialized);
-		}
+/* helper functions */
+/** @brief throw an exception if argo::env::init() has not yet been called */
+void assert_initialized() {
+	if(!is_initialized) {
+		throw std::logic_error(msg_uninitialized);
 	}
+}
 
-	/**
-	 * @brief parse an environment variable
-	 * @tparam T type of value
-	 * @param name the environment variable to parse
-	 * @param fallback the default value to use if the environment variable is undefined
-	 * @return a pair <env_used, value>, where env_used is true iff the environment variable is set,
-	 *         and value is either the value of the environment variable or the fallback value.
-	 */
-	template<typename T>
-	std::pair<bool, T> parse_env(std::string name, T fallback) {
-		auto env_get = std::getenv(name.c_str());
-		try {
-			if(env_get != nullptr) {
-				std::string env_string(env_get);
-				std::stringstream env_stream(env_string);
-				T env_value;
-				env_stream >> env_value;
-				return std::make_pair(true, env_value);
-			} else {
-				return std::make_pair(false, fallback);
-			}
-		} catch (const std::invalid_argument& e) {
-			// environment variable exists, but value is not convertable to an unsigned long
-			std::cerr << msg_illegal_format << name << std::endl;
-			throw;
-		} catch (const std::out_of_range& e) {
-			// environment variable exists, but value is out of range
-			std::cerr << msg_out_of_range << name << std::endl;
-			throw;
+/**
+ * @brief parse an environment variable
+ * @tparam T type of value
+ * @param name the environment variable to parse
+ * @param fallback the default value to use if the environment variable is undefined
+ * @return a pair <env_used, value>, where env_used is true iff the environment variable is set,
+ *         and value is either the value of the environment variable or the fallback value.
+ */
+template<typename T>
+std::pair<bool, T> parse_env(std::string name, T fallback) {
+	auto env_get = std::getenv(name.c_str());
+	try {
+		if(env_get != nullptr) {
+			std::string env_string(env_get);
+			std::stringstream env_stream(env_string);
+			T env_value;
+			env_stream >> env_value;
+			return std::make_pair(true, env_value);
+		} else {
+			return std::make_pair(false, fallback);
 		}
+	} catch (const std::invalid_argument& e) {
+		// environment variable exists, but value is not convertable to an unsigned long
+		std::cerr << msg_illegal_format << name << std::endl;
+		throw;
+	} catch (const std::out_of_range& e) {
+		// environment variable exists, but value is out of range
+		std::cerr << msg_out_of_range << name << std::endl;
+		throw;
 	}
+}
 
-} // unnamed namespace
+}  // unnamed namespace
 
 namespace argo {
 namespace env {

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -139,7 +139,7 @@ std::size_t mpi_windows_per_node();
  */
 std::size_t print_statistics();
 
-} // namespace env
-} // namespace argo
+}  // namespace env
+}  // namespace argo
 
 #endif // ARGODSM_SRC_ENV_ENV_HPP_

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -62,83 +62,84 @@
  */
 
 namespace argo {
-	/**
-	 * @brief namespace for environment variable handling functionality
-	 * @note argo::env::init() must be called before other functions in this
-	 *       namespace work correctly
-	 */
-	namespace env {
-		/**
-		 * @brief read and store environment variables used by ArgoDSM
-		 * @details the environment is only read once, to avoid having
-		 *          to check that values are not changing later
-		 */
-		void init();
+/**
+ * @brief namespace for environment variable handling functionality
+ * @note argo::env::init() must be called before other functions in this
+ *       namespace work correctly
+ */
+namespace env {
+/**
+ * @brief read and store environment variables used by ArgoDSM
+ * @details the environment is only read once, to avoid having
+ *          to check that values are not changing later
+ */
+void init();
 
-		/**
-		 * @brief get the memory size requested by environment variable
-		 * @return the requested memory size in bytes
-		 * @see @ref ARGO_MEMORY_SIZE
-		 */
-		std::size_t memory_size();
+/**
+ * @brief get the memory size requested by environment variable
+ * @return the requested memory size in bytes
+ * @see @ref ARGO_MEMORY_SIZE
+ */
+std::size_t memory_size();
 
-		/**
-		 * @brief get the cache size requested by environment variable
-		 * @return the requested cache size in bytes
-		 * @see @ref ARGO_CACHE_SIZE
-		 */
-		std::size_t cache_size();
+/**
+ * @brief get the cache size requested by environment variable
+ * @return the requested cache size in bytes
+ * @see @ref ARGO_CACHE_SIZE
+ */
+std::size_t cache_size();
 
-		/**
-		 * @brief get the write buffer size requested by environment variable
-		 * @return the requested write buffer size in cache blocks
-		 * @see @ref ARGO_WRITE_BUFFER_SIZE
-		 */
-		std::size_t write_buffer_size();
+/**
+ * @brief get the write buffer size requested by environment variable
+ * @return the requested write buffer size in cache blocks
+ * @see @ref ARGO_WRITE_BUFFER_SIZE
+ */
+std::size_t write_buffer_size();
 
-		/**
-		 * @brief get the write buffer write back size requested by environment variable
-		 * @return the requested write buffer write back size in cache blocks
-		 * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
-		 */
-		std::size_t write_buffer_write_back_size();
+/**
+ * @brief get the write buffer write back size requested by environment variable
+ * @return the requested write buffer write back size in cache blocks
+ * @see @ref ARGO_WRITE_BUFFER_WRITE_BACK_SIZE
+ */
+std::size_t write_buffer_write_back_size();
 
-		/**
-		 * @brief get the allocation policy requested by environment variable
-		 * @return the requested allocation policy as a number
-		 * @see @ref ARGO_ALLOCATION_POLICY
-		 */
-		std::size_t allocation_policy();
+/**
+ * @brief get the allocation policy requested by environment variable
+ * @return the requested allocation policy as a number
+ * @see @ref ARGO_ALLOCATION_POLICY
+ */
+std::size_t allocation_policy();
 
-		/**
-		 * @brief get the allocation block size requested by environment variable
-		 * @return the requested allocation block size as a number of pages
-		 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
-		 */
-		std::size_t allocation_block_size();
+/**
+ * @brief get the allocation block size requested by environment variable
+ * @return the requested allocation block size as a number of pages
+ * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
+ */
+std::size_t allocation_block_size();
 
-		/**
-		 * @brief get the number of pages fetched remotely per load requested
-		 * by environment variable
-		 * @return the number of pages
-		 * @see @ref ARGO_LOAD_SIZE
-		 */
-		std::size_t load_size();
+/**
+ * @brief get the number of pages fetched remotely per load requested
+ * by environment variable
+ * @return the number of pages
+ * @see @ref ARGO_LOAD_SIZE
+ */
+std::size_t load_size();
 
-		/**
-		 * @brief get the number of MPI windows per node requested
-		 * @return the number of MPI windows per node
-		 * @see @ref ARGO_MPI_WINDOWS_PER_NODE
-		 */
-		std::size_t mpi_windows_per_node();
+/**
+ * @brief get the number of MPI windows per node requested
+ * @return the number of MPI windows per node
+ * @see @ref ARGO_MPI_WINDOWS_PER_NODE
+ */
+std::size_t mpi_windows_per_node();
 
-		/**
-		 * @brief Get the requested statistics print level
-		 * @return The requested statistics print level
-		 * @see @ref ARGO_PRINT_STATISTICS
-		 */
-		std::size_t print_statistics();
-	} // namespace env
+/**
+ * @brief Get the requested statistics print level
+ * @return The requested statistics print level
+ * @see @ref ARGO_PRINT_STATISTICS
+ */
+std::size_t print_statistics();
+
+} // namespace env
 } // namespace argo
 
 #endif // ARGODSM_SRC_ENV_ENV_HPP_

--- a/src/mempools/dummy_mempool.hpp
+++ b/src/mempools/dummy_mempool.hpp
@@ -9,58 +9,60 @@
 #define ARGODSM_SRC_MEMPOOLS_DUMMY_MEMPOOL_HPP_
 
 namespace argo {
-	/**
-	 * @brief Dummy memory pool
-	 * @todo replace with code to use mmap for ArgoDSM global address space
-	 */
-	class memory_pool {
-		private:
-			/** @todo Documentation */
-			char* memory;
-			/** @todo Documentation */
-			std::size_t max_size;
-			/** @todo Documentation */
-			std::size_t offset;
 
-		public:
-			/** type of allocation failures within this memory pool */
-			using bad_alloc = std::bad_alloc;
+/**
+ * @brief Dummy memory pool
+ * @todo replace with code to use mmap for ArgoDSM global address space
+ */
+class memory_pool {
+	private:
+		/** @todo Documentation */
+		char* memory;
+		/** @todo Documentation */
+		std::size_t max_size;
+		/** @todo Documentation */
+		std::size_t offset;
 
-			/**
-			 * @brief Default constructor: initializes memory on heap and sets offset to 0
-			 * @param size The amount of memory in the pool
-			 */
-			explicit memory_pool(std::size_t size) : memory(new char[size]), max_size(size), offset{0} {}
+	public:
+		/** type of allocation failures within this memory pool */
+		using bad_alloc = std::bad_alloc;
 
-			/**
-			 * @brief Reserve more memory
-			 * @param size Amount of memory reserved
-			 * @return The pointer to the first byte of the newly reserved memory area
-			 * @todo move size check to separate function?
-			 */
-			char* reserve(std::size_t size) {
-				if(offset+size > max_size) throw bad_alloc();
-				char* ptr = &memory[offset];
-				offset += size;
-				return ptr;
-			}
+		/**
+		 * @brief Default constructor: initializes memory on heap and sets offset to 0
+		 * @param size The amount of memory in the pool
+		 */
+		explicit memory_pool(std::size_t size) : memory(new char[size]), max_size(size), offset{0} {}
 
-			/**
-			 * @brief fail to grow the memory pool
-			 * @param size minimum size to grow
-			 */
-			void grow(std::size_t size) {
-				throw std::bad_alloc();
-			}
+		/**
+		 * @brief Reserve more memory
+		 * @param size Amount of memory reserved
+		 * @return The pointer to the first byte of the newly reserved memory area
+		 * @todo move size check to separate function?
+		 */
+		char* reserve(std::size_t size) {
+			if(offset+size > max_size) throw bad_alloc();
+			char* ptr = &memory[offset];
+			offset += size;
+			return ptr;
+		}
 
-			/**
-			 * @brief check remaining available memory in pool
-			 * @return remaining bytes in memory pool
-			 */
-			std::size_t available() {
-				return max_size - offset;
-			}
-	};
-} // namespace argo
+		/**
+		 * @brief fail to grow the memory pool
+		 * @param size minimum size to grow
+		 */
+		void grow(std::size_t size) {
+			throw std::bad_alloc();
+		}
+
+		/**
+		 * @brief check remaining available memory in pool
+		 * @return remaining bytes in memory pool
+		 */
+		std::size_t available() {
+			return max_size - offset;
+		}
+};
+
+}  // namespace argo
 
 #endif // ARGODSM_SRC_MEMPOOLS_DUMMY_MEMPOOL_HPP_

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -11,167 +11,165 @@
 #include "../synchronization/broadcast.hpp"
 
 namespace argo {
-	namespace mempools {
+namespace mempools {
 
-		/** @brief helper enum for choosing how to call grow() */
-		enum growth_mode_t {
-			/** @brief caller always needs to grow the mempool */
-			ALWAYS,
-			/** @brief growing is handled by ArgoDSM node zero */
-			NODE_ZERO_ONLY
-		};
+/** @brief helper enum for choosing how to call grow() */
+enum growth_mode_t {
+	/** @brief caller always needs to grow the mempool */
+	ALWAYS,
+	/** @brief growing is handled by ArgoDSM node zero */
+	NODE_ZERO_ONLY
+};
+
+/**
+ * @brief check whether growth needs to happen
+ * @tparam g enumeration of possibilities, used for partial specialization
+ * @return true if grow() should be called,
+ *         false if this is taken care of somewhere else
+ */
+template<growth_mode_t g>
+inline bool do_grow();
+
+/**
+ * @brief synchronize memory metainformation (address) after growing
+ *        to ensure visibility
+ * @tparam g enumeration of possibilities, used for partial specialization
+ * @param m pointer to the memory information to synchronize
+ */
+template<growth_mode_t g>
+inline void synchronize(memory_t* const m);
+
+/* full template specializations */
+
+/**
+ * @brief always enable growing the memory pool
+ * @return always true
+ */
+template<>
+inline bool do_grow<ALWAYS>() {
+	return true;
+}
+
+/**
+ * @brief restrict growing to ArgoDSM node 0
+ * @return true when called on ArgoDSM node 0, false otherwise
+ */
+template<>
+inline bool do_grow<NODE_ZERO_ONLY>() {
+	auto nid = backend::node_id();
+	return nid == 0;
+}
+
+/**
+ * @brief used when no additional synchronization is required
+ * @param m ignored
+ */
+template<>
+inline void synchronize<ALWAYS>(memory_t* const m) {
+	if(*m == nullptr) {
+		throw std::bad_alloc();
+	}
+	return;
+}
+
+/**
+ * @copydoc synchronize()
+ * @todo replace literal 0 with non-magic number
+ * @todo replace nullptr with non-magic representation of undefined memory
+ */
+template<>
+inline void synchronize<NODE_ZERO_ONLY>(memory_t* const m) {
+	auto memory_ptr = synchronization::broadcast(0, *m);
+	/** @todo verify this barrier is needed */
+	argo::backend::barrier();
+	if(memory_ptr == nullptr) {
+		throw std::bad_alloc();
+	}
+	*m = memory_ptr;
+}
+
+/**
+ * @brief Dynamically growing memory pool
+ */
+template<template<class> class Allocator, growth_mode_t growth_mode, std::size_t chunk_size = 4096>
+class dynamic_memory_pool {
+	private:
+		/**  @brief typedef for byte-size allocator */
+		using allocator_t = Allocator<char>;
+
+		/** @brief the internally used allocator */
+		allocator_t* allocator;
+
+		/** @brief current base address of this memory pool's memory */
+		memory_t memory;
+
+		/** @brief current size of the memory pool */
+		std::size_t max_size;
+
+		/** @brief amount of memory in pool that is already allocated */
+		std::size_t offset;
+
+	public:
+		/** type of allocation failures within this memory pool */
+		using bad_alloc = std::bad_alloc;
 
 		/**
-		 * @brief check whether growth needs to happen
-		 * @tparam g enumeration of possibilities, used for partial specialization
-		 * @return true if grow() should be called,
-		 *         false if this is taken care of somewhere else
+		 * @brief Default constructor: initializes memory on heap and sets offset to 0
+		 * @param a a pointer to the allocator to use for growing this mempool
+		 * @todo passing the allocator by pointer may be unnecessary
 		 */
-		template<growth_mode_t g>
-		inline bool do_grow();
+		explicit dynamic_memory_pool(allocator_t* a) : allocator(a), memory(nullptr), max_size(0), offset{0} {}
 
 		/**
-		 * @brief synchronize memory metainformation (address) after growing
-		 *        to ensure visibility
-		 * @tparam g enumeration of possibilities, used for partial specialization
-		 * @param m pointer to the memory information to synchronize
+		 * @brief Reserve more memory
+		 * @param size Amount of memory reserved
+		 * @return The pointer to the first byte of the newly reserved memory area
+		 * @todo move size check to separate function?
 		 */
-		template<growth_mode_t g>
-		inline void synchronize(memory_t* const m);
-
-		/* full template specializations */
-
-		/**
-		 * @brief always enable growing the memory pool
-		 * @return always true
-		 */
-		template<>
-		inline bool do_grow<ALWAYS>() {
-			return true;
-		}
-
-		/**
-		 * @brief restrict growing to ArgoDSM node 0
-		 * @return true when called on ArgoDSM node 0, false otherwise
-		 */
-		template<>
-		inline bool do_grow<NODE_ZERO_ONLY>() {
-			auto nid = backend::node_id();
-			return nid == 0;
-		}
-
-		/**
-		 * @brief used when no additional synchronization is required
-		 * @param m ignored
-		 */
-		template<>
-		inline void synchronize<ALWAYS>(memory_t* const m) {
-			if(*m == nullptr) {
-				throw std::bad_alloc();
+		char* reserve(std::size_t size) {
+			if(offset+size > max_size) {
+				throw bad_alloc();
+				/* defensively return nullptr if throwing is not supported */
+				return nullptr;
 			}
-
-			return;
+			char* ptr = &memory[offset];
+			offset += size;
+			return ptr;
 		}
 
 		/**
-		 * @copydoc synchronize()
-		 * @todo replace literal 0 with non-magic number
-		 * @todo replace nullptr with non-magic representation of undefined memory
+		 * @brief fail to grow the memory pool
+		 * @param size minimum size to grow
 		 */
-		template<>
-		inline void synchronize<NODE_ZERO_ONLY>(memory_t* const m) {
-			auto memory_ptr = synchronization::broadcast(0, *m);
-			/** @todo verify this barrier is needed */
-			argo::backend::barrier();
-			if(memory_ptr == nullptr) {
-				throw std::bad_alloc();
+		void grow(std::size_t size) {
+			/* sanity check */
+			if(!size) {
+				size = 1;
 			}
-			*m = memory_ptr;
+			/* try to allocate more memory */
+			auto alloc_size = ((size + chunk_size - 1) / chunk_size) * chunk_size;
+			max_size = alloc_size;
+			offset = 0;
+
+			try {
+				if(do_grow<growth_mode>()) {
+					memory = allocator->allocate(alloc_size);
+				}
+			} catch(const std::bad_alloc&) {
+				memory = nullptr;
+			}
+			synchronize<growth_mode>(&memory);
 		}
 
 		/**
-		 * @brief Dynamically growing memory pool
+		 * @brief check remaining available memory in pool
+		 * @return remaining bytes in memory pool
 		 */
-		template<template<class> class Allocator, growth_mode_t growth_mode, std::size_t chunk_size = 4096>
-		class dynamic_memory_pool {
-			private:
-				/**  @brief typedef for byte-size allocator */
-				using allocator_t = Allocator<char>;
-
-				/** @brief the internally used allocator */
-				allocator_t* allocator;
-
-				/** @brief current base address of this memory pool's memory */
-				memory_t memory;
-
-				/** @brief current size of the memory pool */
-				std::size_t max_size;
-
-				/** @brief amount of memory in pool that is already allocated */
-				std::size_t offset;
-
-			public:
-				/** type of allocation failures within this memory pool */
-				using bad_alloc = std::bad_alloc;
-
-				/**
-				 * @brief Default constructor: initializes memory on heap and sets offset to 0
-				 * @param a a pointer to the allocator to use for growing this mempool
-				 * @todo passing the allocator by pointer may be unnecessary
-				 */
-				explicit dynamic_memory_pool(allocator_t* a) : allocator(a), memory(nullptr), max_size(0), offset{0} {}
-
-				/**
-				 * @brief Reserve more memory
-				 * @param size Amount of memory reserved
-				 * @return The pointer to the first byte of the newly reserved memory area
-				 * @todo move size check to separate function?
-				 */
-				char* reserve(std::size_t size) {
-					if(offset+size > max_size) {
-						throw bad_alloc();
-						/* defensively return nullptr if throwing is not supported */
-						return nullptr;
-					}
-					char* ptr = &memory[offset];
-					offset += size;
-					return ptr;
-				}
-
-				/**
-				 * @brief fail to grow the memory pool
-				 * @param size minimum size to grow
-				 */
-				void grow(std::size_t size) {
-					/* sanity check */
-					if(!size) {
-						size = 1;
-					}
-					/* try to allocate more memory */
-					auto alloc_size = ((size + chunk_size - 1) / chunk_size) * chunk_size;
-					max_size = alloc_size;
-					offset = 0;
-
-					try {
-						if(do_grow<growth_mode>()) {
-							memory = allocator->allocate(alloc_size);
-						}
-					} catch(const std::bad_alloc&) {
-						memory = nullptr;
-					}
-					synchronize<growth_mode>(&memory);
-				}
-
-				/**
-				 * @brief check remaining available memory in pool
-				 * @return remaining bytes in memory pool
-				 */
-				std::size_t available() {
-					return max_size - offset;
-				}
-		};
-
-	} // namespace mempools
-} // namespace argo
+		std::size_t available() {
+			return max_size - offset;
+		}
+}; // class dynamic_memory_pool
+}  // namespace mempools
+}  // namespace argo
 
 #endif // ARGODSM_SRC_MEMPOOLS_DYNAMIC_MEMPOOL_HPP_

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -168,7 +168,8 @@ class dynamic_memory_pool {
 		std::size_t available() {
 			return max_size - offset;
 		}
-}; // class dynamic_memory_pool
+};
+
 }  // namespace mempools
 }  // namespace argo
 

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -22,128 +22,127 @@
 constexpr int PAGESIZE = 4096;
 
 namespace argo {
-	namespace mempools {
+namespace mempools {
+/**
+ * @brief Globally growing memory pool
+ */
+template<std::size_t chunk_size = 4096>
+class global_memory_pool {
+	private:
+		/** @brief current base address of this memory pool's memory */
+		char* memory;
+
+		/** @brief current size of the memory pool */
+		std::size_t max_size;
+
+		/** @brief amount of memory in pool that is already allocated */
+		std::ptrdiff_t* offset;
+
+		/** @todo Documentation */
+		argo::globallock::global_tas_lock *global_tas_lock;
+
+	public:
+		/** type of allocation failures within this memory pool */
+		using bad_alloc = std::bad_alloc;
+
+		/** reserved space for internal use */
+		static const std::size_t reserved = 4096;
 		/**
-		 * @brief Globally growing memory pool
+		 * @brief Default constructor: initializes memory on heap and sets offset to 0
 		 */
-		template<std::size_t chunk_size = 4096>
-		class global_memory_pool {
-			private:
-				/** @brief current base address of this memory pool's memory */
-				char* memory;
+		global_memory_pool() {
+			auto nodes = backend::number_of_nodes();
+			memory = backend::global_base();
+			max_size = backend::global_size();
+			/**@todo this initialization should move to tools::init() land */
+			using namespace data_distribution;
+			base_distribution<0>::set_memory_space(nodes, memory, max_size);
 
-				/** @brief current size of the memory pool */
-				std::size_t max_size;
+			// Reset maximum size to the full memory size minus the space reserved for internal use
+			max_size -= reserved;
+			// Attach memory pool offset to the start of the reserved space
+			offset = new (&memory[max_size]) ptrdiff_t;
 
-				/** @brief amount of memory in pool that is already allocated */
-				std::ptrdiff_t* offset;
+			using tas_lock = argo::globallock::global_tas_lock;
+			// Attach internal lock field sizeof(ptrdiff_t) bytes after the start of the reserved space
+			tas_lock::internal_field_type* field = new (&memory[max_size+sizeof(std::ptrdiff_t)]) tas_lock::internal_field_type;
+			global_tas_lock = new tas_lock(field);
 
-				/** @todo Documentation */
-				argo::globallock::global_tas_lock *global_tas_lock;
+			// Home node makes sure that offset points to Argo's starting address
+			global_ptr<char> gptr(&memory[max_size]);
+			if(backend::node_id() == gptr.node()) {
+				*offset = static_cast<std::ptrdiff_t>(0);
+			}
+			backend::barrier();
+		}
 
-			public:
-				/** type of allocation failures within this memory pool */
-				using bad_alloc = std::bad_alloc;
+		/** @todo Documentation */
+		~global_memory_pool() {
+			delete global_tas_lock;
+			backend::finalize();
+		}
 
-				/** reserved space for internal use */
-				static const std::size_t reserved = 4096;
-				/**
-				 * @brief Default constructor: initializes memory on heap and sets offset to 0
-				 */
-				global_memory_pool() {
-					auto nodes = backend::number_of_nodes();
-					memory = backend::global_base();
-					max_size = backend::global_size();
-					/**@todo this initialization should move to tools::init() land */
-					using namespace data_distribution;
-					base_distribution<0>::set_memory_space(nodes, memory, max_size);
+		/**
+		 *@brief  Resets the memory pool to the initial state instead of de-allocating and (re)allocating all buffers again.
+		 *Resets the memory pool to the initial state instead of de-allocating and (re)allocating all buffers again.
+		 *Any allocator or memory pool depending on this memory pool now has undefined behaviour.
+		 */
+		void reset() {
+			backend::barrier();
+			memory = backend::global_base();
+			// Move back one page as the last page is left for internal use
+			max_size = backend::global_size() - reserved;
 
-					// Reset maximum size to the full memory size minus the space reserved for internal use
-					max_size -= reserved;
-					// Attach memory pool offset to the start of the reserved space
-					offset = new (&memory[max_size]) ptrdiff_t;
+			// Home node makes sure that offset points to Argo's starting address
+			using namespace data_distribution;
+			global_ptr<char> gptr(&memory[max_size]);
+			if(backend::node_id() == gptr.node()) {
+				*offset = static_cast<std::ptrdiff_t>(0);
+			}
+			backend::barrier();
+		}
 
-					using tas_lock = argo::globallock::global_tas_lock;
-					// Attach internal lock field sizeof(ptrdiff_t) bytes after the start of the reserved space
-					tas_lock::internal_field_type* field = new (&memory[max_size+sizeof(std::ptrdiff_t)]) tas_lock::internal_field_type;
-					global_tas_lock = new tas_lock(field);
+		/**
+		 * @brief Reserve more memory
+		 * @param size Amount of memory reserved
+		 * @return The pointer to the first byte of the newly reserved memory area
+		 * @todo move size check to separate function?
+		 */
+		char* reserve(std::size_t size) {
+			char* ptr;
+			global_tas_lock->lock();
+			if(*offset+size > max_size) {
+				global_tas_lock->unlock();
+				throw bad_alloc();
+			}
+			ptr = &memory[*offset];
+			*offset += size;
+			global_tas_lock->unlock();
+			return ptr;
+		}
 
-					// Home node makes sure that offset points to Argo's starting address
-					global_ptr<char> gptr(&memory[max_size]);
-					if(backend::node_id() == gptr.node()) {
-						*offset = static_cast<std::ptrdiff_t>(0);
-					}
-					backend::barrier();
-				}
+		/**
+		 * @brief fail to grow the memory pool
+		 * @param size minimum size to grow
+		 */
+		void grow(std::size_t size) {
+			(void)size; // size is not needed for unconditional failure
+			throw std::bad_alloc();
+		}
 
-				/** @todo Documentation */
-				~global_memory_pool() {
-					delete global_tas_lock;
-					backend::finalize();
-				}
-
-				/**
-				 *@brief  Resets the memory pool to the initial state instead of de-allocating and (re)allocating all buffers again.
-				 *Resets the memory pool to the initial state instead of de-allocating and (re)allocating all buffers again.
-				 *Any allocator or memory pool depending on this memory pool now has undefined behaviour.
-				 */
-				void reset() {
-					backend::barrier();
-					memory = backend::global_base();
-					// Move back one page as the last page is left for internal use
-					max_size = backend::global_size() - reserved;
-
-					// Home node makes sure that offset points to Argo's starting address
-					using namespace data_distribution;
-					global_ptr<char> gptr(&memory[max_size]);
-					if(backend::node_id() == gptr.node()) {
-						*offset = static_cast<std::ptrdiff_t>(0);
-					}
-					backend::barrier();
-				}
-
-				/**
-				 * @brief Reserve more memory
-				 * @param size Amount of memory reserved
-				 * @return The pointer to the first byte of the newly reserved memory area
-				 * @todo move size check to separate function?
-				 */
-				char* reserve(std::size_t size) {
-					char* ptr;
-					global_tas_lock->lock();
-					if(*offset+size > max_size) {
-						global_tas_lock->unlock();
-						throw bad_alloc();
-					}
-					ptr = &memory[*offset];
-					*offset += size;
-					global_tas_lock->unlock();
-					return ptr;
-				}
-
-
-				/**
-				 * @brief fail to grow the memory pool
-				 * @param size minimum size to grow
-				 */
-				void grow(std::size_t size) {
-					(void)size; // size is not needed for unconditional failure
-					throw std::bad_alloc();
-				}
-
-				/**
-				 * @brief check remaining available memory in pool
-				 * @return remaining bytes in memory pool
-				 */
-				std::size_t available() {
-					std::size_t avail;
-					global_tas_lock->lock();
-					avail = max_size - *offset;
-					global_tas_lock->unlock();
-					return avail;
-				}
-		};
-	} // namespace mempools
-} // namespace argo
+		/**
+		 * @brief check remaining available memory in pool
+		 * @return remaining bytes in memory pool
+		 */
+		std::size_t available() {
+			std::size_t avail;
+			global_tas_lock->lock();
+			avail = max_size - *offset;
+			global_tas_lock->unlock();
+			return avail;
+		}
+}; // class global_memory_pool
+}  // namespace mempools
+}  // namespace argo
 
 #endif // ARGODSM_SRC_MEMPOOLS_GLOBAL_MEMPOOL_HPP_

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -23,6 +23,7 @@ constexpr int PAGESIZE = 4096;
 
 namespace argo {
 namespace mempools {
+
 /**
  * @brief Globally growing memory pool
  */
@@ -141,7 +142,8 @@ class global_memory_pool {
 			global_tas_lock->unlock();
 			return avail;
 		}
-}; // class global_memory_pool
+};
+
 }  // namespace mempools
 }  // namespace argo
 

--- a/src/signal/signal.hpp
+++ b/src/signal/signal.hpp
@@ -41,13 +41,13 @@ enum x86_pf_error_code {
 #endif /* REG_ERR */
 
 namespace {
-	/** @brief typedef for signal handlers */
-	using sig_handler = struct sigaction;
-	/** @brief typedef for function type used by ArgoDSM */
-	using handler_ftype = void(*)(int, siginfo_t*, void*);
+/** @brief typedef for signal handlers */
+using sig_handler = struct sigaction;
+/** @brief typedef for function type used by ArgoDSM */
+using handler_ftype = void(*)(int, siginfo_t*, void*);
 
-	/** @brief error message string */
-	const std::string msg_argo_unitialized = "ArgoDSM must be configured to capture a signal before application handlers can be installed";
+/** @brief error message string */
+const std::string msg_argo_unitialized = "ArgoDSM must be configured to capture a signal before application handlers can be installed";
 }  // namespace
 
 namespace argo {
@@ -131,7 +131,7 @@ class signal_handler {
 				return;
 			}
 		}
-}; // class signal_handler
+};
 
 template<int S> handler_ftype signal_handler<S>::argo_handler = nullptr;
 template<int S> sig_handler signal_handler<S>::application_handler;

--- a/src/signal/signal.hpp
+++ b/src/signal/signal.hpp
@@ -48,93 +48,95 @@ namespace {
 
 	/** @brief error message string */
 	const std::string msg_argo_unitialized = "ArgoDSM must be configured to capture a signal before application handlers can be installed";
-}
+}  // namespace
 
 namespace argo {
-	namespace signal {
+namespace signal {
+/**
+ * @brief Originating access type of segfault
+ */
+enum class access_type {
+	read,
+	write,
+	undefined
+};
+
+/**
+ * @brief class wrapper for managing a single POSIX signal
+ * @tparam SIGNAL the signal number
+ */
+template<int SIGNAL>
+class signal_handler {
+	private:
+		/** @brief signal handling function for ArgoDSM */
+		static handler_ftype argo_handler;
+		/** @brief signal handler for application use */
+		static sig_handler application_handler;
+
+	public:
 		/**
-		 * @brief Originating access type of segfault
+		 * @brief install a signal handler for ArgoDSM
+		 * @param h the function to handle signals
+		 * @details The function will only be called for signals
+		 *          that relate to ArgoDSM's internal workings
 		 */
-		enum class access_type {
-			read,
-			write,
-			undefined
-		};
+		static void install_argo_handler(const handler_ftype h) {
+			argo_handler = h;
+			sig_handler s;
+			s.sa_flags = SA_SIGINFO;
+			s.sa_sigaction = argo_signal_handler;
+			sigaction(SIGNAL, &s, &application_handler);
+		}
 
 		/**
-		 * @brief class wrapper for managing a single POSIX signal
-		 * @tparam SIGNAL the signal number
+		 * @brief install a signal handler for application use
+		 * @param h the signal handler for the application
+		 * @return the previous signal handler of the application
+		 * @details The signal handler will only be called for signals
+		 *          that are not consumed by ArgoDSM internally
 		 */
-		template<int SIGNAL>
-		class signal_handler {
-			private:
-				/** @brief signal handling function for ArgoDSM */
-				static handler_ftype argo_handler;
-				/** @brief signal handler for application use */
-				static sig_handler application_handler;
+		static sig_handler install_application_handler(sig_handler* h) {
+			if(argo_handler == nullptr) {
+				throw std::runtime_error(msg_argo_unitialized);
+			}
+			sig_handler r = *h;
+			std::swap(r, application_handler);
+			return r;
+		}
 
-			public:
-				/**
-				 * @brief install a signal handler for ArgoDSM
-				 * @param h the function to handle signals
-				 * @details The function will only be called for signals
-				 *          that relate to ArgoDSM's internal workings
-				 */
-				static void install_argo_handler(const handler_ftype h) {
-					argo_handler = h;
-					sig_handler s;
-					s.sa_flags = SA_SIGINFO;
-					s.sa_sigaction = argo_signal_handler;
-					sigaction(SIGNAL, &s, &application_handler);
+		/**
+		 * @brief a generic signal handler function
+		 * @param sig the signal number
+		 * @param si additional signal information
+		 * @param context context in use with received signal
+		 * @see check `man sigaction` for additional information
+		 */
+		static void argo_signal_handler(int sig, siginfo_t *si, void *context) {
+			namespace vm = argo::virtual_memory;
+			const auto addr = si->si_addr;
+			const auto start = static_cast<char*>(vm::start_address());
+			const auto end = start + vm::size();
+			if (addr < start || addr >= end) {
+				/* application signal */
+				if(application_handler.sa_flags & SA_SIGINFO) {
+					application_handler.sa_sigaction(sig, si, context);
+					return;
+				} else {
+					application_handler.sa_handler(sig);
+					return;
 				}
+			} else {
+				/* internal signal */
+				argo_handler(sig, si, context);
+				return;
+			}
+		}
+}; // class signal_handler
 
-				/**
-				 * @brief install a signal handler for application use
-				 * @param h the signal handler for the application
-				 * @return the previous signal handler of the application
-				 * @details The signal handler will only be called for signals
-				 *          that are not consumed by ArgoDSM internally
-				 */
-				static sig_handler install_application_handler(sig_handler* h) {
-					if(argo_handler == nullptr) {
-						throw std::runtime_error(msg_argo_unitialized);
-					}
-					sig_handler r = *h;
-					std::swap(r, application_handler);
-					return r;
-				}
+template<int S> handler_ftype signal_handler<S>::argo_handler = nullptr;
+template<int S> sig_handler signal_handler<S>::application_handler;
 
-				/**
-				 * @brief a generic signal handler function
-				 * @param sig the signal number
-				 * @param si additional signal information
-				 * @param context context in use with received signal
-				 * @see check `man sigaction` for additional information
-				 */
-				static void argo_signal_handler(int sig, siginfo_t *si, void *context) {
-					namespace vm = argo::virtual_memory;
-					const auto addr = si->si_addr;
-					const auto start = static_cast<char*>(vm::start_address());
-					const auto end = start + vm::size();
-					if (addr < start || addr >= end) {
-						/* application signal */
-						if(application_handler.sa_flags & SA_SIGINFO) {
-							application_handler.sa_sigaction(sig, si, context);
-							return;
-						} else {
-							application_handler.sa_handler(sig);
-							return;
-						}
-					} else {
-						/* internal signal */
-						argo_handler(sig, si, context);
-						return;
-					}
-				}
-		};
-		template<int S> handler_ftype signal_handler<S>::argo_handler = nullptr;
-		template<int S> sig_handler signal_handler<S>::application_handler;
-	} // namespace signal
-} // namespace argo
+}  // namespace signal
+}  // namespace argo
 
 #endif // ARGODSM_SRC_SIGNAL_SIGNAL_HPP_

--- a/src/synchronization/broadcast.hpp
+++ b/src/synchronization/broadcast.hpp
@@ -12,39 +12,41 @@
 
 namespace argo {
 namespace synchronization {
-	/**
-	 * @brief broadcast a single value
-	 * @tparam T the type of the value to broadcast
-	 * @param from the source node of the broadcast
-	 * @param value to broadcast
-	 * @return The value broadcasted
-	 * @todo is this a collective call?
-	 * @todo should this be merged with the backend interface?
-	 */
-	template<typename T>
-	T broadcast(node_id_t from, const T value) {
-		T v = value;
-		backend::broadcast(from, &v);
-		return v;
-	}
+
+/**
+ * @brief broadcast a single value
+ * @tparam T the type of the value to broadcast
+ * @param from the source node of the broadcast
+ * @param value to broadcast
+ * @return The value broadcasted
+ * @todo is this a collective call?
+ * @todo should this be merged with the backend interface?
+ */
+template<typename T>
+T broadcast(node_id_t from, const T value) {
+	T v = value;
+	backend::broadcast(from, &v);
+	return v;
+}
 
 #if 0
-	/**
-	 * @brief synchronize a global memory address across all ArgoDSM nodes
-	 * @tparam from the source node of the broadcast
-	 * @tparam T the type of the value to broadcast
-	 * @param value
-	 */
-	template<node_id_t from, typename T>
-	void synchronize(T* ptr) {
-		backend::broadcast(from, ptr);
-	}
-	template<typename T>
-	void synchronize(T* ptr) {
-		auto from = backend::node_id();
-		backend::broadcast(from, ptr);
-	}
+/**
+ * @brief synchronize a global memory address across all ArgoDSM nodes
+ * @tparam from the source node of the broadcast
+ * @tparam T the type of the value to broadcast
+ * @param value
+ */
+template<node_id_t from, typename T>
+void synchronize(T* ptr) {
+	backend::broadcast(from, ptr);
+}
+template<typename T>
+void synchronize(T* ptr) {
+	auto from = backend::node_id();
+	backend::broadcast(from, ptr);
+}
 #endif
+
 }  // namespace synchronization
 }  // namespace argo
 

--- a/src/synchronization/broadcast.hpp
+++ b/src/synchronization/broadcast.hpp
@@ -11,41 +11,41 @@
 #include "../types/types.hpp"
 
 namespace argo {
-	namespace synchronization {
-		/**
-		 * @brief broadcast a single value
-		 * @tparam T the type of the value to broadcast
-		 * @param from the source node of the broadcast
-		 * @param value to broadcast
-		 * @return The value broadcasted
-		 * @todo is this a collective call?
-		 * @todo should this be merged with the backend interface?
-		 */
-		template<typename T>
-		T broadcast(node_id_t from, const T value) {
-			T v = value;
-			backend::broadcast(from, &v);
-			return v;
-		}
+namespace synchronization {
+	/**
+	 * @brief broadcast a single value
+	 * @tparam T the type of the value to broadcast
+	 * @param from the source node of the broadcast
+	 * @param value to broadcast
+	 * @return The value broadcasted
+	 * @todo is this a collective call?
+	 * @todo should this be merged with the backend interface?
+	 */
+	template<typename T>
+	T broadcast(node_id_t from, const T value) {
+		T v = value;
+		backend::broadcast(from, &v);
+		return v;
+	}
 
 #if 0
-		/**
-		 * @brief synchronize a global memory address across all ArgoDSM nodes
-		 * @tparam from the source node of the broadcast
-		 * @tparam T the type of the value to broadcast
-		 * @param value
-		 */
-		template<node_id_t from, typename T>
-		void synchronize(T* ptr) {
-			backend::broadcast(from, ptr);
-		}
-		template<typename T>
-		void synchronize(T* ptr) {
-			auto from = backend::node_id();
-			backend::broadcast(from, ptr);
-		}
+	/**
+	 * @brief synchronize a global memory address across all ArgoDSM nodes
+	 * @tparam from the source node of the broadcast
+	 * @tparam T the type of the value to broadcast
+	 * @param value
+	 */
+	template<node_id_t from, typename T>
+	void synchronize(T* ptr) {
+		backend::broadcast(from, ptr);
+	}
+	template<typename T>
+	void synchronize(T* ptr) {
+		auto from = backend::node_id();
+		backend::broadcast(from, ptr);
+	}
 #endif
-	} // namespace synchronization
-} // namespace argo
+}  // namespace synchronization
+}  // namespace argo
 
 #endif // ARGODSM_SRC_SYNCHRONIZATION_BROADCAST_HPP_

--- a/src/synchronization/cohort_lock.hpp
+++ b/src/synchronization/cohort_lock.hpp
@@ -31,6 +31,7 @@ extern "C" {
 
 namespace argo {
 namespace globallock {
+
 /**
  * @brief a global  'cohort' lock - needs to be called collectively
  * @details Locks in levels and tries to hand over the lock as locally
@@ -196,7 +197,8 @@ class cohort_lock {
 				}
 			}
 		}
-}; // class cohort_lock
+};
+
 }  // namespace globallock
 }  // namespace argo
 

--- a/src/synchronization/cohort_lock.hpp
+++ b/src/synchronization/cohort_lock.hpp
@@ -30,174 +30,174 @@ extern "C" {
 #include "intranode/ticket_lock.hpp"
 
 namespace argo {
-	namespace globallock {
+namespace globallock {
+/**
+ * @brief a global  'cohort' lock - needs to be called collectively
+ * @details Locks in levels and tries to hand over the lock as locally
+ *         as possible.
+ * @warning Do not allocate this lock on the global memory. It contains
+ *         data that need to be node local. Also, keep in mind that the
+ *         constructor calls conew_, so the constructor should be called
+ *         by all the nodes at the same time.
+ *
+ * @todo Allow for global and dynamic allocation
+ */
+class cohort_lock {
+	private:
+		/** @brief internally used lock type */
+		using global_lock_type = argo::globallock::global_tas_lock;
+
+		/** @brief To keep track if the local ArgoDSM node has the global lock or not */
+		bool has_global_lock;
+
+		/** @brief Keeps track of how many times we handed over the NUMA lock on a specific NUMA node */
+		int numanodes;
+
+		/** @brief keeps track of which NUMA node has the NUMA lock */
+		int *handovers;
+
+		/** @brief Keeps track of how many times we handed over the global lock between the NUMA nodes */
+		int numahandover;
+
+		/** @brief number of NUMA nodes in the system */
+		std::atomic<int> nodelockowner;
+
+		/** @brief which node the lock is/was locked in */
+		int node;
+
+		/** @brief Mapping between CPUs and NUMA nodes */
+		std::vector<int> numa_mapping;
+
+		/** @brief Field necessary for the global_lock */
+		global_lock_type::internal_field_type *global_lock_field;
+
+		/** @brief A global TAS lock for locking between ArgoDSM nodes */
+		global_lock_type *global_lock;
+
+		/** @brief Local MCS locks for locking internally on a NUMA node */
+		argo::locallock::mcs_lock *local_lock;
+
+		/** @brief A local MCS lock shared by all the NUMA nodes - used for handing lock over between HW NUMA nodes */
+		argo::locallock::ticket_lock *node_lock;
+
+		/** @brief maximum amount of local handovers withing a NUMA node - numbers are experimental */
+		static const int MAX_HANDOVER = 8192;
+
+		/** @brief maximum amount of local handovers between NUMA nodes on the same ArgoDSM node - numbers are experimental */
+		static const int MAX_HANDOVER_NODELOCK = 128;
+
+		/** @brief Constant for no NUMA node having the node_lock */
+		static const int NO_OWNER = -1;
+
 		/**
-		 * @brief a global  'cohort' lock - needs to be called collectively
-		 * @details Locks in levels and tries to hand over the lock as locally
-		 *         as possible.
-		 * @warning Do not allocate this lock on the global memory. It contains
-		 *         data that need to be node local. Also, keep in mind that the
-		 *         constructor calls conew_, so the constructor should be called
-		 *         by all the nodes at the same time.
+		 * @brief Return the NUMA node in which the calling thread is being run.
+		 * @return The NUMA node ID
 		 *
-		 * @todo Allow for global and dynamic allocation
+		 * This function utilizes the sched_getcpu and the
+		 * numa_node_of_cpu function. While the first is very quick, the
+		 * second is extremely slow, so the results are preinitialized
+		 * at the constructor.
 		 */
-		class cohort_lock {
-			private:
-				/** @brief internally used lock type */
-				using global_lock_type = argo::globallock::global_tas_lock;
+		int numa_node() {
+			/*
+			 * int cpu = sched_getcpu();
+			 * return numa_mapping[cpu];
+			 */
+			return 0; /// @bug FIXME
+		}
 
-				/** @brief To keep track if the local ArgoDSM node has the global lock or not */
-				bool has_global_lock;
-
-				/** @brief Keeps track of how many times we handed over the NUMA lock on a specific NUMA node */
-				int numanodes;
-
-				/** @brief keeps track of which NUMA node has the NUMA lock */
-				int *handovers;
-
-				/** @brief Keeps track of how many times we handed over the global lock between the NUMA nodes */
-				int numahandover;
-
-				/** @brief number of NUMA nodes in the system */
-				std::atomic<int> nodelockowner;
-
-				/** @brief which node the lock is/was locked in */
-				int node;
-
-				/** @brief Mapping between CPUs and NUMA nodes */
-				std::vector<int> numa_mapping;
-
-				/** @brief Field necessary for the global_lock */
-				global_lock_type::internal_field_type *global_lock_field;
-
-				/** @brief A global TAS lock for locking between ArgoDSM nodes */
-				global_lock_type *global_lock;
-
-				/** @brief Local MCS locks for locking internally on a NUMA node */
-				argo::locallock::mcs_lock *local_lock;
-
-				/** @brief A local MCS lock shared by all the NUMA nodes - used for handing lock over between HW NUMA nodes */
-				argo::locallock::ticket_lock *node_lock;
-
-				/** @brief maximum amount of local handovers withing a NUMA node - numbers are experimental */
-				static const int MAX_HANDOVER = 8192;
-
-				/** @brief maximum amount of local handovers between NUMA nodes on the same ArgoDSM node - numbers are experimental */
-				static const int MAX_HANDOVER_NODELOCK = 128;
-
-				/** @brief Constant for no NUMA node having the node_lock */
-				static const int NO_OWNER = -1;
-
-				/**
-				 * @brief Return the NUMA node in which the calling thread is being run.
-				 * @return The NUMA node ID
-				 *
-				 * This function utilizes the sched_getcpu and the
-				 * numa_node_of_cpu function. While the first is very quick, the
-				 * second is extremely slow, so the results are preinitialized
-				 * at the constructor.
-				 */
-				int numa_node() {
-					/*
-					 * int cpu = sched_getcpu();
-					 * return numa_mapping[cpu];
-					 */
-					return 0; /// @bug FIXME
+	public:
+		/**
+		 * @brief construct global 'cohort' lock.
+		 *
+		 * This lock performs handovers in three levels: First within
+		 * the same NUMA node, then within the same ArgoDSM node, and
+		 * finally over ArgoDSM nodes.
+		 */
+		cohort_lock() :
+			has_global_lock(false),
+			numanodes(1), // sane default
+			numahandover(0),
+			nodelockowner(NO_OWNER),
+			global_lock_field(argo::conew_<typename global_lock_type::internal_field_type>()),
+			global_lock(new global_lock_type(global_lock_field)),
+			node_lock(new argo::locallock::ticket_lock()) {
+			int num_cpus = sysconf(_SC_NPROCESSORS_CONF); // sane default
+			numa_mapping.resize(num_cpus, 0);
+			#ifdef ARGO_USE_LIBNUMA
+			/* use libnuma only if it is actually available */
+			if(numa_available() != -1) {
+				numanodes = numa_num_configured_nodes();
+				/* Initialize the NUMA map */
+				for (int i = 0; i < num_cpus; ++i) {
+					numa_mapping[i] = numa_node_of_cpu(i);
 				}
+			}
+			#endif
+			/* initialize hierarchy components */
+			handovers = new int[numanodes]();
+			local_lock = new argo::locallock::mcs_lock[numanodes];
+		}
 
-			public:
-				/**
-				 * @brief construct global 'cohort' lock.
-				 *
-				 * This lock performs handovers in three levels: First within
-				 * the same NUMA node, then within the same ArgoDSM node, and
-				 * finally over ArgoDSM nodes.
-				 */
-				cohort_lock() :
-					has_global_lock(false),
-					numanodes(1), // sane default
-					numahandover(0),
-					nodelockowner(NO_OWNER),
-					global_lock_field(argo::conew_<typename global_lock_type::internal_field_type>()),
-					global_lock(new global_lock_type(global_lock_field)),
-					node_lock(new argo::locallock::ticket_lock()) {
-					int num_cpus = sysconf(_SC_NPROCESSORS_CONF); // sane default
-					numa_mapping.resize(num_cpus, 0);
-					#ifdef ARGO_USE_LIBNUMA
-					/* use libnuma only if it is actually available */
-					if(numa_available() != -1) {
-						numanodes = numa_num_configured_nodes();
-						/* Initialize the NUMA map */
-						for (int i = 0; i < num_cpus; ++i) {
-							numa_mapping[i] = numa_node_of_cpu(i);
-						}
-					}
-					#endif
-					/* initialize hierarchy components */
-					handovers = new int[numanodes]();
-					local_lock = new argo::locallock::mcs_lock[numanodes];
+		/** @todo Documentation */
+		~cohort_lock() {
+			codelete_(global_lock_field);
+			delete global_lock;
+			delete[] local_lock;
+			delete node_lock;
+			delete[] handovers;
+		}
+
+		/**
+		 * @brief Release the lock
+		 */
+		void unlock() {
+			/* Check if we can hand over the lock locally */
+			if(local_lock[node].is_contended() && handovers[node] < MAX_HANDOVER) {
+				handovers[node]++;
+			} else {
+				/* Cant hand over locally in the NUMA node - releases the NUMA lock */
+				handovers[node] = 0;
+				nodelockowner = NO_OWNER;
+
+				/* check if we should hand over to another NUMA node or ArgoDSM node */
+				if(node_lock->is_contended() && numahandover < MAX_HANDOVER_NODELOCK) {
+					/* Hand over to another NUMA node */
+					numahandover++;
+				} else {
+					/* hand over to another ArgoDSM node */
+					has_global_lock = false;
+					numahandover = 0;
+					global_lock->unlock();
 				}
+				node_lock->unlock();
+			}
+			local_lock[node].unlock();
+		}
 
-				/** @todo Documentation */
-				~cohort_lock() {
-					codelete_(global_lock_field);
-					delete global_lock;
-					delete[] local_lock;
-					delete node_lock;
-					delete[] handovers;
+		/**
+		 * @brief Acquire the lock
+		 */
+		void lock() {
+			node = numa_node();
+
+			/* Take the local lock for your NUMA node */
+			local_lock[node].lock();
+			/* Checks if this NUMA node already has the node_lock or not */
+			if(node != nodelockowner) {
+				/* Take the node_lock and set that this NUMA node has the node_lock */
+				node_lock->lock();
+				nodelockowner = node;
+				/* Check if this ArgoDSM node has the global lock or not */
+				if(!has_global_lock) {
+					/* Take the global lock */
+					global_lock->lock();
+					has_global_lock = true;
 				}
-
-				/**
-				 * @brief Release the lock
-				 */
-				void unlock() {
-					/* Check if we can hand over the lock locally */
-					if(local_lock[node].is_contended() && handovers[node] < MAX_HANDOVER) {
-						handovers[node]++;
-					} else {
-						/* Cant hand over locally in the NUMA node - releases the NUMA lock */
-						handovers[node] = 0;
-						nodelockowner = NO_OWNER;
-
-						/* check if we should hand over to another NUMA node or ArgoDSM node */
-						if(node_lock->is_contended() && numahandover < MAX_HANDOVER_NODELOCK) {
-							/* Hand over to another NUMA node */
-							numahandover++;
-						} else {
-							/* hand over to another ArgoDSM node */
-							has_global_lock = false;
-							numahandover = 0;
-							global_lock->unlock();
-						}
-						node_lock->unlock();
-					}
-					local_lock[node].unlock();
-				}
-
-				/**
-				 * @brief Acquire the lock
-				 */
-				void lock() {
-					node = numa_node();
-
-					/* Take the local lock for your NUMA node */
-					local_lock[node].lock();
-					/* Checks if this NUMA node already has the node_lock or not */
-					if(node != nodelockowner) {
-						/* Take the node_lock and set that this NUMA node has the node_lock */
-						node_lock->lock();
-						nodelockowner = node;
-						/* Check if this ArgoDSM node has the global lock or not */
-						if(!has_global_lock) {
-							/* Take the global lock */
-							global_lock->lock();
-							has_global_lock = true;
-						}
-					}
-				}
-		};
-	} // namespace globallock
-} // namespace argo
+			}
+		}
+}; // class cohort_lock
+}  // namespace globallock
+}  // namespace argo
 
 #endif // ARGODSM_SRC_SYNCHRONIZATION_COHORT_LOCK_HPP_

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -14,7 +14,10 @@
 
 namespace argo {
 namespace globallock {
-/** @brief a global test-and-set lock */
+
+/**
+ * @brief a global test-and-set lock
+ */
 class global_tas_lock {
 	private:
 		/** @brief constant signifying lock is in an initial state and free */
@@ -109,7 +112,8 @@ class global_tas_lock {
 		 *       user code must use this type alias
 		 */
 		using internal_field_type = std::size_t;
-}; // class global_tas_lock
+};
+
 }  // namespace globallock
 }  // namespace argo
 

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -13,104 +13,104 @@
 #include "../data_distribution/global_ptr.hpp"
 
 namespace argo {
-	namespace globallock {
-		/** @brief a global test-and-set lock */
-		class global_tas_lock {
-			private:
-				/** @brief constant signifying lock is in an initial state and free */
-				static const std::size_t init = -2;
-				/** @brief constant signifying lock is taken */
-				static const std::size_t locked = -1;
+namespace globallock {
+/** @brief a global test-and-set lock */
+class global_tas_lock {
+	private:
+		/** @brief constant signifying lock is in an initial state and free */
+		static const std::size_t init = -2;
+		/** @brief constant signifying lock is taken */
+		static const std::size_t locked = -1;
 
-				/** @brief import global_ptr */
-				using global_size_t = typename argo::data_distribution::global_ptr<std::size_t>;
+		/** @brief import global_ptr */
+		using global_size_t = typename argo::data_distribution::global_ptr<std::size_t>;
 
-				/**
-				 * @brief pointer to lock field
-				 * @todo should be replaced with an ArgoDSM-specific atomic type
-				 *       to allow efficient synchronization over more backends
-				 */
-				global_size_t lastuser;
+		/**
+		 * @brief pointer to lock field
+		 * @todo should be replaced with an ArgoDSM-specific atomic type
+		 *       to allow efficient synchronization over more backends
+		 */
+		global_size_t lastuser;
 
-			public:
-				/**
-				 * @brief construct global tas lock from existing memory in global address space
-				 * @param f pointer to global field for storing lock state
-				 */
-				explicit global_tas_lock(std::size_t* f) : lastuser(global_size_t(f)) {
-					*lastuser = init;
+	public:
+		/**
+		 * @brief construct global tas lock from existing memory in global address space
+		 * @param f pointer to global field for storing lock state
+		 */
+		explicit global_tas_lock(std::size_t* f) : lastuser(global_size_t(f)) {
+			*lastuser = init;
+		}
+
+		/**
+		 * @brief try to lock
+		 * @return true if lock was successfully taken,
+		 *         false otherwise
+		 */
+		bool try_lock() {
+			auto old = backend::atomic::exchange(lastuser, locked, atomic::memory_order::relaxed);
+			if(old != locked) {
+				std::size_t self = backend::node_id();
+				if(old == self || old == init) {
+					/* note: doing nothing here is only safe because we are using
+					 *       an SC for DRF memory model in ArgoDSM.
+					 *       When changing this to something more strict, e.g.
+					 *       TSO, then here a write buffer ordering must be
+					 *       enforced.
+					 *       A trivial implementation would call a
+					 *       self-downgrade (as release() does), but a
+					 *       better implementation could be thought of
+					 *       if a better write-buffer is also implemented.
+					 * why: semantically, we acquire at the beginning of
+					 *      a lock. Any OTHER node seeing changes from within
+					 *      the critical section can could therefore deduce
+					 *      which writes from before the critical section must
+					 *      have been issued. As write buffers can be cleared at
+					 *      any time without ordering guarantees, this may cause
+					 *      problems depending on the memory model. Using
+					 *      SC for DRF disallows making such deductions, as they
+					 *      would imply a data race.
+					 */
+
+					/* note: here a node-local acquire synchronization is needed.
+					 *       The global lock still has to function as a correct
+					 *       lock locally, so semantically we must ensure proper
+					 *       synchronization at least within this node.
+					 */
+					std::atomic_thread_fence(std::memory_order_acquire);
+				} else {
+					backend::acquire();
 				}
+				return true;
+			} else {
+				return false;
+			}
+		}
 
-				/**
-				 * @brief try to lock
-				 * @return true if lock was successfully taken,
-				 *         false otherwise
-				 */
-				bool try_lock() {
-					auto old = backend::atomic::exchange(lastuser, locked, atomic::memory_order::relaxed);
-					if(old != locked) {
-						std::size_t self = backend::node_id();
-						if(old == self || old == init) {
-							/* note: doing nothing here is only safe because we are using
-							 *       an SC for DRF memory model in ArgoDSM.
-							 *       When changing this to something more strict, e.g.
-							 *       TSO, then here a write buffer ordering must be
-							 *       enforced.
-							 *       A trivial implementation would call a
-							 *       self-downgrade (as release() does), but a
-							 *       better implementation could be thought of
-							 *       if a better write-buffer is also implemented.
-							 * why: semantically, we acquire at the beginning of
-							 *      a lock. Any OTHER node seeing changes from within
-							 *      the critical section can could therefore deduce
-							 *      which writes from before the critical section must
-							 *      have been issued. As write buffers can be cleared at
-							 *      any time without ordering guarantees, this may cause
-							 *      problems depending on the memory model. Using
-							 *      SC for DRF disallows making such deductions, as they
-							 *      would imply a data race.
-							 */
+		/**
+		 * @brief release the lock
+		 */
+		void unlock() {
+			std::size_t self = backend::node_id();
+			backend::release();
+			backend::atomic::store(lastuser, self);
+		}
 
-							/* note: here a node-local acquire synchronization is needed.
-							 *       The global lock still has to function as a correct
-							 *       lock locally, so semantically we must ensure proper
-							 *       synchronization at least within this node.
-							 */
-							std::atomic_thread_fence(std::memory_order_acquire);
-						} else {
-							backend::acquire();
-						}
-						return true;
-					} else {
-						return false;
-					}
-				}
+		/**
+		 * @brief take the lock
+		 */
+		void lock() {
+			while(!try_lock())
+				std::this_thread::yield();
+		}
 
-				/**
-				 * @brief release the lock
-				 */
-				void unlock() {
-					std::size_t self = backend::node_id();
-					backend::release();
-					backend::atomic::store(lastuser, self);
-				}
-
-				/**
-				 * @brief take the lock
-				 */
-				void lock() {
-					while(!try_lock())
-						std::this_thread::yield();
-				}
-
-				/**
-				 * @brief internally used type for lock field
-				 * @note this type may change without warning,
-				 *       user code must use this type alias
-				 */
-				using internal_field_type = std::size_t;
-		};
-	} // namespace globallock
-} // namespace argo
+		/**
+		 * @brief internally used type for lock field
+		 * @note this type may change without warning,
+		 *       user code must use this type alias
+		 */
+		using internal_field_type = std::size_t;
+}; // class global_tas_lock
+}  // namespace globallock
+}  // namespace argo
 
 #endif // ARGODSM_SRC_SYNCHRONIZATION_GLOBAL_TAS_LOCK_HPP_

--- a/src/synchronization/intranode/mcs_lock.hpp
+++ b/src/synchronization/intranode/mcs_lock.hpp
@@ -24,7 +24,7 @@ namespace locallock {
  * @warning The MCS need to be locked and unlocked by the same thread.
  */
 class mcs_lock {
-private:
+ private:
 	/** @brief Thread nodes for the lock */
 	struct mcs_node {
 		/** @brief Construct a new node */
@@ -42,7 +42,7 @@ private:
 	/** @brief Local nodes for the different locks each thread can have */
 	thread_local static std::map<mcs_lock*, mcs_node> selfs;
 
-public:
+ public:
 	/**
 	 * @brief Construct an MCS lock
 	 */
@@ -72,7 +72,7 @@ public:
 	bool is_contended();
 };
 
-} // namespace locallock
-} // namespace argo
+}  // namespace locallock
+}  // namespace argo
 
 #endif // ARGODSM_SRC_SYNCHRONIZATION_INTRANODE_MCS_LOCK_HPP_

--- a/src/synchronization/intranode/mcs_lock.hpp
+++ b/src/synchronization/intranode/mcs_lock.hpp
@@ -24,7 +24,7 @@ namespace locallock {
  * @warning The MCS need to be locked and unlocked by the same thread.
  */
 class mcs_lock {
- private:
+private:
 	/** @brief Thread nodes for the lock */
 	struct mcs_node {
 		/** @brief Construct a new node */
@@ -42,7 +42,7 @@ class mcs_lock {
 	/** @brief Local nodes for the different locks each thread can have */
 	thread_local static std::map<mcs_lock*, mcs_node> selfs;
 
- public:
+public:
 	/**
 	 * @brief Construct an MCS lock
 	 */

--- a/src/synchronization/intranode/ticket_lock.hpp
+++ b/src/synchronization/intranode/ticket_lock.hpp
@@ -11,7 +11,10 @@
 
 namespace argo {
 namespace locallock {
-/** @brief a global test-and-set lock */
+
+/**
+ * @brief a global ticket lock
+ */
 class ticket_lock {
 	private:
 		/** @brief Amount of threads wanting the lock */
@@ -51,7 +54,8 @@ class ticket_lock {
 			local_out = out_counter.load(std::memory_order_relaxed);
 			return (local_in - local_out) > 1;
 		}
-}; // class ticket_lock
+};
+
 }  // namespace locallock
 }  // namespace argo
 

--- a/src/synchronization/intranode/ticket_lock.hpp
+++ b/src/synchronization/intranode/ticket_lock.hpp
@@ -11,48 +11,48 @@
 
 namespace argo {
 namespace locallock {
-	/** @brief a global test-and-set lock */
-	class ticket_lock {
-		private:
-			/** @brief Amount of threads wanting the lock */
-			std::atomic<int> in_counter;
+/** @brief a global test-and-set lock */
+class ticket_lock {
+	private:
+		/** @brief Amount of threads wanting the lock */
+		std::atomic<int> in_counter;
 
-			/** @brief Amount of threads exiting the lock */
-			std::atomic<int> out_counter;
+		/** @brief Amount of threads exiting the lock */
+		std::atomic<int> out_counter;
 
-		public:
-			/**
-			 * @brief constructs a ticket_lock
-			 */
-			ticket_lock() : in_counter(0), out_counter(0) {}
+	public:
+		/**
+		 * @brief constructs a ticket_lock
+		 */
+		ticket_lock() : in_counter(0), out_counter(0) {}
 
-			/**
-			 * @brief take the lock by fetching your ticket and wait untill out_counter matches your ticket
-			 */
-			void lock() {
-				int ticket = in_counter.fetch_add(1, std::memory_order_relaxed);
-				while(out_counter.load(std::memory_order_acquire) != ticket) {}
-			}
+		/**
+		 * @brief take the lock by fetching your ticket and wait untill out_counter matches your ticket
+		 */
+		void lock() {
+			int ticket = in_counter.fetch_add(1, std::memory_order_relaxed);
+			while(out_counter.load(std::memory_order_acquire) != ticket) {}
+		}
 
-			/**
-			 * @brief release the lock
-			 */
-			void unlock() {
-				out_counter.fetch_add(1, std::memory_order_release);
-			}
+		/**
+		 * @brief release the lock
+		 */
+		void unlock() {
+			out_counter.fetch_add(1, std::memory_order_release);
+		}
 
-			/**
-			 * @brief Checks if the lock is contended by comparing in vs out counters
-			 * @return true it the lock is contended (some thread is waiting to get the lock) false otherwise.
-			 */
-			bool is_contended(){
-				int local_in, local_out;
-				local_in = in_counter.load(std::memory_order_relaxed);
-				local_out = out_counter.load(std::memory_order_relaxed);
-				return (local_in - local_out) > 1;
-			}
-	};
-} // namespace locallock
-} // namespace argo
+		/**
+		 * @brief Checks if the lock is contended by comparing in vs out counters
+		 * @return true it the lock is contended (some thread is waiting to get the lock) false otherwise.
+		 */
+		bool is_contended(){
+			int local_in, local_out;
+			local_in = in_counter.load(std::memory_order_relaxed);
+			local_out = out_counter.load(std::memory_order_relaxed);
+			return (local_in - local_out) > 1;
+		}
+}; // class ticket_lock
+}  // namespace locallock
+}  // namespace argo
 
 #endif // ARGODSM_SRC_SYNCHRONIZATION_INTRANODE_TICKET_LOCK_HPP_

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -21,94 +21,96 @@
 #include "virtual_memory.hpp"
 
 namespace {
-	/* file constants */
-	/** @todo hardcoded start address */
-	char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
-	/** @todo hardcoded size */
-	const ptrdiff_t ARGO_SIZE = 0x80000000000l;
+/* file constants */
+/** @todo hardcoded start address */
+char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
+/** @todo hardcoded size */
+const ptrdiff_t ARGO_SIZE = 0x80000000000l;
 
-	/** @brief error message string */
-	const std::string msg_insufficient_memory = "ArgoDSM anonymous mappable memory is insufficient.";
-	/** @brief error message string */
-	const std::string msg_mprotect_fail = "ArgoDSM could not mprotect anonymous mapping";
-	/** @brief error message string */
-	const std::string msg_invalid_remap = "ArgoDSM encountered an invalid mapping attempt in virtual address space";
-	/** @brief error message string */
-	const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
+/** @brief error message string */
+const std::string msg_insufficient_memory = "ArgoDSM anonymous mappable memory is insufficient.";
+/** @brief error message string */
+const std::string msg_mprotect_fail = "ArgoDSM could not mprotect anonymous mapping";
+/** @brief error message string */
+const std::string msg_invalid_remap = "ArgoDSM encountered an invalid mapping attempt in virtual address space";
+/** @brief error message string */
+const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
 
-	/* file variables */
-	/** @brief the address at which the backing storage space starts */
-	char* backing_addr;
-	/** @brief the current offset into the backing storage space */
-	std::size_t backing_offset;
-	/** @brief the offset within the memory region controlled to the beginning of the virtual address space */
-	std::size_t file_offset;
-} // namespace
+/* file variables */
+/** @brief the address at which the backing storage space starts */
+char* backing_addr;
+/** @brief the current offset into the backing storage space */
+std::size_t backing_offset;
+/** @brief the offset within the memory region controlled to the beginning of the virtual address space */
+std::size_t file_offset;
+}  // namespace
 
 namespace argo {
 namespace virtual_memory {
-	void init() {
-		/** @todo check desired range is free */
-		constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED|MAP_NORESERVE;
-		backing_addr = static_cast<char*>(
-			::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0));
-		if(backing_addr == MAP_FAILED) {
-			std::cerr << msg_main_mmap_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
-		char* virtual_addr = ARGO_START + ARGO_SIZE/2l;
-		backing_offset = 0;
-		file_offset = virtual_addr - backing_addr;
+
+void init() {
+	/** @todo check desired range is free */
+	constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED|MAP_NORESERVE;
+	backing_addr = static_cast<char*>(
+		::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0));
+	if(backing_addr == MAP_FAILED) {
+		std::cerr << msg_main_mmap_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+		exit(EXIT_FAILURE);
 	}
+	char* virtual_addr = ARGO_START + ARGO_SIZE/2l;
+	backing_offset = 0;
+	file_offset = virtual_addr - backing_addr;
+}
 
-	void* start_address() {
-		return backing_addr + file_offset;
+void* start_address() {
+	return backing_addr + file_offset;
+}
+
+std::size_t size() {
+	return ARGO_SIZE/4;
+}
+
+void* allocate_mappable(std::size_t alignment, std::size_t size) {
+	/* compute next free well-aligned offset */
+	backing_offset = ((backing_offset + alignment - 1)/alignment);
+	backing_offset *= alignment;
+
+	/* check it is within size limits */
+	if(backing_offset > argo::virtual_memory::size()) {
+		std::cerr << msg_insufficient_memory << std::endl;
+		throw std::system_error(std::make_error_code(std::errc::not_enough_memory), msg_insufficient_memory);
+		return nullptr;
 	}
+	char* r = backing_addr + backing_offset;
+	/* mark memory as used */
+	backing_offset += size;
 
-	std::size_t size() {
-		return ARGO_SIZE/4;
+	/* make memory writable */
+	int err = mprotect(r, size, PROT_READ|PROT_WRITE);
+	if(err) {
+		std::cerr << msg_mprotect_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
+		return nullptr;
 	}
+	return r;
+}
 
-	void* allocate_mappable(std::size_t alignment, std::size_t size) {
-		/* compute next free well-aligned offset */
-		backing_offset = ((backing_offset + alignment - 1)/alignment);
-		backing_offset *= alignment;
-
-		/* check it is within size limits */
-		if(backing_offset > argo::virtual_memory::size()) {
-			std::cerr << msg_insufficient_memory << std::endl;
-			throw std::system_error(std::make_error_code(std::errc::not_enough_memory), msg_insufficient_memory);
-			return nullptr;
-		}
-		char* r = backing_addr + backing_offset;
-		/* mark memory as used */
-		backing_offset += size;
-
-		/* make memory writable */
-		int err = mprotect(r, size, PROT_READ|PROT_WRITE);
-		if(err) {
-			std::cerr << msg_mprotect_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
-			return nullptr;
-		}
-		return r;
+void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+	/**@todo move pagesize 4096 to hw module */
+	int err = remap_file_pages(addr, size, 0, (file_offset + offset)/4096, 0);
+	if(err) {
+		std::cerr << msg_invalid_remap << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_invalid_remap);
+		exit(EXIT_FAILURE);
 	}
-
-	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
-		/**@todo move pagesize 4096 to hw module */
-		int err = remap_file_pages(addr, size, 0, (file_offset + offset)/4096, 0);
-		if(err) {
-			std::cerr << msg_invalid_remap << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_invalid_remap);
-			exit(EXIT_FAILURE);
-		}
-		err = mprotect(addr, size, prot);
-		if(err) {
-			std::cerr << msg_mprotect_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
-			exit(EXIT_FAILURE);
-		}
+	err = mprotect(addr, size, prot);
+	if(err) {
+		std::cerr << msg_mprotect_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
+		exit(EXIT_FAILURE);
 	}
-} // namespace virtual_memory
-} // namespace argo
+}
+
+}  // namespace virtual_memory
+}  // namespace argo

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -20,75 +20,77 @@
 #include "virtual_memory.hpp"
 
 namespace {
-	/* file constants */
-	/** @todo hardcoded start address */
-	char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
-	/** @todo hardcoded end address */
-	char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
-	/** @todo hardcoded size */
-	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+/* file constants */
+/** @todo hardcoded start address */
+char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
+/** @todo hardcoded end address */
+char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
+/** @todo hardcoded size */
+const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
 
-	/** @brief error message string */
-	const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
-	/** @brief error message string */
-	const std::string msg_mmap_fail = "ArgoDSM failed to map in virtual address space.";
-	/** @brief error message string */
-	const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
+/** @brief error message string */
+const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
+/** @brief error message string */
+const std::string msg_mmap_fail = "ArgoDSM failed to map in virtual address space.";
+/** @brief error message string */
+const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
 
-	/* file variables */
-	/** @brief a file descriptor for backing the virtual address space used by ArgoDSM */
-	int fd;
-	/** @brief the address at which the virtual address space used by ArgoDSM starts */
-	void* start_addr;
+/* file variables */
+/** @brief a file descriptor for backing the virtual address space used by ArgoDSM */
+int fd;
+/** @brief the address at which the virtual address space used by ArgoDSM starts */
+void* start_addr;
 } // namespace
 
 namespace argo {
 namespace virtual_memory {
-	void init() {
-		fd = syscall(__NR_memfd_create, "argocache", 0);
-		if(ftruncate(fd, ARGO_SIZE)) {
-			std::cerr << msg_main_mmap_fail << std::endl;
-			/** @todo do something? */
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
-		/** @todo check desired range is free */
-		constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
-		start_addr = ::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0);
-		if(start_addr == MAP_FAILED) {
-			std::cerr << msg_main_mmap_fail << std::endl;
-			/** @todo do something? */
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
-	}
 
-	void* start_address() {
-		return start_addr;
+void init() {
+	fd = syscall(__NR_memfd_create, "argocache", 0);
+	if(ftruncate(fd, ARGO_SIZE)) {
+		std::cerr << msg_main_mmap_fail << std::endl;
+		/** @todo do something? */
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+		exit(EXIT_FAILURE);
 	}
+	/** @todo check desired range is free */
+	constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+	start_addr = ::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0);
+	if(start_addr == MAP_FAILED) {
+		std::cerr << msg_main_mmap_fail << std::endl;
+		/** @todo do something? */
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+		exit(EXIT_FAILURE);
+	}
+}
 
-	std::size_t size() {
-		return ARGO_SIZE/2;
-	}
+void* start_address() {
+	return start_addr;
+}
 
-	void* allocate_mappable(std::size_t alignment, std::size_t size) {
-		void* p;
-		auto r = posix_memalign(&p, alignment, size);
-		if(r || p == nullptr) {
-			std::cerr << msg_alloc_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
-			return nullptr;
-		}
-		return p;
-	}
+std::size_t size() {
+	return ARGO_SIZE/2;
+}
 
-	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
-		auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
-		if(p == MAP_FAILED) {
-			std::cerr << msg_mmap_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
+void* allocate_mappable(std::size_t alignment, std::size_t size) {
+	void* p;
+	auto r = posix_memalign(&p, alignment, size);
+	if(r || p == nullptr) {
+		std::cerr << msg_alloc_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
+		return nullptr;
 	}
-} // namespace virtual_memory
-} // namespace argo
+	return p;
+}
+
+void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+	auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
+	if(p == MAP_FAILED) {
+		std::cerr << msg_mmap_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
+		exit(EXIT_FAILURE);
+	}
+}
+
+}  // namespace virtual_memory
+}  // namespace argo

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -43,52 +43,52 @@ namespace {
 } // namespace
 
 namespace argo {
-	namespace virtual_memory {
-		void init() {
-			fd = syscall(__NR_memfd_create, "argocache", 0);
-			if(ftruncate(fd, ARGO_SIZE)) {
-				std::cerr << msg_main_mmap_fail << std::endl;
-				/** @todo do something? */
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
-			/** @todo check desired range is free */
-			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
-			start_addr = ::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0);
-			if(start_addr == MAP_FAILED) {
-				std::cerr << msg_main_mmap_fail << std::endl;
-				/** @todo do something? */
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
+namespace virtual_memory {
+	void init() {
+		fd = syscall(__NR_memfd_create, "argocache", 0);
+		if(ftruncate(fd, ARGO_SIZE)) {
+			std::cerr << msg_main_mmap_fail << std::endl;
+			/** @todo do something? */
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+			exit(EXIT_FAILURE);
 		}
+		/** @todo check desired range is free */
+		constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+		start_addr = ::mmap(static_cast<void*>(ARGO_START), ARGO_SIZE, PROT_NONE, flags, -1, 0);
+		if(start_addr == MAP_FAILED) {
+			std::cerr << msg_main_mmap_fail << std::endl;
+			/** @todo do something? */
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+			exit(EXIT_FAILURE);
+		}
+	}
 
-		void* start_address() {
-			return start_addr;
-		}
+	void* start_address() {
+		return start_addr;
+	}
 
-		std::size_t size() {
-			return ARGO_SIZE/2;
-		}
+	std::size_t size() {
+		return ARGO_SIZE/2;
+	}
 
-		void* allocate_mappable(std::size_t alignment, std::size_t size) {
-			void* p;
-			auto r = posix_memalign(&p, alignment, size);
-			if(r || p == nullptr) {
-				std::cerr << msg_alloc_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
-				return nullptr;
-			}
-			return p;
+	void* allocate_mappable(std::size_t alignment, std::size_t size) {
+		void* p;
+		auto r = posix_memalign(&p, alignment, size);
+		if(r || p == nullptr) {
+			std::cerr << msg_alloc_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
+			return nullptr;
 		}
+		return p;
+	}
 
-		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
-			auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
-			if(p == MAP_FAILED) {
-				std::cerr << msg_mmap_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
+	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+		auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
+		if(p == MAP_FAILED) {
+			std::cerr << msg_mmap_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
+			exit(EXIT_FAILURE);
 		}
-	} // namespace virtual_memory
+	}
+} // namespace virtual_memory
 } // namespace argo

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -49,63 +49,63 @@ namespace {
 } // namespace
 
 namespace argo {
-	namespace virtual_memory {
-		void init() {
-			/* find maximum filesize */
-			struct statvfs b;
-			statvfs("/dev/shm", &b);
-			avail = b.f_bavail * b.f_bsize;
-			if(avail > static_cast<std::size_t>(ARGO_SIZE_LIMIT)) {
-				avail = ARGO_SIZE_LIMIT;
-			}
-			std::string filename = "/argocache" + std::to_string(getpid());
-			fd = shm_open(filename.c_str(), O_RDWR|O_CREAT, 0644);
-			if(shm_unlink(filename.c_str())) {
-				std::cerr << msg_main_mmap_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
-			if(ftruncate(fd, avail)) {
-				std::cerr << msg_main_mmap_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
-			/** @todo check desired range is free */
-			constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
-			start_addr = ::mmap(static_cast<void*>(ARGO_START), avail, PROT_NONE, flags, -1, 0);
-			if(start_addr == MAP_FAILED) {
-				std::cerr << msg_main_mmap_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
+namespace virtual_memory {
+	void init() {
+		/* find maximum filesize */
+		struct statvfs b;
+		statvfs("/dev/shm", &b);
+		avail = b.f_bavail * b.f_bsize;
+		if(avail > static_cast<std::size_t>(ARGO_SIZE_LIMIT)) {
+			avail = ARGO_SIZE_LIMIT;
 		}
+		std::string filename = "/argocache" + std::to_string(getpid());
+		fd = shm_open(filename.c_str(), O_RDWR|O_CREAT, 0644);
+		if(shm_unlink(filename.c_str())) {
+			std::cerr << msg_main_mmap_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+			exit(EXIT_FAILURE);
+		}
+		if(ftruncate(fd, avail)) {
+			std::cerr << msg_main_mmap_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+			exit(EXIT_FAILURE);
+		}
+		/** @todo check desired range is free */
+		constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+		start_addr = ::mmap(static_cast<void*>(ARGO_START), avail, PROT_NONE, flags, -1, 0);
+		if(start_addr == MAP_FAILED) {
+			std::cerr << msg_main_mmap_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+			exit(EXIT_FAILURE);
+		}
+	}
 
-		void* start_address() {
-			return start_addr;
-		}
+	void* start_address() {
+		return start_addr;
+	}
 
-		std::size_t size() {
-			return avail;
-		}
+	std::size_t size() {
+		return avail;
+	}
 
-		void* allocate_mappable(std::size_t alignment, std::size_t size) {
-			void* p;
-			auto r = posix_memalign(&p, alignment, size);
-			if(r || p == nullptr) {
-				std::cerr << msg_alloc_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
-				return nullptr;
-			}
-			return p;
+	void* allocate_mappable(std::size_t alignment, std::size_t size) {
+		void* p;
+		auto r = posix_memalign(&p, alignment, size);
+		if(r || p == nullptr) {
+			std::cerr << msg_alloc_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
+			return nullptr;
 		}
+		return p;
+	}
 
-		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
-			auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
-			if(p == MAP_FAILED) {
-				std::cerr << msg_mmap_fail << std::endl;
-				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
-				exit(EXIT_FAILURE);
-			}
+	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+		auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
+		if(p == MAP_FAILED) {
+			std::cerr << msg_mmap_fail << std::endl;
+			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
+			exit(EXIT_FAILURE);
 		}
-	} // namespace virtual_memory
+	}
+} // namespace virtual_memory
 } // namespace argo

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -22,90 +22,92 @@
 #include "virtual_memory.hpp"
 
 namespace {
-	/* file constants */
-	/** @todo hardcoded start address */
-	char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
-	/** @todo hardcoded end address */
-	char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
-	/** @todo hardcoded size */
-	const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
-	/** @todo hardcoded maximum size */
-	const ptrdiff_t ARGO_SIZE_LIMIT = 0x80000000000l;
+/* file constants */
+/** @todo hardcoded start address */
+char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
+/** @todo hardcoded end address */
+char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
+/** @todo hardcoded size */
+const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+/** @todo hardcoded maximum size */
+const ptrdiff_t ARGO_SIZE_LIMIT = 0x80000000000l;
 
-	/** @brief error message string */
-	const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
-	/** @brief error message string */
-	const std::string msg_mmap_fail = "ArgoDSM failed to map in virtual address space.";
-	/** @brief error message string */
-	const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
+/** @brief error message string */
+const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";
+/** @brief error message string */
+const std::string msg_mmap_fail = "ArgoDSM failed to map in virtual address space.";
+/** @brief error message string */
+const std::string msg_main_mmap_fail = "ArgoDSM failed to set up virtual memory. Please report a bug.";
 
-	/* file variables */
-	/** @brief a file descriptor for backing the virtual address space used by ArgoDSM */
-	int fd;
-	/** @brief the address at which the virtual address space used by ArgoDSM starts */
-	void* start_addr;
-	/** @brief the size of the ArgoDSM virtual address space */
-	std::size_t avail;
-} // namespace
+/* file variables */
+/** @brief a file descriptor for backing the virtual address space used by ArgoDSM */
+int fd;
+/** @brief the address at which the virtual address space used by ArgoDSM starts */
+void* start_addr;
+/** @brief the size of the ArgoDSM virtual address space */
+std::size_t avail;
+}  // namespace
 
 namespace argo {
 namespace virtual_memory {
-	void init() {
-		/* find maximum filesize */
-		struct statvfs b;
-		statvfs("/dev/shm", &b);
-		avail = b.f_bavail * b.f_bsize;
-		if(avail > static_cast<std::size_t>(ARGO_SIZE_LIMIT)) {
-			avail = ARGO_SIZE_LIMIT;
-		}
-		std::string filename = "/argocache" + std::to_string(getpid());
-		fd = shm_open(filename.c_str(), O_RDWR|O_CREAT, 0644);
-		if(shm_unlink(filename.c_str())) {
-			std::cerr << msg_main_mmap_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
-		if(ftruncate(fd, avail)) {
-			std::cerr << msg_main_mmap_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
-		/** @todo check desired range is free */
-		constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
-		start_addr = ::mmap(static_cast<void*>(ARGO_START), avail, PROT_NONE, flags, -1, 0);
-		if(start_addr == MAP_FAILED) {
-			std::cerr << msg_main_mmap_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
-	}
 
-	void* start_address() {
-		return start_addr;
+void init() {
+	/* find maximum filesize */
+	struct statvfs b;
+	statvfs("/dev/shm", &b);
+	avail = b.f_bavail * b.f_bsize;
+	if(avail > static_cast<std::size_t>(ARGO_SIZE_LIMIT)) {
+		avail = ARGO_SIZE_LIMIT;
 	}
+	std::string filename = "/argocache" + std::to_string(getpid());
+	fd = shm_open(filename.c_str(), O_RDWR|O_CREAT, 0644);
+	if(shm_unlink(filename.c_str())) {
+		std::cerr << msg_main_mmap_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+		exit(EXIT_FAILURE);
+	}
+	if(ftruncate(fd, avail)) {
+		std::cerr << msg_main_mmap_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+		exit(EXIT_FAILURE);
+	}
+	/** @todo check desired range is free */
+	constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
+	start_addr = ::mmap(static_cast<void*>(ARGO_START), avail, PROT_NONE, flags, -1, 0);
+	if(start_addr == MAP_FAILED) {
+		std::cerr << msg_main_mmap_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
+		exit(EXIT_FAILURE);
+	}
+}
 
-	std::size_t size() {
-		return avail;
-	}
+void* start_address() {
+	return start_addr;
+}
 
-	void* allocate_mappable(std::size_t alignment, std::size_t size) {
-		void* p;
-		auto r = posix_memalign(&p, alignment, size);
-		if(r || p == nullptr) {
-			std::cerr << msg_alloc_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
-			return nullptr;
-		}
-		return p;
-	}
+std::size_t size() {
+	return avail;
+}
 
-	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
-		auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
-		if(p == MAP_FAILED) {
-			std::cerr << msg_mmap_fail << std::endl;
-			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
-			exit(EXIT_FAILURE);
-		}
+void* allocate_mappable(std::size_t alignment, std::size_t size) {
+	void* p;
+	auto r = posix_memalign(&p, alignment, size);
+	if(r || p == nullptr) {
+		std::cerr << msg_alloc_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(r)), msg_alloc_fail);
+		return nullptr;
 	}
-} // namespace virtual_memory
-} // namespace argo
+	return p;
+}
+
+void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
+	auto p = ::mmap(addr, size, prot, MAP_SHARED|MAP_FIXED, fd, offset);
+	if(p == MAP_FAILED) {
+		std::cerr << msg_mmap_fail << std::endl;
+		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
+		exit(EXIT_FAILURE);
+	}
+}
+
+}  // namespace virtual_memory
+}  // namespace argo

--- a/src/virtual_memory/virtual_memory.hpp
+++ b/src/virtual_memory/virtual_memory.hpp
@@ -10,45 +10,45 @@
 #include <utility>
 
 namespace argo {
-	namespace virtual_memory {
-		/**
-		 * @brief initialize the ArgoDSM virtual address space
-		 * @todo virtual address space handling should be wrapped into an object
-		 */
-		void init();
+namespace virtual_memory {
+	/**
+	 * @brief initialize the ArgoDSM virtual address space
+	 * @todo virtual address space handling should be wrapped into an object
+	 */
+	void init();
 
-		/**
-		 * @brief get a pointer to the ArgoDSM virtual memory
-		 * @return the pointer to ArgoDSM virtual memory
-		 */
-		void* start_address();
+	/**
+	 * @brief get a pointer to the ArgoDSM virtual memory
+	 * @return the pointer to ArgoDSM virtual memory
+	 */
+	void* start_address();
 
-		/**
-		 * @brief get size of the ArgoDSM virtual memory
-		 * @return the size of the ArgoDSM virtual memory
-		 */
-		std::size_t size();
+	/**
+	 * @brief get size of the ArgoDSM virtual memory
+	 * @return the size of the ArgoDSM virtual memory
+	 */
+	std::size_t size();
 
-		/**
-		 * @brief allocate memory that can be mapped into ArgoDSM virtual address space later
-		 * @param alignment the alignment of the allocation
-		 * @param size size of the allocation
-		 * @return a pointer to the new memory allocation
-		 * @details this will allocate memory that is guaranteed to work with map_memory().
-		 *          Any memory allocated through other means may not be possible to map
-		 *          into the visible ArgoDSM virtual memory space later.
-		 */
-		void* allocate_mappable(std::size_t alignment, std::size_t size);
+	/**
+	 * @brief allocate memory that can be mapped into ArgoDSM virtual address space later
+	 * @param alignment the alignment of the allocation
+	 * @param size size of the allocation
+	 * @return a pointer to the new memory allocation
+	 * @details this will allocate memory that is guaranteed to work with map_memory().
+	 *          Any memory allocated through other means may not be possible to map
+	 *          into the visible ArgoDSM virtual memory space later.
+	 */
+	void* allocate_mappable(std::size_t alignment, std::size_t size);
 
-		/**
-		 * @brief map memory into ArgoDSM virtual address space
-		 * @param addr the address to map to
-		 * @param size the size of the mapping
-		 * @param offset the offset into the backing memory
-		 * @param prot protection flags for the mapping
-		 */
-		void map_memory(void* addr, std::size_t size, std::size_t offset, int prot);
-	} // namespace virtual_memory
+	/**
+	 * @brief map memory into ArgoDSM virtual address space
+	 * @param addr the address to map to
+	 * @param size the size of the mapping
+	 * @param offset the offset into the backing memory
+	 * @param prot protection flags for the mapping
+	 */
+	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot);
+} // namespace virtual_memory
 } // namespace argo
 
 #endif // ARGODSM_SRC_VIRTUAL_MEMORY_VIRTUAL_MEMORY_HPP_

--- a/src/virtual_memory/virtual_memory.hpp
+++ b/src/virtual_memory/virtual_memory.hpp
@@ -11,44 +11,46 @@
 
 namespace argo {
 namespace virtual_memory {
-	/**
-	 * @brief initialize the ArgoDSM virtual address space
-	 * @todo virtual address space handling should be wrapped into an object
-	 */
-	void init();
 
-	/**
-	 * @brief get a pointer to the ArgoDSM virtual memory
-	 * @return the pointer to ArgoDSM virtual memory
-	 */
-	void* start_address();
+/**
+ * @brief initialize the ArgoDSM virtual address space
+ * @todo virtual address space handling should be wrapped into an object
+ */
+void init();
 
-	/**
-	 * @brief get size of the ArgoDSM virtual memory
-	 * @return the size of the ArgoDSM virtual memory
-	 */
-	std::size_t size();
+/**
+ * @brief get a pointer to the ArgoDSM virtual memory
+ * @return the pointer to ArgoDSM virtual memory
+ */
+void* start_address();
 
-	/**
-	 * @brief allocate memory that can be mapped into ArgoDSM virtual address space later
-	 * @param alignment the alignment of the allocation
-	 * @param size size of the allocation
-	 * @return a pointer to the new memory allocation
-	 * @details this will allocate memory that is guaranteed to work with map_memory().
-	 *          Any memory allocated through other means may not be possible to map
-	 *          into the visible ArgoDSM virtual memory space later.
-	 */
-	void* allocate_mappable(std::size_t alignment, std::size_t size);
+/**
+ * @brief get size of the ArgoDSM virtual memory
+ * @return the size of the ArgoDSM virtual memory
+ */
+std::size_t size();
 
-	/**
-	 * @brief map memory into ArgoDSM virtual address space
-	 * @param addr the address to map to
-	 * @param size the size of the mapping
-	 * @param offset the offset into the backing memory
-	 * @param prot protection flags for the mapping
-	 */
-	void map_memory(void* addr, std::size_t size, std::size_t offset, int prot);
-} // namespace virtual_memory
-} // namespace argo
+/**
+ * @brief allocate memory that can be mapped into ArgoDSM virtual address space later
+ * @param alignment the alignment of the allocation
+ * @param size size of the allocation
+ * @return a pointer to the new memory allocation
+ * @details this will allocate memory that is guaranteed to work with map_memory().
+ *          Any memory allocated through other means may not be possible to map
+ *          into the visible ArgoDSM virtual memory space later.
+ */
+void* allocate_mappable(std::size_t alignment, std::size_t size);
+
+/**
+ * @brief map memory into ArgoDSM virtual address space
+ * @param addr the address to map to
+ * @param size the size of the mapping
+ * @param offset the offset into the backing memory
+ * @param prot protection flags for the mapping
+ */
+void map_memory(void* addr, std::size_t size, std::size_t offset, int prot);
+
+}  // namespace virtual_memory
+}  // namespace argo
 
 #endif // ARGODSM_SRC_VIRTUAL_MEMORY_VIRTUAL_MEMORY_HPP_


### PR DESCRIPTION
There is really no need to indent code inside namespaces.

While at it, cleaned up various places in the code (mostly in comments that now fit in single lines).

Before we merge this, we should discuss whether to adopt the C++17 way of writing nested namespaces.