### PR TITLE
Install ArgoDSM headers directly under include

### DIFF
--- a/docs/_includes/argo_example.cpp
+++ b/docs/_includes/argo_example.cpp
@@ -5,7 +5,7 @@
 
 #include <pthread.h>
 
-#include "argo/argo.hpp"
+#include "argo.hpp"
 
 struct thread_args {
 	int data_begin;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ install(TARGETS argo
 	ARCHIVE DESTINATION lib)
 
 install(DIRECTORY .
-	DESTINATION include/argo
+	DESTINATION include
 	COMPONENT "Development"
 	FILES_MATCHING
 		PATTERN "*.h"


### PR DESCRIPTION
The ArgoDSM headers are currently installed to
`ARGO_INSTALL_DIRECTORY/include/argo`, which is both
confusing as this breaks absolute include paths internally and
requires external include paths to specify the argo prefix.
Installing the ArgoDSM headers to `ARGO_INSTALL_DIRECTORY/include`
directly while maintaining the directory structure resolves this.