### PR TITLE
Make sure the C interface only uses C stuff

### DIFF
--- a/src/argo.cpp
+++ b/src/argo.cpp
@@ -132,11 +132,11 @@ extern "C" {
 		argo::reset();
 	}
 
-	int argo_node_id() {
+	unsigned int argo_node_id() {
 		return argo::node_id();
 	}
 
-	int argo_number_of_nodes() {
+	unsigned int argo_number_of_nodes() {
 		return argo::number_of_nodes();
 	}
 
@@ -144,7 +144,7 @@ extern "C" {
 		return argo::is_argo_address(addr);
 	}
 
-	argo::node_id_t argo_get_homenode(void* addr) {
+	unsigned int argo_get_homenode(void* addr) {
 		return argo::get_homenode(addr);
 	}
 

--- a/src/argo.h
+++ b/src/argo.h
@@ -41,13 +41,13 @@ void argo_reset();
  * @brief A unique ArgoDSM node identifier. Counting starts from 0.
  * @return The node id
  */
-int  argo_node_id();
+unsigned int argo_node_id();
 
 /**
  * @brief Number of ArgoDSM nodes being run
  * @return The total number of ArgoDSM nodes
  */
-int  argo_number_of_nodes();
+unsigned int argo_number_of_nodes();
 
 /**
  * @brief Check if addr belongs in the ArgoDSM memory space
@@ -64,7 +64,7 @@ bool argo_is_argo_address(void* addr);
  * been first-touched under the first-touch allocation policy
  * @pre addr must be an address in ArgoDSM memory
  */
-argo::node_id_t argo_get_homenode(void* addr);
+unsigned int argo_get_homenode(void* addr);
 
 /**
  * @brief Get the block size of the current allocation policy

--- a/tests/stlallocation.cpp
+++ b/tests/stlallocation.cpp
@@ -43,7 +43,7 @@ TEST_F(cppTest, simpleList) {
 
 	my_list* l = conew_<my_list>();
 
-	for(int i = 0; i < argo_number_of_nodes(); i++) {
+	for(unsigned int i = 0; i < argo_number_of_nodes(); i++) {
 		if(argo_node_id() == i) {
 			ASSERT_NO_THROW(l->push_back(i));
 		}
@@ -68,7 +68,7 @@ TEST_F(cppTest, simpleVector) {
 
 	my_vector* v = conew_<my_vector>();
 
-	for(int i = 0; i < argo_number_of_nodes(); i++) {
+	for(unsigned int i = 0; i < argo_number_of_nodes(); i++) {
 		if(argo_node_id() == i) {
 			ASSERT_NO_THROW(v->push_back(i));
 		}


### PR DESCRIPTION
The C header file came with some C++ stuff (`argo::node_id_t`) and also used `int` instead of `unsigned int` as the return type of some functions returning node_id's. This PR makes all these `unsigned ints` instead.