### PR TITLE
Eliminate `using namespace` commands

### DIFF
--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -7,4 +7,4 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - run: pip install cpplint
-    - run: cpplint --quiet --root=../ --filter=-build/c++11,-build/include,-build/namespaces,-runtime/array,-runtime/string,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/tab --recursive src tests
+    - run: cpplint --quiet --root=../ --filter=-build/c++11,-build/include,-runtime/array,-runtime/string,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/tab --recursive src tests

--- a/src/allocators/allocators.cpp
+++ b/src/allocators/allocators.cpp
@@ -6,7 +6,6 @@
 
 #include "allocators.hpp"
 
-namespace mem = argo::mempools;
 namespace alloc = argo::allocators;
 
 /* default allocators */
@@ -16,32 +15,28 @@ alloc::collective_allocator alloc::default_collective_allocator;
 
 extern "C"
 void* collective_alloc(size_t size) {
-	using namespace argo::allocators;
 	/** @bug this is wrong: either it should not be done at all, or also when using the C++ interface */
 	argo::backend::barrier();
-	return static_cast<void*>(default_collective_allocator.allocate(size));
+	return static_cast<void*>(alloc::default_collective_allocator.allocate(size));
 }
 
 extern "C"
 void collective_free(void* ptr) {
-	using namespace argo::allocators;
-	using atype = decltype(default_collective_allocator)::value_type;
+	using atype = decltype(alloc::default_collective_allocator)::value_type;
 	if (ptr == NULL)
 		return;
-	default_collective_allocator.free(static_cast<atype*>(ptr));
+	alloc::default_collective_allocator.free(static_cast<atype*>(ptr));
 }
 
 extern "C"
 void* dynamic_alloc(size_t size) {
-	using namespace argo::allocators;
-	return static_cast<void*>(default_dynamic_allocator.allocate(size));
+	return static_cast<void*>(alloc::default_dynamic_allocator.allocate(size));
 }
 
 extern "C"
 void dynamic_free(void* ptr) {
-	using namespace argo::allocators;
-	using atype = decltype(default_dynamic_allocator)::value_type;
+	using atype = decltype(alloc::default_dynamic_allocator)::value_type;
 	if (ptr == NULL)
 		return;
-	default_dynamic_allocator.free(static_cast<atype*>(ptr));
+	alloc::default_dynamic_allocator.free(static_cast<atype*>(ptr));
 }

--- a/src/allocators/collective_allocator.hpp
+++ b/src/allocators/collective_allocator.hpp
@@ -107,7 +107,7 @@ T* conew_(Ps&&... ps) {
 	}
 
 	void* ptr = collective_alloc(sizeof(T));
