### PR TITLE
Remove unneeded `exit` calls after `throw` lines

### DIFF
--- a/src/data_distribution/cyclic_distribution.hpp
+++ b/src/data_distribution/cyclic_distribution.hpp
@@ -28,7 +28,6 @@ class cyclic_distribution : public base_distribution<instance> {
 			if(homenode >= base_distribution<instance>::nodes) {
 				std::cerr << msg_fetch_homenode_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-				exit(EXIT_FAILURE);
 			}
 			return homenode;
 		}
@@ -47,7 +46,6 @@ class cyclic_distribution : public base_distribution<instance> {
 			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
 				std::cerr << msg_fetch_offset_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-				exit(EXIT_FAILURE);
 			}
 			return offset;
 		}

--- a/src/data_distribution/first_touch_distribution.hpp
+++ b/src/data_distribution/first_touch_distribution.hpp
@@ -130,7 +130,6 @@ class first_touch_distribution : public base_distribution<instance> {
 			if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
 				std::cerr << msg_fetch_homenode_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-				exit(EXIT_FAILURE);
 			}
 			return homenode;
 		}
@@ -156,7 +155,6 @@ class first_touch_distribution : public base_distribution<instance> {
 			if(homenode >= static_cast<node_id_t>(base_distribution<instance>::nodes)) {
 				std::cerr << msg_fetch_homenode_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-				exit(EXIT_FAILURE);
 			}
 			return homenode;
 		}
@@ -188,7 +186,6 @@ class first_touch_distribution : public base_distribution<instance> {
 				offset >= base_distribution<instance>::size_per_node) {
 				std::cerr << msg_fetch_offset_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-				exit(EXIT_FAILURE);
 			}
 			return offset;
 		}
@@ -216,7 +213,6 @@ class first_touch_distribution : public base_distribution<instance> {
 			if(offset >= base_distribution<instance>::size_per_node) {
 				std::cerr << msg_fetch_offset_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-				exit(EXIT_FAILURE);
 			}
 			return offset;
 		}
@@ -300,7 +296,6 @@ void first_touch_distribution<instance>::first_touch(const std::size_t& addr) {
 		if (!succeeded) {
 			std::cerr << msg_first_touch_fail << std::endl;
 			throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_first_touch_fail);
-			exit(EXIT_FAILURE);
 		}
 
 		/* store page info in the local window */

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -28,7 +28,6 @@ class naive_distribution : public base_distribution<instance> {
 			if(homenode >= base_distribution<instance>::nodes) {
 				std::cerr << msg_fetch_homenode_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-				exit(EXIT_FAILURE);
 			}
 			return homenode;
 		}
@@ -44,7 +43,6 @@ class naive_distribution : public base_distribution<instance> {
 			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
 				std::cerr << msg_fetch_offset_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-				exit(EXIT_FAILURE);
 			}
 			return offset;
 		}

--- a/src/data_distribution/prime_mapp_distribution.hpp
+++ b/src/data_distribution/prime_mapp_distribution.hpp
@@ -31,7 +31,6 @@ class prime_mapp_distribution : public base_distribution<instance> {
 			if(homenode >= base_distribution<instance>::nodes) {
 				std::cerr << msg_fetch_homenode_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-				exit(EXIT_FAILURE);
 			}
 			return homenode;
 		}
@@ -68,7 +67,6 @@ class prime_mapp_distribution : public base_distribution<instance> {
 			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
 				std::cerr << msg_fetch_offset_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-				exit(EXIT_FAILURE);
 			}
 			return offset;
 		}

--- a/src/data_distribution/skew_mapp_distribution.hpp
+++ b/src/data_distribution/skew_mapp_distribution.hpp
@@ -29,7 +29,6 @@ class skew_mapp_distribution : public base_distribution<instance> {
 			if(homenode >= base_distribution<instance>::nodes) {
 				std::cerr << msg_fetch_homenode_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_homenode_fail);
-				exit(EXIT_FAILURE);
 			}
 			return homenode;
 		}
@@ -48,7 +47,6 @@ class skew_mapp_distribution : public base_distribution<instance> {
 			if(offset >= static_cast<std::size_t>(base_distribution<instance>::size_per_node)) {
 				std::cerr << msg_fetch_offset_fail << std::endl;
 				throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_fetch_offset_fail);
-				exit(EXIT_FAILURE);
 			}
 			return offset;
 		}

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -58,7 +58,6 @@ void init() {
 	if(backing_addr == MAP_FAILED) {
 		std::cerr << msg_main_mmap_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 	char* virtual_addr = ARGO_START + ARGO_SIZE/2l;
 	backing_offset = 0;
@@ -103,13 +102,11 @@ void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
 	if(err) {
 		std::cerr << msg_invalid_remap << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_invalid_remap);
-		exit(EXIT_FAILURE);
 	}
 	err = mprotect(addr, size, prot);
 	if(err) {
 		std::cerr << msg_mprotect_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mprotect_fail);
-		exit(EXIT_FAILURE);
 	}
 }
 

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -51,7 +51,6 @@ void init() {
 		std::cerr << msg_main_mmap_fail << std::endl;
 		/** @todo do something? */
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 	/** @todo check desired range is free */
 	constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
@@ -60,7 +59,6 @@ void init() {
 		std::cerr << msg_main_mmap_fail << std::endl;
 		/** @todo do something? */
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 }
 
@@ -88,7 +86,6 @@ void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
 	if(p == MAP_FAILED) {
 		std::cerr << msg_mmap_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 }
 

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -64,12 +64,10 @@ void init() {
 	if(shm_unlink(filename.c_str())) {
 		std::cerr << msg_main_mmap_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 	if(ftruncate(fd, avail)) {
 		std::cerr << msg_main_mmap_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 	/** @todo check desired range is free */
 	constexpr int flags = MAP_ANONYMOUS|MAP_SHARED|MAP_FIXED;
@@ -77,7 +75,6 @@ void init() {
 	if(start_addr == MAP_FAILED) {
 		std::cerr << msg_main_mmap_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_main_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 }
 
@@ -105,7 +102,6 @@ void map_memory(void* addr, std::size_t size, std::size_t offset, int prot) {
 	if(p == MAP_FAILED) {
 		std::cerr << msg_mmap_fail << std::endl;
 		throw std::system_error(std::make_error_code(static_cast<std::errc>(errno)), msg_mmap_fail);
-		exit(EXIT_FAILURE);
 	}
 }
 


### PR DESCRIPTION
It is not a good idea to have dead (and potentially confusing) code in the code base; esp. if this is in code which is not tested in any way in ArgoDSM's testsuite.  This PR removes it.

Closes #97.