### PR TITLE
No 4096

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 cmake_minimum_required(VERSION 3.3)
 project(ArgoDSM VERSION 0.1)
 
+# define PAGE_SIZE: the commented out code returns an int; we want a size_t
+#execute_process(COMMAND getconf PAGESIZE OUTPUT_VARIABLE SYSTEM_PAGE_SIZE)
+add_definitions(-DPAGE_SIZE=4096UL) #${SYSTEM_PAGE_SIZE})
+
 set(DEFAULT_C_FLAGS "-std=c17 -pthread -Wall -Wextra -Werror")
 set(DEFAULT_CXX_FLAGS "-std=c++17 -pthread -DOMPI_SKIP_MPICXX=1 -Wall -Wextra -Werror")
 set(DEFAULT_LINK_FLAGS "")

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -16,6 +16,11 @@
 #include "../data_distribution/global_ptr.hpp"
 #include "../types/types.hpp"
 
+/**
+ * @brief The size of a hardware memory page
+ */
+constexpr std::size_t PAGE_SIZE = 4096;
+
 namespace argo {
 /**
  * @brief namespace for backend functionality

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -16,11 +16,6 @@
 #include "../data_distribution/global_ptr.hpp"
 #include "../types/types.hpp"
 
-/**
- * @brief The size of a hardware memory page
- */
-constexpr std::size_t PAGE_SIZE = 4096;
-
 namespace argo {
 /**
  * @brief namespace for backend functionality

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -20,7 +20,7 @@ void _selective_acquire(void *addr, std::size_t size) {
 		return;
 	}
 
-	const std::size_t block_size = page_size*CACHELINE;
+	const std::size_t block_size = PAGE_SIZE*CACHELINE;
 	const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
 	const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
 	std::size_t argo_address =
@@ -94,7 +94,7 @@ void _selective_release(void *addr, std::size_t size) {
 		return;
 	}
 
-	const std::size_t block_size = page_size*CACHELINE;
+	const std::size_t block_size = PAGE_SIZE*CACHELINE;
 	const std::size_t start_address = reinterpret_cast<std::size_t>(argo::virtual_memory::start_address());
 	const std::size_t page_misalignment = reinterpret_cast<std::size_t>(addr)%block_size;
 	std::size_t argo_address =
@@ -126,7 +126,7 @@ void _selective_release(void *addr, std::size_t size) {
 		if(cacheControl[cache_index].dirty == DIRTY) {
 			mprotect(reinterpret_cast<char*>(start_address) + page_address, block_size, PROT_READ);
 			for(int i = 0; i <CACHELINE; i++) {
-				storepageDIFF(cache_index+i, page_address+page_size*i);
+				storepageDIFF(cache_index+i, page_address+PAGE_SIZE*i);
 			}
 			argo_write_buffer->erase(cache_index);
 			cacheControl[cache_index].dirty = CLEAN;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -253,13 +253,6 @@ static const argo_byte WRITER = 4;
 /** @brief Constant for reader states */
 static const argo_byte READER = 5;
 
-/**
- * @brief The size of a hardware memory page
- * @note  This should be better centralized for all
- *        modules and backend implementations
- */
-constexpr std::size_t page_size = 4096;
-
 /* External declarations */
 /**
  * @brief Argo cache data structure

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -25,7 +25,7 @@
 #include "virtual_memory/virtual_memory.hpp"
 
 /** @brief Block size based on backend definition */
-const std::size_t block_size = page_size*CACHELINE;
+const std::size_t block_size = PAGE_SIZE*CACHELINE;
 
 /**
  * @brief	A write buffer in FIFO style with the capability to erase any
@@ -138,7 +138,7 @@ class write_buffer {
 			mprotect(page_ptr, block_size, PROT_READ);
 			cacheControl[cache_index].dirty = CLEAN;
 			for(std::size_t i = 0; i < CACHELINE; i++) {
-				storepageDIFF(cache_index+i, page_size*i+page_address);
+				storepageDIFF(cache_index+i, PAGE_SIZE*i+page_address);
 			}
 			cache_locks[cache_index].unlock();
 		}

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -82,7 +82,7 @@ void init(std::size_t argo_size, std::size_t cache_size) {
 	/** @todo the cache_size parameter is not needed
 	 *        and should not be part of the backend interface */
 	(void)(cache_size);
-	memory = static_cast<char*>(vm::allocate_mappable(4096, argo_size));
+	memory = static_cast<char*>(vm::allocate_mappable(PAGE_SIZE, argo_size));
 	memory_size = argo_size;
 	using namespace data_distribution;
 	base_distribution<0>::set_memory_space(nodes, memory, argo_size);
@@ -91,15 +91,15 @@ void init(std::size_t argo_size, std::size_t cache_size) {
 	 *        the homenode and offset for an address */
 	if (is_first_touch_policy()) {
 		/* calculate the directory size and allocate memory */
-		std::size_t owners_dir_size = 3*(argo_size/4096UL);
+		std::size_t owners_dir_size = 3*(argo_size/PAGE_SIZE);
 		std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
-		owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / 4096UL))*4096UL;
-		global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(4096UL, owners_dir_size_bytes));
+		owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / PAGE_SIZE))*PAGE_SIZE;
+		global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(PAGE_SIZE, owners_dir_size_bytes));
 		/* hardcode first-touch directory values so
 		   that we perform only load operations */
 		for(std::size_t j = 0; j < owners_dir_size; j += 3) {
 			global_owners_dir[j] = 0;
-			global_owners_dir[j+1] = j/3 * 4096UL;
+			global_owners_dir[j+1] = j/3 * PAGE_SIZE;
 			global_owners_dir[j+2] = 0;
 		}
 	}