-	using namespace data_distribution;
+	using data_distribution::global_ptr;
 	global_ptr<void> gptr(ptr, false, false);
 	// The home node of ptr handles initialization
 	if (initialize && argo::backend::node_id() == gptr.node()) {
@@ -165,7 +165,7 @@ void codelete_(T* ptr) {
 		synchronize = false;
 	}
 
-	using namespace data_distribution;
+	using data_distribution::global_ptr;
 	global_ptr<T> gptr(ptr, false, false);
 	// The home node of ptr handles deinitialization
 	if (deinitialize && argo::backend::node_id() == gptr.node()) {
@@ -218,7 +218,7 @@ T* conew_array(size_t size) {
 	}
 
 	void* ptr = collective_alloc(sizeof(T) * size);
-	using namespace data_distribution;
+	using data_distribution::global_ptr;
 	global_ptr<void> gptr(ptr, false, false);
 	// The home node of ptr handles initialization
 	if (initialize && argo::backend::node_id() == gptr.node()) {
@@ -269,7 +269,7 @@ void codelete_array(T* ptr) {
 		synchronize = false;
 	}
 
-	using namespace data_distribution;
+	using data_distribution::global_ptr;
 	global_ptr<T> gptr(ptr, false, false);
 	// The home node of ptr handles deinitialization
 	if (deinitialize && argo::backend::node_id() == gptr.node()) {

--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -88,13 +88,14 @@ namespace argo {
 	 */
 	static void reset_allocators() {
 		default_global_mempool->reset();
-		using namespace alloc;
-		using namespace mem;
-		collective_prepool = dynamic_memory_pool<global_allocator, NODE_ZERO_ONLY>(&default_global_allocator);
-		dynamic_prepool = dynamic_memory_pool<global_allocator, ALWAYS>(&default_global_allocator);
-		default_global_allocator = global_allocator<char>();
-		default_dynamic_allocator = default_dynamic_allocator_t();
-		default_collective_allocator = collective_allocator();
+		using alloc::default_dynamic_allocator;
+		using alloc::default_collective_allocator;
+		using alloc::default_global_allocator;
+		collective_prepool = mem::dynamic_memory_pool<alloc::global_allocator, mem::NODE_ZERO_ONLY>(&default_global_allocator);
+		dynamic_prepool = mem::dynamic_memory_pool<alloc::global_allocator, mem::ALWAYS>(&default_global_allocator);
+		default_global_allocator = alloc::global_allocator<char>();
+		default_dynamic_allocator = alloc::default_dynamic_allocator_t();
+		default_collective_allocator = alloc::collective_allocator();
 		default_global_allocator.set_mempool(default_global_mempool);
 		default_dynamic_allocator.set_mempool(&dynamic_prepool);
 		default_collective_allocator.set_mempool(&collective_prepool);

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -25,7 +25,6 @@
  */
 static MPI_Datatype fitting_mpi_int(std::size_t size) {
 	MPI_Datatype t_type;
-	using namespace argo;
 
 	switch (size) {
 	// Until UCX supports 1/2 byte atomics, they must be disabled
@@ -60,7 +59,6 @@ static MPI_Datatype fitting_mpi_int(std::size_t size) {
  */
 static MPI_Datatype fitting_mpi_uint(std::size_t size) {
 	MPI_Datatype t_type;
-	using namespace argo;
 
 	switch (size) {
 	// Until UCX supports 1/2 byte atomics, they must be disabled
@@ -93,7 +91,6 @@ static MPI_Datatype fitting_mpi_uint(std::size_t size) {
  */
 static MPI_Datatype fitting_mpi_float(std::size_t size) {
 	MPI_Datatype t_type;
-	using namespace argo;
 
 	switch (size) {
 	case 4:

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -21,7 +21,6 @@
 
 namespace vm = argo::virtual_memory;
 namespace sig = argo::signal;
-using namespace argo::backend;
 
 /** @brief a lock for atomically executed operations */
 std::mutex atomic_op_mutex;
@@ -85,12 +84,12 @@ void init(std::size_t argo_size, std::size_t cache_size) {
 	(void)(cache_size);
 	memory = static_cast<char*>(vm::allocate_mappable(PAGE_SIZE, argo_size));
 	memory_size = argo_size;
-	using namespace data_distribution;
+	using argo::data_distribution::base_distribution;
 	base_distribution<0>::set_memory_space(nodes, memory, argo_size);
 	sig::signal_handler<SIGSEGV>::install_argo_handler(&singlenode_handler);
 	/** @note first-touch needs a directory for fetching
 	 *        the homenode and offset for an address */
-	if (is_first_touch_policy()) {
+	if (argo::data_distribution::is_first_touch_policy()) {
 		/* calculate the directory size and allocate memory */
 		std::size_t owners_dir_size = 3*(argo_size/PAGE_SIZE);
 		std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);
@@ -132,10 +131,9 @@ void reset_stats() {}
 void finalize() {}
 
 void reset_coherence() {
-	using namespace data_distribution;
 	/** @note first-touch needs a directory for fetching
 	 *        the homenode and offset for an address */
-	if (is_first_touch_policy()) {
+	if (argo::data_distribution::is_first_touch_policy()) {
 		/* calculate the directory size and allocate memory */
 		std::size_t owners_dir_size = 3*(memory_size/PAGE_SIZE);
 		std::size_t owners_dir_size_bytes = owners_dir_size*sizeof(std::size_t);

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -54,7 +54,7 @@ class global_memory_pool {
 			memory = backend::global_base();
 			max_size = backend::global_size();
 			/**@todo this initialization should move to tools::init() land */
-			using namespace data_distribution;
+			using argo::data_distribution::base_distribution;
 			base_distribution<0>::set_memory_space(nodes, memory, max_size);
 
 			// Reset maximum size to the full memory size minus the space reserved for internal use
@@ -68,6 +68,7 @@ class global_memory_pool {
 			global_tas_lock = new tas_lock(field);
 
 			// Home node makes sure that offset points to Argo's starting address
+			using argo::data_distribution::global_ptr;
 			global_ptr<char> gptr(&memory[max_size]);
 			if(backend::node_id() == gptr.node()) {
 				*offset = static_cast<std::ptrdiff_t>(0);
@@ -93,7 +94,7 @@ class global_memory_pool {
 			max_size = backend::global_size() - reserved;
 
 			// Home node makes sure that offset points to Argo's starting address
-			using namespace data_distribution;
+			using argo::data_distribution::global_ptr;
 			global_ptr<char> gptr(&memory[max_size]);
 			if(backend::node_id() == gptr.node()) {
 				*offset = static_cast<std::ptrdiff_t>(0);

--- a/tests/allocators.cpp
+++ b/tests/allocators.cpp
@@ -369,24 +369,25 @@ TEST_F(AllocatorTest, PerfectForwardingCollectiveNew) {
  * @brief Test the "parser" for the allocation parameters
  */
 TEST_F(AllocatorTest, AllocationParametersParsing) {
-	using namespace argo;
-	using namespace argo::_internal;
+	using alloc = argo::allocation;
 
-	ASSERT_TRUE((alloc_param_in<allocation::initialize,
-		allocation::initialize>::value));
-	ASSERT_TRUE((alloc_param_in<allocation::no_initialize,
-		allocation::no_initialize>::value));
-	ASSERT_TRUE((alloc_param_in<allocation::deinitialize,
-		allocation::deinitialize>::value));
-	ASSERT_TRUE((alloc_param_in<allocation::no_deinitialize,
-		allocation::no_deinitialize>::value));
-	ASSERT_TRUE((alloc_param_in<allocation::synchronize,
-		allocation::synchronize>::value));
-	ASSERT_TRUE((alloc_param_in<allocation::no_synchronize,
-		allocation::no_synchronize>::value));
+	using argo::_internal::alloc_param_in;
+	ASSERT_TRUE((alloc_param_in<alloc::initialize,
+		alloc::initialize>::value));
+	ASSERT_TRUE((alloc_param_in<alloc::no_initialize,
+		alloc::no_initialize>::value));
+	ASSERT_TRUE((alloc_param_in<alloc::deinitialize,
+		alloc::deinitialize>::value));
+	ASSERT_TRUE((alloc_param_in<alloc::no_deinitialize,
+		alloc::no_deinitialize>::value));
+	ASSERT_TRUE((alloc_param_in<alloc::synchronize,
+		alloc::synchronize>::value));
+	ASSERT_TRUE((alloc_param_in<alloc::no_synchronize,
+		alloc::no_synchronize>::value));
 
-	using all_yes = alloc_params<allocation::initialize,
-		allocation::deinitialize, allocation::synchronize>;
+	using argo::_internal::alloc_params;
+	using all_yes = alloc_params<alloc::initialize,
+		alloc::deinitialize, alloc::synchronize>;
 	ASSERT_TRUE(all_yes::initialize);
 	ASSERT_TRUE(all_yes::deinitialize);
 	ASSERT_TRUE(all_yes::synchronize);
@@ -394,8 +395,8 @@ TEST_F(AllocatorTest, AllocationParametersParsing) {
 	ASSERT_FALSE(all_yes::no_deinitialize);
 	ASSERT_FALSE(all_yes::no_synchronize);
 
-	using all_no = alloc_params<allocation::no_initialize,
-		allocation::no_deinitialize, allocation::no_synchronize>;
+	using all_no = alloc_params<alloc::no_initialize,
+		alloc::no_deinitialize, alloc::no_synchronize>;
 	ASSERT_FALSE(all_no::initialize);
 	ASSERT_FALSE(all_no::deinitialize);
 	ASSERT_FALSE(all_no::synchronize);
@@ -403,7 +404,7 @@ TEST_F(AllocatorTest, AllocationParametersParsing) {
 	ASSERT_TRUE(all_no::no_deinitialize);
 	ASSERT_TRUE(all_no::no_synchronize);
 
-	using just_one = alloc_params<allocation::synchronize>;
+	using just_one = alloc_params<alloc::synchronize>;
 	ASSERT_FALSE(just_one::initialize);
 	ASSERT_FALSE(just_one::deinitialize);
 	ASSERT_TRUE(just_one::synchronize);

--- a/tests/stlallocation.cpp
+++ b/tests/stlallocation.cpp
@@ -36,18 +36,15 @@ class cppTest : public testing::Test {
  * @brief Unittest that checks that an STL list can be allocated globally and populated
  */
 TEST_F(cppTest, simpleList) {
-	using namespace std;
-	using namespace argo;
-	using namespace argo::allocators;
-	using my_list = std::list<int, dynamic_allocator<int>>;
+	using my_list = std::list<int, argo::allocators::dynamic_allocator<int>>;
 
-	my_list* l = conew_<my_list>();
+	my_list* l = argo::conew_<my_list>();
 
 	for(unsigned int i = 0; i < argo_number_of_nodes(); i++) {
 		if(argo_node_id() == i) {
 			ASSERT_NO_THROW(l->push_back(i));
 		}
-		barrier();
+		argo::barrier();
 	}
 
 	int id = 0;
@@ -61,18 +58,15 @@ TEST_F(cppTest, simpleList) {
  * @brief Unittest that checks that an STL vector can be allocated globally and populated
  */
 TEST_F(cppTest, simpleVector) {
-	using namespace std;
-	using namespace argo;
-	using namespace argo::allocators;
-	using my_vector = std::vector<int, dynamic_allocator<int>>;
+	using my_vector = std::vector<int, argo::allocators::dynamic_allocator<int>>;
 
-	my_vector* v = conew_<my_vector>();
+	my_vector* v = argo::conew_<my_vector>();
 
 	for(unsigned int i = 0; i < argo_number_of_nodes(); i++) {
 		if(argo_node_id() == i) {
 			ASSERT_NO_THROW(v->push_back(i));
 		}
-		barrier();
+		argo::barrier();
 	}
 
 	int id = 0;


### PR DESCRIPTION
There is no need to import the complete namespace via a `using namespace` statement when more specific `using` declarations or only a few mentions of the namespace in calls are sufficient.

These changes eliminate all `cpplint` warnings of the `build/namespace` category