### PR TITLE
Remove unnecessary .hpp includes from argo.hpp

### DIFF
--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -10,10 +10,7 @@
 #include <cstddef>
 
 #include "allocators/allocators.hpp"
-#include "backend/backend.hpp"
-#include "data_distribution/data_distribution.hpp"
 #include "synchronization/synchronization.hpp"
-#include "types/types.hpp"
 
 extern "C" {
 #include "argo.h"


### PR DESCRIPTION
In contrast to argo.h, the argo.hpp file contained many .hpp include files. Both compilation and running ArgoDSM seem to work OK when these includes are not present, so this PR simply removes them.