### PR TITLE
Add the full path directory for include files

### DIFF
--- a/src/allocators/allocators.h
+++ b/src/allocators/allocators.h
@@ -7,7 +7,7 @@
 #ifndef ARGODSM_SRC_ALLOCATORS_ALLOCATORS_H_
 #define ARGODSM_SRC_ALLOCATORS_ALLOCATORS_H_
 
-#include "collective_allocator.h"
-#include "dynamic_allocator.h"
+#include "allocators/collective_allocator.h"
+#include "allocators/dynamic_allocator.h"
 
 #endif // ARGODSM_SRC_ALLOCATORS_ALLOCATORS_H_

--- a/src/allocators/collective_allocator.hpp
+++ b/src/allocators/collective_allocator.hpp
@@ -26,9 +26,9 @@
 #include <stack>
 #include <utility>
 
-#include "../backend/backend.hpp"
-#include "../mempools/dynamic_mempool.hpp"
-#include "../mempools/global_mempool.hpp"
+#include "backend/backend.hpp"
+#include "mempools/dynamic_mempool.hpp"
+#include "mempools/global_mempool.hpp"
 
 #include "dynamic_allocator.hpp"
 #include "generic_allocator.hpp"
@@ -36,7 +36,7 @@
 
 /* forward declarations */
 extern "C" {
-#include "collective_allocator.h"
+#include "allocators/collective_allocator.h"
 }
 
 namespace argo {

--- a/src/allocators/dynamic_allocator.hpp
+++ b/src/allocators/dynamic_allocator.hpp
@@ -26,15 +26,15 @@
 #include <stack>
 #include <utility>
 
-#include "../mempools/dynamic_mempool.hpp"
-#include "../mempools/global_mempool.hpp"
+#include "mempools/dynamic_mempool.hpp"
+#include "mempools/global_mempool.hpp"
 
 #include "generic_allocator.hpp"
 #include "null_lock.hpp"
 
 /* forward declarations */
 extern "C" {
-#include "dynamic_allocator.h"
+#include "allocators/dynamic_allocator.h"
 }
 
 namespace argo {

--- a/src/allocators/generic_allocator.hpp
+++ b/src/allocators/generic_allocator.hpp
@@ -21,7 +21,8 @@
 
 #include <map>
 #include <stack>
-#include "../backend/backend.hpp"
+
+#include "backend/backend.hpp"
 
 namespace argo {
 

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -13,8 +13,8 @@
 #include <cstdint>
 #include <stdexcept>
 
-#include "../data_distribution/global_ptr.hpp"
-#include "../types/types.hpp"
+#include "data_distribution/global_ptr.hpp"
+#include "types/types.hpp"
 
 namespace argo {
 /**

--- a/src/backend/explicit_instantiations.inc.cpp
+++ b/src/backend/explicit_instantiations.inc.cpp
@@ -4,7 +4,7 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
-#include "../types/types.hpp"
+#include "types/types.hpp"
 
 /** @brief explicit instantiation for pointers to raw memory */
 template void broadcast(node_id_t, memory_t*);

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -7,8 +7,8 @@
 #include <shared_mutex>
 #include <vector>
 
-#include "../backend.hpp"
-#include "swdsm.h"
+#include "backend/backend.hpp"
+#include "backend/mpi/swdsm.h"
 #include "virtual_memory/virtual_memory.hpp"
 
 namespace argo {

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -12,8 +12,8 @@
 #include <atomic>
 #include <type_traits>
 
-#include "../backend.hpp"
-#include "swdsm.h"
+#include "backend/backend.hpp"
+#include "backend/mpi/swdsm.h"
 
 /**
  * @brief Returns an MPI integer type that exactly matches in size the argument given

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -9,10 +9,10 @@
 #include <memory>
 #include <vector>
 
+#include "backend/mpi/swdsm.h"
 #include "data_distribution/global_ptr.hpp"
 #include "env/env.hpp"
 #include "signal/signal.hpp"
-#include "swdsm.h"
 #include "virtual_memory/virtual_memory.hpp"
 
 namespace dd = argo::data_distribution;

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -17,7 +17,7 @@
 #include <mutex>
 #include <utility>
 
-#include "swdsm.h"
+#include "backend/mpi/swdsm.h"
 
 #include "backend/backend.hpp"
 #include "env/env.hpp"

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -11,7 +11,7 @@
 #include <cstring>
 #include <mutex>
 
-#include "../backend.hpp"
+#include "backend/backend.hpp"
 #include "data_distribution/global_ptr.hpp"
 #include "signal/signal.hpp"
 #include "synchronization/global_tas_lock.hpp"

--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -11,7 +11,8 @@
 #include <iostream>
 #include <string>
 
-#include "../types/types.hpp"
+#include "env/env.hpp"
+#include "types/types.hpp"
 
 namespace argo {
 namespace data_distribution {

--- a/src/data_distribution/data_distribution.hpp
+++ b/src/data_distribution/data_distribution.hpp
@@ -15,6 +15,8 @@
 #include "prime_mapp_distribution.hpp"
 #include "skew_mapp_distribution.hpp"
 
+#include "env/env.hpp"
+
 /**
  * @note backend.hpp is not included here as it includes global_ptr.hpp,
  *       which means that the data distribution definitions precede the

--- a/src/data_distribution/global_ptr.hpp
+++ b/src/data_distribution/global_ptr.hpp
@@ -9,8 +9,8 @@
 
 #include <string>
 
-#include "../env/env.hpp"
 #include "data_distribution.hpp"
+#include "env/env.hpp"
 
 namespace argo {
 namespace data_distribution {

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -7,8 +7,8 @@
 #ifndef ARGODSM_SRC_MEMPOOLS_DYNAMIC_MEMPOOL_HPP_
 #define ARGODSM_SRC_MEMPOOLS_DYNAMIC_MEMPOOL_HPP_
 
-#include "../backend/backend.hpp"
-#include "../synchronization/broadcast.hpp"
+#include "backend/backend.hpp"
+#include "synchronization/broadcast.hpp"
 
 namespace argo {
 namespace mempools {

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -14,9 +14,9 @@
 #include <iostream>
 #include <memory>
 
-#include "../backend/backend.hpp"
-#include "../data_distribution/global_ptr.hpp"
-#include "../synchronization/global_tas_lock.hpp"
+#include "backend/backend.hpp"
+#include "data_distribution/global_ptr.hpp"
+#include "synchronization/global_tas_lock.hpp"
 
 /** @todo Documentation */
 constexpr int PAGESIZE = 4096;

--- a/src/synchronization/broadcast.hpp
+++ b/src/synchronization/broadcast.hpp
@@ -7,8 +7,8 @@
 #ifndef ARGODSM_SRC_SYNCHRONIZATION_BROADCAST_HPP_
 #define ARGODSM_SRC_SYNCHRONIZATION_BROADCAST_HPP_
 
-#include "../backend/backend.hpp"
-#include "../types/types.hpp"
+#include "backend/backend.hpp"
+#include "types/types.hpp"
 
 namespace argo {
 namespace synchronization {

--- a/src/synchronization/cohort_lock.hpp
+++ b/src/synchronization/cohort_lock.hpp
@@ -16,15 +16,15 @@
 #endif
 
 extern "C" {
-#include "cohort_lock.h"
+#include "synchronization/cohort_lock.h"
 }
 
 // C++ headers
 #include <vector>
 
-#include "../allocators/collective_allocator.hpp"
-#include "../backend/backend.hpp"
-#include "../data_distribution/data_distribution.hpp"
+#include "allocators/collective_allocator.hpp"
+#include "backend/backend.hpp"
+#include "data_distribution/data_distribution.hpp"
 #include "global_tas_lock.hpp"
 #include "intranode/mcs_lock.hpp"
 #include "intranode/ticket_lock.hpp"

--- a/src/synchronization/global_tas_lock.hpp
+++ b/src/synchronization/global_tas_lock.hpp
@@ -9,8 +9,9 @@
 
 #include <atomic>
 #include <thread>
-#include "../backend/backend.hpp"
-#include "../data_distribution/global_ptr.hpp"
+
+#include "backend/backend.hpp"
+#include "data_distribution/global_ptr.hpp"
 
 namespace argo {
 namespace globallock {

--- a/src/synchronization/synchronization.cpp
+++ b/src/synchronization/synchronization.cpp
@@ -4,7 +4,7 @@
  * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
  */
 
-#include "../backend/backend.hpp"
+#include "backend/backend.hpp"
 #include "synchronization.hpp"
 
 namespace argo {

--- a/src/synchronization/synchronization.hpp
+++ b/src/synchronization/synchronization.hpp
@@ -43,7 +43,7 @@ namespace argo {
 } // namespace argo
 
 extern "C" {
-#include "./synchronization.h"
+#include "synchronization/synchronization.h"
 }
 
 #endif // ARGODSM_SRC_SYNCHRONIZATION_SYNCHRONIZATION_HPP_


### PR DESCRIPTION
There is no need to specify relative paths (`../`, etc.) or not include
the directory prefix (from `src`).  This PR modifies all includes that
violated this property.  In addition a missing include was added.