@@ -136,15 +136,15 @@ void reset_coherence() {
 	 *        the homenode and offset for an address */
 	if (is_first_touch_policy()) {
 		/* calculate the directory size and allocate memory */
-		std::size_t owners_dir_size = 3*(memory_size/4096UL);
+		std::size_t owners_dir_size = 3*(memory_size/PAGE_SIZE);
 		std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
-		owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / 4096UL))*4096UL;
-		global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(4096UL, owners_dir_size_bytes));
+		owners_dir_size_bytes = (1 + ((owners_dir_size_bytes-1) / PAGE_SIZE))*PAGE_SIZE;
+		global_owners_dir = static_cast<std::uintptr_t*>(vm::allocate_mappable(PAGE_SIZE, owners_dir_size_bytes));
 		/* hardcode first-touch directory values so
 		   that we perform only load operations */
 		for(std::size_t j = 0; j < owners_dir_size; j += 3) {
 			global_owners_dir[j] = 0;
-			global_owners_dir[j+1] = j/3 * 4096UL;
+			global_owners_dir[j+1] = j/3 * PAGE_SIZE;
 			global_owners_dir[j+2] = 0;
 		}
 	}

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -91,7 +91,7 @@ inline void synchronize<NODE_ZERO_ONLY>(memory_t* const m) {
 /**
  * @brief Dynamically growing memory pool
  */
-template<template<class> class Allocator, growth_mode_t growth_mode, std::size_t chunk_size = 4096>
+template<template<class> class Allocator, growth_mode_t growth_mode, std::size_t chunk_size = PAGE_SIZE>
 class dynamic_memory_pool {
 	private:
 		/**  @brief typedef for byte-size allocator */

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -18,16 +18,13 @@
 #include "../data_distribution/global_ptr.hpp"
 #include "../synchronization/global_tas_lock.hpp"
 
-/** @todo Documentation */
-constexpr int PAGESIZE = 4096;
-
 namespace argo {
 namespace mempools {
 
 /**
  * @brief Globally growing memory pool
  */
-template<std::size_t chunk_size = 4096>
+template<std::size_t chunk_size = PAGE_SIZE>
 class global_memory_pool {
 	private:
 		/** @brief current base address of this memory pool's memory */
@@ -47,7 +44,7 @@ class global_memory_pool {
 		using bad_alloc = std::bad_alloc;
 
 		/** reserved space for internal use */
-		static const std::size_t reserved = 4096;
+		static const std::size_t reserved = PAGE_SIZE;
 		/**
 		 * @brief Default constructor: initializes memory on heap and sets offset to 0
 		 */

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <system_error>
 
+#include "backend/backend.hpp"
 #include "virtual_memory.hpp"
 
 namespace {
@@ -97,8 +98,7 @@ void* allocate_mappable(std::size_t alignment, std::size_t size) {
 }
 
 void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
-	/**@todo move pagesize 4096 to hw module */
-	int err = remap_file_pages(addr, size, 0, (file_offset + offset)/4096, 0);
+	int err = remap_file_pages(addr, size, 0, (file_offset + offset)/PAGE_SIZE, 0);
 	if(err) {
 		std::cerr << msg_invalid_remap << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_invalid_remap);

--- a/tests/api.cpp
+++ b/tests/api.cpp
@@ -28,9 +28,6 @@ namespace dd = argo::data_distribution;
 namespace mem = argo::mempools;
 extern mem::global_memory_pool<>* default_global_mempool;
 
-/** @brief ArgoDSM page size */
-const std::size_t page_size = 4096;
-
 /** @brief A "random" char constant */
 constexpr char c_const = 'a';
 
@@ -79,7 +76,7 @@ TEST_F(APITest, GetHomeNode) {
 	char* end = start + argo::backend::global_size();
 
 	/* Touch an equal (+/- 1) number of pages per node */
-	for(std::size_t s = page_size*node_id; s < alloc_size-1; s += page_size*num_nodes) {
+	for(std::size_t s = PAGE_SIZE*node_id; s < alloc_size-1; s += PAGE_SIZE*num_nodes) {
 		tmp[s] = c_const;
 	}
 	argo::barrier();
@@ -87,7 +84,7 @@ TEST_F(APITest, GetHomeNode) {
 	/* Test that the number of pages owned by each node is equal (+/- 1) */
 	std::size_t counter = 0;
 	std::vector<std::size_t> node_counters(num_nodes);
-	for(char* c = start; c < end; c += page_size) {
+	for(char* c = start; c < end; c += PAGE_SIZE) {
 		node_counters[argo::get_homenode(c)]++;
 		counter++;
 	}
@@ -109,9 +106,9 @@ TEST_F(APITest, GetBlockSize) {
 	std::size_t api_block_size = argo::get_block_size();
 	std::size_t size_per_node = argo::backend::global_size()/argo::number_of_nodes();
 	if(dd::is_cyclic_policy()) {
-		ASSERT_EQ(api_block_size, env_block_size*page_size);
+		ASSERT_EQ(api_block_size, env_block_size*PAGE_SIZE);
 	} else if (dd::is_first_touch_policy()) {
-		ASSERT_EQ(api_block_size, page_size);
+		ASSERT_EQ(api_block_size, PAGE_SIZE);
 	} else {
 		ASSERT_EQ(api_block_size, size_per_node);
 	}

--- a/tests/backend.cpp
+++ b/tests/backend.cpp
@@ -688,7 +688,7 @@ TEST_F(backendTest, randAccessesPeriodicSelectiveReleaseAcquireArray) {
  */
 TEST_F(backendTest, randAccessesBarrierPage) {
 	// Allocate global page
-	constexpr std::size_t array_size = 4096 / sizeof(unsigned char);
+	constexpr std::size_t array_size = PAGE_SIZE / sizeof(unsigned char);
 	unsigned char*const array = argo::conew_array<unsigned char>(array_size);
 
 	// Allocate indices array and populate it
@@ -745,7 +745,7 @@ TEST_F(backendTest, randAccessesBarrierPage) {
  */
 TEST_F(backendTest, randAccessesBulkySelectiveReleaseAcquirePage) {
 	// Allocate global page
-	constexpr std::size_t array_size = 4096 / sizeof(unsigned char);
+	constexpr std::size_t array_size = PAGE_SIZE / sizeof(unsigned char);
 	unsigned char*const array = argo::conew_array<unsigned char>(array_size);
 
 	// Allocate indices array and populate it
@@ -808,7 +808,7 @@ TEST_F(backendTest, randAccessesBulkySelectiveReleaseAcquirePage) {
  */
 TEST_F(backendTest, randAccessesPeriodicSelectiveReleaseAcquirePage) {
 	// Allocate global page
-	constexpr std::size_t array_size = 4096 / sizeof(unsigned char);
+	constexpr std::size_t array_size = PAGE_SIZE / sizeof(unsigned char);
 	unsigned char*const array = argo::conew_array<unsigned char>(array_size);
 
 	// Allocate indices array and populate it


### PR DESCRIPTION
Eliminate all uses of the magic 4096 constant
This constant is used for the size of a page, but was hard-coded in
various places using various forms (4096, 4096UL, ...).  Also, various
header files used different definitions / names for it (pagesize,
page_size, PAGESIZE).

This commit adds a `PAGE_SIZE` constexpr and uses it in all `src` files.

Addresses the biggest part of #49.  (Does not deal with CACHELINE.)