### PR TITLE
Fix missing definition of PAGE_SIZE in external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@
 cmake_minimum_required(VERSION 3.3)
 project(ArgoDSM VERSION 0.1)
 
-# define PAGE_SIZE: the commented out code returns an int; we want a size_t
-#execute_process(COMMAND getconf PAGESIZE OUTPUT_VARIABLE SYSTEM_PAGE_SIZE)
-add_definitions(-DPAGE_SIZE=4096UL) #${SYSTEM_PAGE_SIZE})
 
 set(DEFAULT_C_FLAGS "-std=c17 -pthread -Wall -Wextra -Werror")
 set(DEFAULT_CXX_FLAGS "-std=c++17 -pthread -DOMPI_SKIP_MPICXX=1 -Wall -Wextra -Werror")
@@ -87,6 +84,30 @@ else()
 	include_directories(${SUBMODULES_DIR}/qd)
 endif()
 
+# Add a restricted option to set the ArgoDSM page size
+set(VALID_PAGE_SIZES 4096UL)
+set(ARGO_PAGE_SIZE 4096UL CACHE STRING "Set the ArgoDSM page size")
+set_property(CACHE ARGO_PAGE_SIZE PROPERTY STRINGS ${VALID_PAGE_SIZES})
+list(FIND VALID_PAGE_SIZES ${ARGO_PAGE_SIZE} index)
+if(index EQUAL -1)
+	message(FATAL_ERROR "Invalid ARGO_PAGE_SIZE. Valid options: ${VALID_PAGE_SIZES}")
+endif()
+
+# Add a restricted option to set the number of ArgoDSM pages per cache line
+set(VALID_CACHE_LINE_SIZES 1L)
+set(ARGO_CACHE_LINE_SIZE 1L CACHE STRING "Set the number of ArgoDSM pages per cache line")
+set_property(CACHE ARGO_CACHE_LINE_SIZE PROPERTY STRINGS ${VALID_CACHE_LINE_SIZES})
+list(FIND VALID_CACHE_LINE_SIZES ${ARGO_CACHE_LINE_SIZE} index)
+if(index EQUAL -1)
+	message(FATAL_ERROR "Invalid ARGO_CACHE_LINE_SIZE. Valid options: ${VALID_CACHE_LINE_SIZES}")
+endif()
+
+# Generate config.hpp containing the above set options and install it
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/config.hpp.in ${CMAKE_BINARY_DIR}/config/config.hpp @ONLY)
+include_directories(${CMAKE_BINARY_DIR}/config)
+install(FILES ${CMAKE_BINARY_DIR}/config/config.hpp
+	DESTINATION include/argo)
+
 include_directories("${PROJECT_SOURCE_DIR}/src")
 add_subdirectory(src)
 
@@ -138,4 +159,3 @@ if(BUILD_DOCUMENTATION)
 
 	install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION share/doc)
 endif()
-

--- a/config/config.hpp.in
+++ b/config/config.hpp.in
@@ -1,0 +1,14 @@
+/**
+ * @file
+ * @brief This file provides automatic generation of config.hpp based on CMake options
+ * @note Do not change the values in this file
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef ARGODSM_CONFIG_CONFIG_HPP_
+#define ARGODSM_CONFIG_CONFIG_HPP_
+
+#define PAGE_SIZE @ARGO_PAGE_SIZE@
+#define CACHELINE @ARGO_CACHE_LINE_SIZE@
+
+#endif /* ARGODSM_CONFIG_CONFIG_HPP */

--- a/src/backend/mpi/coherence.cpp
+++ b/src/backend/mpi/coherence.cpp
@@ -9,6 +9,7 @@
 
 #include "backend/backend.hpp"
 #include "backend/mpi/swdsm.h"
+#include "config.hpp"
 #include "virtual_memory/virtual_memory.hpp"
 
 namespace argo {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "backend/mpi/swdsm.h"
+#include "config.hpp"
 #include "data_distribution/global_ptr.hpp"
 #include "env/env.hpp"
 #include "signal/signal.hpp"

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -42,11 +42,6 @@
 #include "backend/backend.hpp"
 #include "mpi_lock.hpp"
 
-#ifndef CACHELINE
-/** @brief Size of a ArgoDSM cacheline in number of pages */
-#define CACHELINE 1L
-#endif
-
 #ifndef NUM_THREADS
 /** @brief Number of maximum local threads in each node */
 /**@bug this limits amount of local threads because of pthread barriers being initialized at startup*/

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -20,6 +20,7 @@
 #include "backend/mpi/swdsm.h"
 
 #include "backend/backend.hpp"
+#include "config.hpp"
 #include "env/env.hpp"
 #include "qd.hpp"
 #include "virtual_memory/virtual_memory.hpp"

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -12,6 +12,7 @@
 #include <mutex>
 
 #include "backend/backend.hpp"
+#include "config.hpp"
 #include "data_distribution/global_ptr.hpp"
 #include "signal/signal.hpp"
 #include "synchronization/global_tas_lock.hpp"

--- a/src/mempools/dynamic_mempool.hpp
+++ b/src/mempools/dynamic_mempool.hpp
@@ -8,6 +8,7 @@
 #define ARGODSM_SRC_MEMPOOLS_DYNAMIC_MEMPOOL_HPP_
 
 #include "backend/backend.hpp"
+#include "config.hpp"
 #include "synchronization/broadcast.hpp"
 
 namespace argo {

--- a/src/mempools/global_mempool.hpp
+++ b/src/mempools/global_mempool.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include "backend/backend.hpp"
+#include "config.hpp"
 #include "data_distribution/global_ptr.hpp"
 #include "synchronization/global_tas_lock.hpp"
 

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -19,6 +19,7 @@
 #include <system_error>
 
 #include "backend/backend.hpp"
+#include "config.hpp"
 #include "virtual_memory.hpp"
 
 namespace {


### PR DESCRIPTION
This PR aims to fix #135 by introducing an automatically generated header `config.hpp` that contains the definitions of PAGE_SIZE and CACHELINE based on values set in CMake configuration. Each time CMake configure is run this file is generated anew with up-to-date values.

Two new CMake configuration options are added:
`ARGO_PAGE_SIZE` which **defaults to**, and currently only accepts, `4096UL`.
`ARGO_CACHE_LINE_SIZE` which **defaults to**, and currently only accepts, `1L`.

The values of these options correspond to `PAGE_SIZE` and `CACHELINE` in the code base, and attempting to set any values besides the expected ones fails. I suggest adding these as options for the sole reason that I believe alternative values may be interesting to work with in the future.

`config.hpp` can be included through `#include "config.hpp"` from any file that needs to access to either `PAGE_SIZE` or `CACHELINE`.