### PR TITLE
Place include .hpp headers alphabetically

### DIFF
--- a/tests/allocators.cpp
+++ b/tests/allocators.cpp
@@ -11,10 +11,10 @@
 #include <iostream>
 #include <tuple>
 // ArgoDSM headers
-#include "argo.hpp"
 #include "allocators/collective_allocator.hpp"
 #include "allocators/generic_allocator.hpp"
 #include "allocators/null_lock.hpp"
+#include "argo.hpp"
 #include "backend/backend.hpp"
 // GoogleTest headers
 #include "gtest/gtest.h"

--- a/tests/api.cpp
+++ b/tests/api.cpp
@@ -10,8 +10,8 @@
 // C++ headers
 #include <iostream>
 // ArgoDSM headers
-#include "argo.hpp"
 #include "allocators/collective_allocator.hpp"
+#include "argo.hpp"
 #include "backend/backend.hpp"
 #include "data_distribution/data_distribution.hpp"
 #include "env/env.hpp"

--- a/tests/lock.cpp
+++ b/tests/lock.cpp
@@ -11,10 +11,10 @@
 #include <iostream>
 #include <thread>
 // ArgoDSM headers
-#include "argo.hpp"
 #include "allocators/collective_allocator.hpp"
 #include "allocators/generic_allocator.hpp"
 #include "allocators/null_lock.hpp"
+#include "argo.hpp"
 #include "backend/backend.hpp"
 #include "data_distribution/global_ptr.hpp"
 #include "synchronization/cohort_lock.hpp"

--- a/tests/omp.cpp
+++ b/tests/omp.cpp
@@ -11,10 +11,10 @@
 // C++ headers
 #include <iostream>
 // ArgoDSM headers
-#include "argo.hpp"
 #include "allocators/collective_allocator.hpp"
 #include "allocators/generic_allocator.hpp"
 #include "allocators/null_lock.hpp"
+#include "argo.hpp"
 #include "backend/backend.hpp"
 // GoogleTest headers
 #include "gtest/gtest.h"

--- a/tests/prefetch.cpp
+++ b/tests/prefetch.cpp
@@ -11,10 +11,10 @@
 #include <atomic>
 #include <iostream>
 // ArgoDSM headers
-#include "argo.hpp"
 #include "allocators/collective_allocator.hpp"
 #include "allocators/generic_allocator.hpp"
 #include "allocators/null_lock.hpp"
+#include "argo.hpp"
 #include "backend/backend.hpp"
 #include "env/env.hpp"
 // GoogleTest headers


### PR DESCRIPTION
Their proper ordering was missed when the tests files were cleaned up.