### PR TITLE
Bump min cmake version to 3.10 (from 3.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) Eta Scale AB. Licensed under the Eta Scale Open Source License. See the LICENSE file for details.
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 project(ArgoDSM VERSION 0.1)
 
 


### PR DESCRIPTION
Current cmake is at least 3.25.1 (or later) in Linux distributions, and some recent ones (e.g. on Ubuntu 24.04) produce warnings when they see a specification of such an ancient min cmake version.

This PR silences these warnings.