### PR TITLE
Move VM reservation to fix MEMFD error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         dbg: [OFF, ON]
-        vm: [ANONYMOUS, SHM]
+        vm: [ANONYMOUS, SHM, MEMFD]
     name: On ${{ matrix.os }} (DBG=${{ matrix.dbg }}, VM=${{ matrix.vm }})
     runs-on: ${{ matrix.os }}
     env:
@@ -29,6 +29,8 @@ jobs:
       - name: Build external
         run: ./.github/scripts/make_external.sh
       - name: Run test suite
-        run: make test -C build
+        run: |
+          sudo sysctl -w vm.overcommit_memory=1
+          make test -C build
       - name: Run external
         run: ./.github/scripts/run_external.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         dbg: [OFF, ON]
-        vm: [ANONYMOUS, SHM, MEMFD]
+        vm: [ANONYMOUS, MEMFD, SHM]
     name: On ${{ matrix.os }} (DBG=${{ matrix.dbg }}, VM=${{ matrix.vm }})
     runs-on: ${{ matrix.os }}
     env:

--- a/src/virtual_memory/anonymous.cpp
+++ b/src/virtual_memory/anonymous.cpp
@@ -24,9 +24,22 @@
 
 namespace {
 /* file constants */
-/** @todo hardcoded start address */
-char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
-/** @todo hardcoded size */
+/**
+ * @brief The start of the ArgoDSM virtual memory space
+ * @note This hard-coded value assumes x86_64 architecture
+ *
+ * The ArgoDSM virtual memory space leaves the first 1/6 for local use.
+ */
+char* const ARGO_START = reinterpret_cast<char*>(0x155555554000l);
+/**
+ * @brief The size of the ArgoDSM virtual memory space
+ * @note This hard-coded value assumes x86_64 architecture
+ *
+ * ArgoDSM reserves a part of the available user-space virtual memory.
+ * In combination with @ref{ARGO_START}, this ensures that the final third
+ * of the virtual memory is left for PIE loads, heap, shared libraries and
+ * the stack among other things.
+ */
 const ptrdiff_t ARGO_SIZE = 0x80000000000l;
 
 /** @brief error message string */

--- a/src/virtual_memory/memfd.cpp
+++ b/src/virtual_memory/memfd.cpp
@@ -21,12 +21,23 @@
 
 namespace {
 /* file constants */
-/** @todo hardcoded start address */
-char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
-/** @todo hardcoded end address */
-char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
-/** @todo hardcoded size */
-const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
+/**
+ * @brief The start of the ArgoDSM virtual memory space
+ * @note This hard-coded value assumes x86_64 architecture
+ *
+ * The ArgoDSM virtual memory space leaves the first 1/6 for local use.
+ */
+char* const ARGO_START = reinterpret_cast<char*>(0x155555554000l);
+/**
+ * @brief The size of the ArgoDSM virtual memory space
+ * @note This hard-coded value assumes x86_64 architecture
+ *
+ * ArgoDSM reserves half of the available user-space virtual memory.
+ * In combination with @ref{ARGO_START}, this ensures that the final third
+ * of the virtual memory is left for PIE loads, heap, shared libraries and
+ * the stack among other things.
+ */
+const ptrdiff_t ARGO_SIZE = 0x400000000000l;
 
 /** @brief error message string */
 const std::string msg_alloc_fail = "ArgoDSM could not allocate mappable memory";

--- a/src/virtual_memory/shm.cpp
+++ b/src/virtual_memory/shm.cpp
@@ -23,13 +23,22 @@
 
 namespace {
 /* file constants */
-/** @todo hardcoded start address */
-char* const ARGO_START = reinterpret_cast<char*>(0x200000000000l);
-/** @todo hardcoded end address */
-char* const ARGO_END   = reinterpret_cast<char*>(0x600000000000l);
-/** @todo hardcoded size */
-const ptrdiff_t ARGO_SIZE = ARGO_END - ARGO_START;
-/** @todo hardcoded maximum size */
+/**
+ * @brief The start of the ArgoDSM virtual memory space
+ * @note This hard-coded value assumes x86_64 architecture
+ *
+ * The ArgoDSM virtual memory space leaves the first 1/6 for local use.
+ */
+char* const ARGO_START = reinterpret_cast<char*>(0x155555554000l);
+/**
+ * @brief The size of the ArgoDSM virtual memory space
+ * @note This hard-coded value assumes x86_64 architecture
+ *
+ * ArgoDSM reserves a part of the available user-space virtual memory.
+ * In combination with @ref{ARGO_START}, this ensures that the final third
+ * of the virtual memory is left for PIE loads, heap, shared libraries and
+ * the stack among other things.
+ */
 const ptrdiff_t ARGO_SIZE_LIMIT = 0x80000000000l;
 
 /** @brief error message string */

--- a/src/virtual_memory/virtual_memory.hpp
+++ b/src/virtual_memory/virtual_memory.hpp
@@ -25,8 +25,9 @@ void init();
 void* start_address();
 
 /**
- * @brief get size of the ArgoDSM virtual memory
- * @return the size of the ArgoDSM virtual memory
+ * @brief Get the usable size of the ArgoDSM virtual memory
+ * @note Up to half of the virtual memory is earmarked for internal structures
+ * @return the usable size of the ArgoDSM virtual memory
  */
 std::size_t size();
 

--- a/src/virtual_memory/vm_limits.hpp
+++ b/src/virtual_memory/vm_limits.hpp
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * @brief This file contains the ArgoDSM virtual memory limits
+ * @copyright Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
+ */
+
+#ifndef ARGODSM_SRC_VIRTUAL_MEMORY_VM_LIMITS_HPP_
+#define ARGODSM_SRC_VIRTUAL_MEMORY_VM_LIMITS_HPP_
+
+/**
+ * @brief The start of the ArgoDSM virtual memory space
+ * @note This value assumes x86_64 architecture
+ *
+ * The ArgoDSM virtual memory space leaves the first 1/6 for local use.
+ */
+char* const ARGO_VM_START = reinterpret_cast<char*>(0x155555554000l);
+
+/**
+ * @brief The maximum size of the ArgoDSM virtual memory space
+ * @note This value assumes x86_64 architecture
+ *
+ * ArgoDSM reserves up to half of the available user-space virtual memory. A
+ * particular VM implementation may choose to reserve less than this number.
+ * In combination with @ref{ARGO_VM_START}, this ensures that the final third
+ * of the virtual memory is left for PIE loads, heap, shared libraries and
+ * the stack among other things.
+ */
+constexpr ptrdiff_t ARGO_VM_SIZE = 0x400000000000l;
+
+#endif  // ARGODSM_SRC_VIRTUAL_MEMORY_VM_LIMITS_HPP_

--- a/src/virtual_memory/vm_limits.hpp
+++ b/src/virtual_memory/vm_limits.hpp
@@ -21,7 +21,7 @@ char* const ARGO_VM_START = reinterpret_cast<char*>(0x155555554000l);
  *
  * ArgoDSM reserves up to half of the available user-space virtual memory. A
  * particular VM implementation may choose to reserve less than this number.
- * In combination with @ref{ARGO_VM_START}, this ensures that the final third
+ * In combination with @ref ARGO_VM_START this ensures that the final third
  * of the virtual memory is left for PIE loads, heap, shared libraries and
  * the stack among other things.
  */


### PR DESCRIPTION
This PR fixes #124 by moving the start of ArgoDSM's Virtual Memory reservation from `0x200000000000` to `0x155555554000`. The start of the reservation is moved from 1/4 into the user-space VM to 1/6 into the user-space VM.

The reason for this change is that for x86_64 specifically, the area beginning at `0x555555554000` (2/3 into the user-space VM) is reserved for PIE loads followed by the heap, and ArgoDSM's current VM reservation intrudes on this area for MEMFD leading to segmentation faults during ArgoDSM initialization. See below for reference:
https://github.com/torvalds/linux/blob/ce19275f0103934828cb19712b6d8552c39476c8/arch/x86/include/asm/elf.h#L237-L243

The same change is applied for SHM and ANONYMOUS for the sake of consistency. An alternative change could be to move this allocation to `0x100000000000` for the sake of easier debugging, but there is functionally no difference.

Finally, MEMFD is added to the GitHub Actions matrix. To facilitate this, `vm.overcommit_memory` is set to 1 (`always overcommit`) ahead of `make test` as this is a requirement for MEMFD.