### PR TITLE
Initialize barrierlockholder to prevent maybe-uninitialized

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1023,7 +1023,7 @@ void self_upgrade(argo::backend::upgrade_type upgrade) {
 }
 
 void swdsm_argo_barrier(int n, argo::backend::upgrade_type upgrade) {
-	pthread_t barrierlockholder;
+	pthread_t barrierlockholder = pthread_t();
 	double t1 = MPI_Wtime();
 
 	// Wait for n threads to arrive


### PR DESCRIPTION
Current master branch fails to compile with gcc 9.4:

```
src/backend/mpi/swdsm.cpp:1058:2: error: ‘barrierlockholder’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (pthread_equal(barrierlockholder, pthread_self())) {
  ^~
cc1plus: all warnings being treated as errors
```