### PR TITLE
Add a cpplint GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       ARGO_VM:  ${{ matrix.vm  }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install packages
         run: |
           sudo apt-get update

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -4,7 +4,7 @@ jobs:
   cpplint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
     - run: pip install cpplint
     - run: cpplint --quiet --root=../ --filter=-build/c++11,-build/include,-build/namespaces,-runtime/array,-runtime/string,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/tab --recursive src tests

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -1,0 +1,10 @@
+name: cpplint
+on: [push, pull_request]
+jobs:
+  cpplint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - run: pip install cpplint
+    - run: cpplint --quiet --root=../ --filter=-build/c++11,-build/include,-build/namespaces,+runtime/array,-runtime/string,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/tab --recursive src tests

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -7,4 +7,4 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
     - run: pip install cpplint
-    - run: cpplint --quiet --root=../ --filter=-build/c++11,-build/include,-build/namespaces,+runtime/array,-runtime/string,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/tab --recursive src tests
+    - run: cpplint --quiet --root=../ --filter=-build/c++11,-build/include,-build/namespaces,-runtime/array,-runtime/string,-whitespace/braces,-whitespace/indent,-whitespace/line_length,-whitespace/tab --recursive src tests


### PR DESCRIPTION
Add a test for code style checking, using cpplint. Checks which are not (yet) satisfied by the ArgoDSM code base are explicitly disabled.  Perhaps some of them are a good idea to enable.